### PR TITLE
Add Assimilate Live FX MCP server

### DIFF
--- a/config/mcporter.json
+++ b/config/mcporter.json
@@ -113,6 +113,17 @@
         "npm_config_loglevel": "error"
       }
     },
+    "assimilate": {
+      "description": "Assimilate Live FX / SCRATCH — 88 tools for professional color grading, compositing, rendering, and virtual production.",
+      "command": "npx",
+      "args": [
+        "-y",
+        "assimilate-mcp"
+      ],
+      "env": {
+        "npm_config_loglevel": "error"
+      }
+    },
     "XcodeBuildMCP": {
       "description": "XcodeBuild MCP server for building, testing, and inspecting Xcode projects and simulators.",
       "command": "npx",


### PR DESCRIPTION
## Summary

- Adds `assimilate` to `config/mcporter.json` — an MCP server for [Assimilate Live FX / SCRATCH](https://assimilateinc.com)
- 88 tools for professional color grading, compositing, rendering, and virtual production
- Published on npm as [`assimilate-mcp`](https://www.npmjs.com/package/assimilate-mcp)

## Usage

```bash
mcporter call assimilate.check_connection
mcporter call assimilate.list_projects
mcporter call assimilate.get_grade
```

## Links

- [GitHub](https://github.com/amac-roguelabs/assimilate-mcp)
- [npm](https://www.npmjs.com/package/assimilate-mcp)
- [Assimilate REST API](https://github.com/Assimilate-Inc/Assimilate-REST)