### PR TITLE
fix(generate-cli): use camelCase for Commander.js option names

### DIFF
--- a/src/cli/generate/template.ts
+++ b/src/cli/generate/template.ts
@@ -434,7 +434,9 @@ export function renderToolCommand(
     });
   const buildArgs = tool.options
     .map((option) => {
-      const source = `cmdOpts.${option.property}`;
+      // Commander.js converts kebab-case flags to camelCase property names
+      const camelCaseProp = option.cliName.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+      const source = `cmdOpts.${camelCaseProp}`;
       return `if (${source} !== undefined) args.${option.property} = ${source};`;
     })
     .join('\n\t\t');


### PR DESCRIPTION
## Problem

Generated CLIs fail to recognize option values when the MCP server uses snake_case property names in its schema.

For example, when a tool has a property `relative_path`, the generated CLI creates:
- Flag: `--relative-path`
- Access: `cmdOpts.relative_path`

But Commander.js converts `--relative-path` to `relativePath` (camelCase), so the option value is never read.

## Solution

Convert the CLI option name to camelCase when generating the `cmdOpts` property access, matching Commander.js's behavior.

## Testing

Tested with an MCP server that uses snake_case properties - options now work correctly.