### PR TITLE
docs: add OAuth server config example

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 * text eol=lf
 *.png binary
+*.tar.gz binary
+*.tgz binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### CLI
 
+- Document OAuth-protected server config setup with `mcporter config add --auth oauth` and `mcporter auth`. (PR #34, thanks @prateek)
 - Respect schema-declared string parameters when coercing numeric-looking `mcporter call` key=value arguments, so Slack timestamps like `thread_ts` stay strings. (PR #141, thanks @Hamzaa6296)
 
 ## [0.8.1] - 2026-03-29

--- a/README.md
+++ b/README.md
@@ -388,6 +388,15 @@ What MCPorter handles for you:
 - Stdio commands inherit the directory of the file that defined them (imports or local config).
 - Import precedence matches the array order; omit `imports` to use the default `["cursor", "claude-code", "claude-desktop", "codex", "windsurf", "opencode", "vscode"]`.
 
+#### OAuth-protected servers
+
+If an HTTP MCP requires browser login (OAuth), persist it with `--auth oauth` (or set `"auth": "oauth"` in JSON), then run `mcporter auth` once:
+
+```bash
+npx mcporter config add notion https://mcp.notion.com/mcp --auth oauth
+npx mcporter auth notion
+```
+
 Provide `configPath` or `rootDir` to CLI/runtime calls when you juggle multiple config files side by side.
 
 #### Config resolution order & system-level configs


### PR DESCRIPTION
Adds a small README snippet showing how to persist an OAuth-backed HTTP MCP server ("auth": "oauth") and complete login via `mcporter auth`.

Also marks `*.tar.gz`/`*.tgz` as binary in `.gitattributes` to avoid line-ending conversions on bundled artifacts.