### PR TITLE
fix: json() returns all results when content has multiple JSON entries

### DIFF
--- a/src/result-utils.ts
+++ b/src/result-utils.ts
@@ -169,13 +169,14 @@ export function createCallResult<T = unknown>(raw: T): CallResult<T> {
 
       const content = extractContentArray(raw);
       if (content) {
+        const results: unknown[] = [];
         for (const entry of content) {
           if (entry && typeof entry === 'object') {
             const typedEntry = entry as Record<string, unknown>;
             if (typedEntry.type === 'json') {
               const parsed = tryParseJson(entry);
               if (parsed !== null) {
-                return parsed as J;
+                results.push(parsed);
               }
               continue;
             }
@@ -184,7 +185,7 @@ export function createCallResult<T = unknown>(raw: T): CallResult<T> {
               if (typeof text === 'string') {
                 const parsedText = tryParseJson(text);
                 if (parsedText !== null) {
-                  return parsedText as J;
+                  results.push(parsedText);
                 }
               }
               continue;
@@ -193,9 +194,15 @@ export function createCallResult<T = unknown>(raw: T): CallResult<T> {
           if (typeof entry === 'string') {
             const parsed = tryParseJson(entry);
             if (parsed !== null) {
-              return parsed as J;
+              results.push(parsed);
             }
           }
+        }
+        if (results.length === 1) {
+          return results[0] as J;
+        }
+        if (results.length > 1) {
+          return results as J;
         }
       }
 

--- a/tests/result-utils.test.ts
+++ b/tests/result-utils.test.ts
@@ -156,6 +156,54 @@ describe('createCallResult json extraction', () => {
   });
 });
 
+describe('createCallResult json multiple results', () => {
+  it('returns all JSON objects when content has multiple text entries with JSON', () => {
+    const response = {
+      content: [
+        { type: 'text', text: '{"id": 1, "name": "Alice"}' },
+        { type: 'text', text: '{"id": 2, "name": "Bob"}' },
+        { type: 'text', text: '{"id": 3, "name": "Charlie"}' },
+      ],
+    };
+    const result = createCallResult(response);
+    expect(result.json()).toEqual([
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+      { id: 3, name: 'Charlie' },
+    ]);
+  });
+
+  it('returns all JSON objects when content has multiple json type entries', () => {
+    const response = {
+      content: [
+        { type: 'json', json: { foo: 'bar' } },
+        { type: 'json', json: { baz: 'qux' } },
+      ],
+    };
+    const result = createCallResult(response);
+    expect(result.json()).toEqual([{ foo: 'bar' }, { baz: 'qux' }]);
+  });
+
+  it('returns single object (not array) when content has only one JSON entry', () => {
+    const response = {
+      content: [{ type: 'text', text: '{"id": 1}' }],
+    };
+    const result = createCallResult(response);
+    expect(result.json()).toEqual({ id: 1 });
+  });
+
+  it('returns all JSON objects from mixed content types', () => {
+    const response = {
+      content: [
+        { type: 'json', json: { from: 'json-type' } },
+        { type: 'text', text: '{"from": "text-type"}' },
+      ],
+    };
+    const result = createCallResult(response);
+    expect(result.json()).toEqual([{ from: 'json-type' }, { from: 'text-type' }]);
+  });
+});
+
 describe('createCallResult structured accessors', () => {
   it('content() returns nested raw content array', () => {
     const nested = [{ type: 'text', text: 'Hello' }];


### PR DESCRIPTION
Closes #51

## Summary

`json()` only returned the first parsed JSON object from the content array, ignoring additional results. MCP servers that return multiple results (e.g. database searches) were truncated to a single entry.

## Fix

Collect all valid JSON entries from the content array instead of returning on first match:
- **Single result** → returns the object directly (preserves existing behavior)
- **Multiple results** → returns an array of all objects

## Changes

- `src/result-utils.ts`: Accumulate results in `json()` instead of early-returning
- 4 new tests covering multi-result text, json, single, and mixed content types

All 381 tests pass. Build clean.

AI-assisted (Claude via Clawdbot), fully tested.