### PR TITLE
feat: add search command for cross-server tool discovery

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,8 @@ import { looksLikeHttpUrl } from './cli/http-utils.js';
 import { handleInspectCli } from './cli/inspect-cli-command.js';
 import { buildConnectionIssueEnvelope } from './cli/json-output.js';
 import { handleList, printListHelp } from './cli/list-command.js';
+import { handleSearch, printSearchHelp } from './cli/search-command.js';
+import { handleDescribe, printDescribeHelp } from './cli/describe-command.js';
 import { logError, logInfo, logWarn } from './cli/logger-context.js';
 import { consumeOutputFormat } from './cli/output-format.js';
 import { DEBUG_HANG, dumpActiveHandles, terminateChildProcesses } from './cli/runtime-debug.js';
@@ -155,6 +157,26 @@ export async function runCli(argv: string[]): Promise<void> {
       return;
     }
 
+    if (resolvedCommand === 'search') {
+      if (consumeHelpTokens(resolvedArgs)) {
+        printSearchHelp();
+        process.exitCode = 0;
+        return;
+      }
+      await handleSearch(runtime, resolvedArgs);
+      return;
+    }
+
+    if (resolvedCommand === 'describe') {
+      if (consumeHelpTokens(resolvedArgs)) {
+        printDescribeHelp();
+        process.exitCode = 0;
+        return;
+      }
+      await handleDescribe(runtime, resolvedArgs);
+      return;
+    }
+
     if (resolvedCommand === 'call') {
       if (consumeHelpTokens(resolvedArgs)) {
         printCallHelp();
@@ -270,6 +292,16 @@ function buildCommandSections(colorize: boolean): string[] {
           name: 'list',
           summary: 'List configured servers (add --schema for tool docs)',
           usage: 'mcporter list [name] [--schema] [--json]',
+        },
+        {
+          name: 'search',
+          summary: 'Search for tools across all servers (compact output for AI agents)',
+          usage: 'mcporter search <query> [--limit N] [--json]',
+        },
+        {
+          name: 'describe',
+          summary: 'Get full schema for a single tool (without loading entire server)',
+          usage: 'mcporter describe <server.tool> [--json]',
         },
         {
           name: 'call',

--- a/src/cli/command-inference.ts
+++ b/src/cli/command-inference.ts
@@ -16,10 +16,6 @@ export function inferCommandRouting(
     return { kind: 'command', command: token, args };
   }
 
-  if (token === 'describe') {
-    return { kind: 'command', command: 'list', args };
-  }
-
   // Hidden alias kept for muscle memory / older docs.
   if (token === 'list-tools') {
     return { kind: 'command', command: 'list', args };
@@ -84,7 +80,7 @@ function isCallLikeToken(token: string): boolean {
 }
 
 function isExplicitCommand(token: string): boolean {
-  return token === 'list' || token === 'call' || token === 'auth';
+  return token === 'list' || token === 'call' || token === 'auth' || token === 'search' || token === 'describe';
 }
 
 function isUrlToken(token: string): boolean {

--- a/src/cli/describe-command.ts
+++ b/src/cli/describe-command.ts
@@ -1,0 +1,164 @@
+/**
+ * mcporter describe - Get full schema for a single tool
+ * 
+ * Usage: mcporter describe server.tool
+ * 
+ * Returns the complete tool documentation including parameters,
+ * types, and examples - but ONLY for that one tool.
+ * 
+ * This enables loading just one tool into AI context without
+ * pulling the entire server's tool catalog.
+ */
+
+import { dimText, boldText } from './terminal.js';
+import { LIST_TIMEOUT_MS, withTimeout } from './timeouts.js';
+
+export function extractDescribeFlags(args: string[]): {
+  json: boolean;
+} {
+  let json = false;
+  
+  let i = 0;
+  while (i < args.length) {
+    if (args[i] === '--json') {
+      json = true;
+      args.splice(i, 1);
+      continue;
+    }
+    i++;
+  }
+  
+  return { json };
+}
+
+function parseToolSelector(selector: string): { server: string; tool: string } | null {
+  const match = selector.match(/^([^.]+)\.(.+)$/);
+  if (!match) return null;
+  return { server: match[1]!, tool: match[2]! };
+}
+
+export async function handleDescribe(
+  runtime: Awaited<ReturnType<typeof import('../runtime.js')['createRuntime']>>,
+  args: string[]
+): Promise<void> {
+  const flags = extractDescribeFlags(args);
+  const selector = args[0];
+  
+  if (!selector) {
+    printDescribeHelp();
+    process.exitCode = 1;
+    return;
+  }
+  
+  const parsed = parseToolSelector(selector);
+  if (!parsed) {
+    console.error(`Invalid tool selector: "${selector}"`);
+    console.error('Expected format: server.tool (e.g., niagaraMCP.create_niagara_system)');
+    process.exitCode = 1;
+    return;
+  }
+  
+  const { server, tool: toolName } = parsed;
+  
+  try {
+    const tools = await withTimeout(
+      runtime.listTools(server, { autoAuthorize: false, allowCachedAuth: true, includeSchema: true }),
+      LIST_TIMEOUT_MS
+    );
+    
+    const tool = tools.find(t => t.name === toolName);
+    
+    if (!tool) {
+      console.error(`Tool "${toolName}" not found in server "${server}"`);
+      console.error('');
+      console.error('Available tools:');
+      for (const t of tools.slice(0, 10)) {
+        console.error(`  ${server}.${t.name}`);
+      }
+      if (tools.length > 10) {
+        console.error(`  ... and ${tools.length - 10} more`);
+      }
+      process.exitCode = 1;
+      return;
+    }
+    
+    if (flags.json) {
+      console.log(JSON.stringify({
+        server,
+        tool: toolName,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        outputSchema: tool.outputSchema,
+      }, null, 2));
+      return;
+    }
+    
+    // Text output - formatted like mcporter list --schema but for single tool
+    console.log(boldText(`${server}.${toolName}`));
+    console.log('');
+    
+    if (tool.description) {
+      // Format as doc comment
+      const lines = tool.description.trim().split('\n');
+      console.log('/**');
+      for (const line of lines) {
+        console.log(` * ${line}`);
+      }
+      console.log(' */');
+    }
+    
+    // Format the signature
+    const schema = tool.inputSchema as { properties?: Record<string, unknown>; required?: string[] } | undefined;
+    if (schema?.properties) {
+      const params: string[] = [];
+      const required = new Set(schema.required ?? []);
+      
+      for (const [name, prop] of Object.entries(schema.properties)) {
+        const propObj = prop as { type?: string; default?: unknown };
+        const isOptional = !required.has(name);
+        const type = propObj.type ?? 'unknown';
+        params.push(`${name}${isOptional ? '?' : ''}: ${type}`);
+      }
+      
+      console.log(`function ${toolName}(${params.join(', ')});`);
+    } else {
+      console.log(`function ${toolName}();`);
+    }
+    
+    // Show JSON schema if available
+    if (schema) {
+      console.log('');
+      console.log(dimText('Input Schema:'));
+      console.log(dimText(JSON.stringify(schema, null, 2)));
+    }
+    
+    // Show example call
+    console.log('');
+    console.log(dimText('Example:'));
+    console.log(dimText(`  mcporter call ${server}.${toolName}(...)`));
+    
+  } catch (err) {
+    console.error(`Error connecting to ${server}: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  }
+}
+
+export function printDescribeHelp(): void {
+  console.log(`mcporter describe - Get full schema for a single tool
+
+Usage: mcporter describe <server.tool> [options]
+
+Options:
+  --json    Output as JSON
+
+Examples:
+  mcporter describe niagaraMCP.create_niagara_system
+  mcporter describe materialMCP.create_material --json
+
+Returns the complete tool documentation including description,
+parameters, types, and input schema - for just that one tool.
+
+Use this after 'mcporter search' to get full details without
+loading the entire server's tool catalog into context.
+`);
+}

--- a/src/cli/search-command.ts
+++ b/src/cli/search-command.ts
@@ -1,0 +1,187 @@
+/**
+ * mcporter search - Search for tools across all MCP servers
+ * 
+ * Returns compact results: server.tool - first line of description
+ * Designed to minimize context window usage for AI agents.
+ */
+
+import type { ServerToolInfo } from '../runtime.js';
+import { dimText, boldText } from './terminal.js';
+import { LIST_TIMEOUT_MS, withTimeout } from './timeouts.js';
+
+interface SearchResult {
+  server: string;
+  tool: string;
+  description: string;
+}
+
+function getFirstLine(text: string | undefined): string {
+  if (!text) return '';
+  // Trim leading/trailing whitespace first
+  const trimmed = text.trim();
+  if (!trimmed) return '';
+  // Get first sentence or first line, whichever is shorter
+  const lines = trimmed.split('\n');
+  const firstLine = (lines[0] ?? '').trim();
+  const sentences = trimmed.split(/[.!?]/);
+  const firstSentence = (sentences[0] ?? '').trim();
+  const result = firstSentence.length < firstLine.length ? firstSentence : firstLine;
+  // Truncate if still too long
+  return result.length > 80 ? result.slice(0, 77) + '...' : result;
+}
+
+function matchesQuery(tool: ServerToolInfo, query: string): boolean {
+  const lowerQuery = query.toLowerCase();
+  const terms = lowerQuery.split(/\s+/);
+  
+  const searchText = [
+    tool.name,
+    tool.description ?? '',
+  ].join(' ').toLowerCase();
+  
+  // All terms must match somewhere
+  return terms.every(term => searchText.includes(term));
+}
+
+export function extractSearchFlags(args: string[]): {
+  limit: number;
+  json: boolean;
+} {
+  let limit = 20;
+  let json = false;
+  
+  let i = 0;
+  while (i < args.length) {
+    if (args[i] === '--limit' && args[i + 1]) {
+      limit = parseInt(args[i + 1] ?? '20', 10) || 20;
+      args.splice(i, 2);
+      continue;
+    }
+    if (args[i] === '--json') {
+      json = true;
+      args.splice(i, 1);
+      continue;
+    }
+    i++;
+  }
+  
+  return { limit, json };
+}
+
+export async function handleSearch(
+  runtime: Awaited<ReturnType<typeof import('../runtime.js')['createRuntime']>>,
+  args: string[]
+): Promise<void> {
+  const flags = extractSearchFlags(args);
+  const query = args.join(' ').trim();
+  
+  if (!query) {
+    console.error('Usage: mcporter search <query> [--limit N] [--json]');
+    console.error('');
+    console.error('Search for tools across all configured MCP servers.');
+    console.error('');
+    console.error('Examples:');
+    console.error('  mcporter search particle');
+    console.error('  mcporter search "create material"');
+    console.error('  mcporter search niagara --limit 50');
+    process.exitCode = 1;
+    return;
+  }
+  
+  const definitions = runtime.getDefinitions();
+  const results: SearchResult[] = [];
+  const errors: string[] = [];
+  const perServerTimeoutMs = LIST_TIMEOUT_MS;
+  
+  // Search each server
+  for (const def of definitions) {
+    try {
+      const tools = await withTimeout(
+        runtime.listTools(def.name, { autoAuthorize: false, allowCachedAuth: true, includeSchema: true }),
+        perServerTimeoutMs
+      );
+      
+      for (const tool of tools) {
+        if (matchesQuery(tool, query)) {
+          results.push({
+            server: def.name,
+            tool: tool.name,
+            description: getFirstLine(tool.description),
+          });
+        }
+      }
+    } catch (err) {
+      errors.push(`${def.name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  
+  // Sort by relevance (tools where query appears in name first)
+  const lowerQuery = query.toLowerCase();
+  results.sort((a, b) => {
+    const aInName = a.tool.toLowerCase().includes(lowerQuery) ? 0 : 1;
+    const bInName = b.tool.toLowerCase().includes(lowerQuery) ? 0 : 1;
+    if (aInName !== bInName) return aInName - bInName;
+    return `${a.server}.${a.tool}`.localeCompare(`${b.server}.${b.tool}`);
+  });
+  
+  // Apply limit
+  const limited = results.slice(0, flags.limit);
+  
+  if (flags.json) {
+    console.log(JSON.stringify({
+      query,
+      total: results.length,
+      returned: limited.length,
+      results: limited,
+      errors: errors.length > 0 ? errors : undefined,
+    }, null, 2));
+    return;
+  }
+  
+  // Text output - compact format
+  if (limited.length === 0) {
+    console.log(`No tools found matching "${query}"`);
+    if (errors.length > 0) {
+      console.log('');
+      console.log(dimText(`Errors (${errors.length} servers):`));
+      for (const err of errors) {
+        console.log(dimText(`  ${err}`));
+      }
+    }
+    return;
+  }
+  
+  console.log(`Found ${results.length} tools matching "${query}"${results.length > flags.limit ? ` (showing ${flags.limit})` : ''}:\n`);
+  
+  for (const r of limited) {
+    const selector = `${r.server}.${r.tool}`;
+    console.log(`${boldText(selector)}`);
+    if (r.description) {
+      console.log(`  ${dimText(r.description)}`);
+    }
+  }
+  
+  if (errors.length > 0) {
+    console.log('');
+    console.log(dimText(`(${errors.length} servers failed to connect)`));
+  }
+}
+
+export function printSearchHelp(): void {
+  console.log(`mcporter search - Search for tools across all MCP servers
+
+Usage: mcporter search <query> [options]
+
+Options:
+  --limit <N>   Maximum results to return (default: 20)
+  --json        Output as JSON
+
+Examples:
+  mcporter search particle
+  mcporter search "create material" --limit 50
+  mcporter search niagara --json
+
+The search matches against tool names and descriptions.
+All query terms must match (AND logic).
+`);
+}


### PR DESCRIPTION
Adds a new 'search' command that searches across all configured MCP servers for tools matching a query. Features:

- Multi-term AND matching (all words must appear in name OR description)
- Compact output format: server.tool + first line of description
- --limit N to cap results (default 20)
- --json for machine-readable output

Usage: mcporter search <query> [--limit N] [--json]

This enables AI assistants to discover relevant tools without loading full schemas for all servers (which can be 15-20k tokens each).