### PR TITLE
fix: collect JSON from multiple content blocks into an array

### DIFF
--- a/tests/result-utils.test.ts
+++ b/tests/result-utils.test.ts
@@ -154,6 +154,61 @@ describe('createCallResult json extraction', () => {
     const result = createCallResult(response);
     expect(result.json()).toEqual({ nested: true });
   });
+
+  it('collects json from multiple text content blocks into an array', () => {
+    const response = {
+      content: [
+        {
+          type: 'text',
+          text: '{"id": 1, "name": "first"}',
+        },
+        {
+          type: 'text',
+          text: '{"id": 2, "name": "second"}',
+        },
+        {
+          type: 'text',
+          text: '{"id": 3, "name": "third"}',
+        },
+      ],
+    };
+    const result = createCallResult(response);
+    expect(result.json()).toEqual([
+      { id: 1, name: 'first' },
+      { id: 2, name: 'second' },
+      { id: 3, name: 'third' },
+    ]);
+  });
+
+  it('returns single object (not array) when only one content block has json', () => {
+    const response = {
+      content: [
+        {
+          type: 'text',
+          text: '{"id": 1, "name": "only"}',
+        },
+      ],
+    };
+    const result = createCallResult(response);
+    expect(result.json()).toEqual({ id: 1, name: 'only' });
+  });
+
+  it('collects json from mixed json and text content blocks', () => {
+    const response = {
+      content: [
+        {
+          type: 'json',
+          json: { id: 1 },
+        },
+        {
+          type: 'text',
+          text: '{"id": 2}',
+        },
+      ],
+    };
+    const result = createCallResult(response);
+    expect(result.json()).toEqual([{ id: 1 }, { id: 2 }]);
+  });
 });
 
 describe('createCallResult structured accessors', () => {


### PR DESCRIPTION
## Summary
- When an MCP server returns `list[BaseModel]` (e.g. FastMCP serializing a Python list of Pydantic models), each item is serialized as a separate text content block in the MCP response
- Previously, `json()` in `createCallResult` returned on the first successfully parsed JSON entry, silently discarding the rest
- This caused tools like `yandex-tracker-mcp.issues_find` (which returns `list[Issue]`) to appear as if they only returned 1 result when there were actually hundreds

**The fix:**
- Collects all valid JSON entries from content blocks
- Single entry → returns the object directly (no behavior change)
- Multiple entries → returns them as an array

## Test plan
- [x] All 18 result-utils tests pass
- [x] Added 3 new test cases covering multi-content JSON collection:
  - `collects json from multiple text content blocks into an array`
  - `returns single object (not array) when only one content block has json`
  - `collects json from mixed json and text content blocks`