### PR TITLE
fix(cli): output valid JSON when --output json falls through to raw

### DIFF
--- a/src/cli/output-utils.ts
+++ b/src/cli/output-utils.ts
@@ -16,6 +16,12 @@ export function printCallOutput<T>(wrapped: CallResult<T>, raw: T, format: Outpu
       if (jsonValue !== null && attemptPrintJson(jsonValue)) {
         return;
       }
+      // When wrapped.json() returns null (e.g. structuredContent responses),
+      // fall back to JSON.stringify on the raw response before resorting to
+      // util.inspect, which produces output that isn't valid JSON.
+      if (attemptPrintJson(raw)) {
+        return;
+      }
       printRaw(raw);
       return;
     }


### PR DESCRIPTION
## Problem

When an MCP tool response uses `structuredContent` (e.g. QMD's search tools), `wrapped.json()` returns `null` because the `json()` method doesn't handle that response shape. The `--output json` code path then falls through to `printRaw()`, which uses `util.inspect()` — producing output with unquoted keys and truncated nested objects (`[Object]`) that isn't valid JSON.

This breaks any tooling that parses mcporter's JSON output (e.g. OpenClaw's QMD memory backend, which was merged in [openclaw/openclaw#19617](https://github.com/openclaw/openclaw/pull/19617)).

### Before
```
$ mcporter call qmd.search --args '{"query":"test","limit":1}' --output json
{
  content: [
    {
      type: 'text',
      text: 'Found 1 result for "test"...'
    }
  ],
  structuredContent: { results: [ [Object] ] }
}
```

### After
```json
{
  "content": [
    {
      "type": "text",
      "text": "Found 1 result for \"test\"..."
    }
  ],
  "structuredContent": {
    "results": [
      {
        "docid": "#30327d",
        "file": "notes/26707/compliance-test-report.md",
        "title": "Compliance test report",
        "score": 0.91
      }
    ]
  }
}
```

## Fix

Add `attemptPrintJson(raw)` as a fallback before `printRaw(raw)` in the `json` output case. This serialises the full response with `JSON.stringify` when `wrapped.json()` returns null, only falling back to `util.inspect` if JSON serialisation itself fails.

Fixes #80