### PR TITLE
fix: error on unknown flags in call command

### DIFF
--- a/src/cli/call-arguments.ts
+++ b/src/cli/call-arguments.ts
@@ -85,6 +85,14 @@ export function parseCallArguments(args: string[]): CallArgsParseResult {
       index += 2;
       continue;
     }
+    // Warn on unknown flags to prevent them from being silently treated as positional args
+    if (token.startsWith('--') && !token.includes('=') && !token.includes(':')) {
+      throw new CliUsageError(
+        `Unknown flag '${token}' passed to call command.\n` +
+          `If you intended to pass a tool argument, use '${token.slice(2)}=<value>' or --args '{"${token.slice(2)}": ...}'.\n` +
+          `Run 'mcporter call --help' to see available flags.`
+      );
+    }
     positional.push(token);
     index += 1;
   }


### PR DESCRIPTION
## Problem

Unknown flags passed to the `call` command were silently treated as positional arguments and mapped to tool parameters via `hydratePositionalArguments`. This caused confusing behavior where:

```bash
mcporter call server.tool --source import
```

Would result in `{"includeStarted": "import"}` being sent to the tool (mapping `import` to the first tool parameter), causing validation errors that were hard to debug.

## Solution

Added a check in `parseCallArguments` to detect unknown `--` prefixed flags before they get pushed to the positional array. Now it throws a helpful `CliUsageError` with suggestions:

```
[mcporter] Unknown flag '--source' passed to call command.
If you intended to pass a tool argument, use 'source=<value>' or --args '{"source": ...}'.
Run 'mcporter call --help' to see available flags.
```

## Testing

- All 377 existing tests pass
- Manually verified that:
  - Unknown flags now error with helpful message
  - Valid calls still work
  - `key=value` style arguments work
  - `--args '{...}'` style arguments work