### PR TITLE
fix: support JSONC in config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added `--raw-strings` (numeric coercion off) and `--no-coerce` (all coercion off) for `mcporter call` argument parsing so IDs/codes can stay literal strings. (PR #59, thanks @nobrainer-tech)
 - Added `CallResult.images()` plus opt-in `mcporter call --save-images <dir>` so image content blocks can be persisted without changing existing stdout output contracts. (PR #61, thanks @daniella-11ways)
 - OAuth transport retries now classify HTTP 405 as HTTP (not auth) and OAuth promotion applies to configured HTTP servers too, so post-auth fallback flows no longer drop credentials on 405-only endpoints. (PR #48, thanks @caseyg)
+- Config loading now parses project and explicit config files as JSONC, so `mcporter.json` / `mcporter.jsonc` can include comments and trailing commas. (PR #42, thanks @aryasaatvik)
 
 ### Tooling / Dependencies
 - Updated dependencies to latest releases (including MCP SDK, Rolldown RC, Zod, Biome, Oxlint, Vitest, Bun types).

--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ See [docs/emit-ts.md](docs/emit-ts.md) for the full flag reference plus inline s
 ## Configuration Reference
 
 Manage this file with `mcporter config list|get|add|remove|import` when you’d rather avoid hand-editing JSON; see [docs/config.md](docs/config.md) for the full walkthrough.
+Config files are parsed as JSONC, so inline `//` and `/* ... */` comments plus trailing commas are supported in both `mcporter.json` and `mcporter.jsonc`.
 
 ### Manage configs with `mcporter config`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,9 +2,9 @@ import fsSync from 'node:fs';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { parseJsonBuffer } from './config/imports/shared.js';
 import { pathsForImport, readExternalEntries } from './config-imports.js';
 import { normalizeServerEntry } from './config-normalize.js';
-import { parseJsonBuffer } from './config/imports/shared.js';
 import {
   DEFAULT_IMPORTS,
   type LoadConfigOptions,

--- a/tests/config-missing.test.ts
+++ b/tests/config-missing.test.ts
@@ -83,4 +83,58 @@ describe('loadServerDefinitions when config is optional', () => {
     await expect(loadServerDefinitions({ configPath: explicitPath })).rejects.toThrow();
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
   });
+
+  it('loads project config files that contain JSONC comments and trailing commas', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-config-jsonc-project-'));
+    const configDir = path.join(tempDir, 'config');
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(
+      path.join(configDir, 'mcporter.json'),
+      `{
+        // local MCP servers
+        "mcpServers": {
+          "demo": {
+            "command": "node",
+            "args": ["./demo-server.mjs",], // trailing comma
+          },
+        },
+      }`,
+      'utf8'
+    );
+
+    try {
+      const servers = await loadServerDefinitions({ rootDir: tempDir });
+      expect(servers).toHaveLength(1);
+      expect(servers[0]?.name).toBe('demo');
+      expect(servers[0]?.command.kind).toBe('stdio');
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it('loads explicit .jsonc config files with comments/trailing commas', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-config-jsonc-explicit-'));
+    const explicitPath = path.join(tempDir, 'mcporter.jsonc');
+    await fs.writeFile(
+      explicitPath,
+      `{
+        /* explicit JSONC file */
+        "mcpServers": {
+          "demo-http": {
+            "url": "https://example.com/mcp", // allowed comment
+          },
+        },
+      }`,
+      'utf8'
+    );
+
+    try {
+      const servers = await loadServerDefinitions({ configPath: explicitPath });
+      expect(servers).toHaveLength(1);
+      expect(servers[0]?.name).toBe('demo-http');
+      expect(servers[0]?.command.kind).toBe('http');
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Use the existing `parseJsonBuffer` helper (which leverages `jsonc-parser`) instead of `JSON.parse()` when reading config files
- Enables comments (`//`, `/* */`) and trailing commas in mcporter config files
- The `jsonc-parser` dependency was already present but wasn't being used for main config file parsing

## Test plan

- [x] All existing tests pass (`pnpm test`)
- [x] Verified JSONC config files with comments are parsed correctly