### PR TITLE
feat: fix native HTTP OAuth flow — fresh transport retry, configurable scope, universal auto-promotion

### DIFF
--- a/src/config-normalize.ts
+++ b/src/config-normalize.ts
@@ -12,6 +12,8 @@ export function normalizeServerEntry(
   const description = raw.description;
   const env = raw.env ? { ...raw.env } : undefined;
   const auth = normalizeAuth(raw.auth);
+  const autoOAuth = raw.autoOAuth ?? raw.auto_oauth;
+  const oauthScope = raw.oauthScope ?? raw.oauth_scope ?? undefined;
   const tokenCacheDir = normalizePath(raw.tokenCacheDir ?? raw.token_cache_dir);
   const clientName = raw.clientName ?? raw.client_name;
   const oauthRedirectUrl = raw.oauthRedirectUrl ?? raw.oauth_redirect_url ?? undefined;
@@ -55,6 +57,8 @@ export function normalizeServerEntry(
     command,
     env,
     auth,
+    autoOAuth,
+    oauthScope,
     tokenCacheDir,
     clientName,
     oauthRedirectUrl,

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -62,6 +62,10 @@ export const RawEntrySchema = z.object({
   client_name: z.string().optional(),
   oauthRedirectUrl: z.string().optional(),
   oauth_redirect_url: z.string().optional(),
+  autoOAuth: z.boolean().optional(),
+  auto_oauth: z.boolean().optional(),
+  oauthScope: z.string().optional(),
+  oauth_scope: z.string().optional(),
   oauthCommand: z
     .object({
       args: z.array(z.string()),
@@ -130,6 +134,8 @@ export interface ServerDefinition {
   readonly command: CommandSpec;
   readonly env?: Record<string, string>;
   readonly auth?: string;
+  readonly autoOAuth?: boolean;
+  readonly oauthScope?: string;
   readonly tokenCacheDir?: string;
   readonly clientName?: string;
   readonly oauthRedirectUrl?: string;

--- a/src/config/imports/external.ts
+++ b/src/config/imports/external.ts
@@ -121,6 +121,11 @@ function convertExternalEntry(value: Record<string, unknown>): RawEntry | null {
     result.auth = auth;
   }
 
+  const autoOAuth = value.autoOAuth ?? value.auto_oauth;
+  if (typeof autoOAuth === 'boolean') {
+    result.autoOAuth = autoOAuth;
+  }
+
   const tokenCacheDir = asString(value.tokenCacheDir ?? value.token_cache_dir ?? value.token_cacheDir);
   if (tokenCacheDir) {
     result.tokenCacheDir = tokenCacheDir;

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -79,7 +79,10 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
       grant_types: ['authorization_code', 'refresh_token'],
       response_types: ['code'],
       token_endpoint_auth_method: 'none',
-      scope: 'mcp:tools',
+      // Use the configured scope if set; otherwise omit scope entirely so the
+      // server / SDK can negotiate the appropriate value.  The previous hardcoded
+      // 'mcp:tools' broke servers that use standard OIDC scopes (see #85).
+      ...(definition.oauthScope != null && definition.oauthScope !== '' ? { scope: definition.oauthScope } : {}),
     };
   }
 

--- a/src/runtime-oauth-support.ts
+++ b/src/runtime-oauth-support.ts
@@ -9,11 +9,14 @@ export function maybeEnableOAuth(definition: ServerDefinition, logger: Logger): 
   if (definition.command.kind !== 'http') {
     return undefined;
   }
-  const isAdHocSource = definition.source && definition.source.kind === 'local' && definition.source.path === '<adhoc>';
-  if (!isAdHocSource) {
+  // Allow users to opt out of auto-OAuth per server with `"autoOAuth": false`.
+  if (definition.autoOAuth === false) {
     return undefined;
   }
-  logger.info(`Detected OAuth requirement for '${definition.name}'. Launching browser flow...`);
+  const sourceHint = definition.source
+    ? ` (from ${definition.source.importKind ?? definition.source.kind}: ${definition.source.path})`
+    : '';
+  logger.info(`Detected OAuth requirement for '${definition.name}'${sourceHint}. Launching browser flow...`);
   return {
     ...definition,
     auth: 'oauth',

--- a/src/runtime/oauth.ts
+++ b/src/runtime/oauth.ts
@@ -6,6 +6,18 @@ import { isUnauthorizedError } from '../runtime-oauth-support.js';
 
 export const DEFAULT_OAUTH_CODE_TIMEOUT_MS = 60_000;
 
+/**
+ * Signals that the OAuth browser flow completed successfully and tokens were saved.
+ * The caller should create a fresh Client + Transport and retry the connection,
+ * because the SDK's StreamableHTTPClientTransport cannot be re-started.
+ */
+export class OAuthCompletedError extends Error {
+  constructor() {
+    super('OAuth flow completed; retry with fresh transport.');
+    this.name = 'OAuthCompletedError';
+  }
+}
+
 export class OAuthTimeoutError extends Error {
   public readonly timeoutMs: number;
   public readonly serverName: string;
@@ -53,12 +65,19 @@ export async function connectWithAuth(
         );
         if (typeof transport.finishAuth === 'function') {
           await transport.finishAuth(code);
-          logger.info('Authorization code accepted. Retrying connection...');
+          logger.info('Authorization code accepted. Tokens saved — reconnecting with fresh transport.');
+          // The SDK's StreamableHTTPClientTransport throws "already started" if
+          // we call client.connect(transport) again. Signal the caller to create
+          // a new Client + Transport pair for the retry.
+          throw new OAuthCompletedError();
         } else {
           logger.warn('Transport does not support finishAuth; cannot complete OAuth flow automatically.');
           throw error;
         }
       } catch (authError) {
+        if (authError instanceof OAuthCompletedError) {
+          throw authError;
+        }
         logger.error('OAuth authorization failed while waiting for callback.', authError);
         throw authError;
       }

--- a/src/runtime/transport.ts
+++ b/src/runtime/transport.ts
@@ -11,7 +11,7 @@ import { readCachedAccessToken } from '../oauth-persistence.js';
 import { materializeHeaders } from '../runtime-header-utils.js';
 import { isUnauthorizedError, maybeEnableOAuth } from '../runtime-oauth-support.js';
 import { closeTransportAndWait } from '../runtime-process-utils.js';
-import { connectWithAuth, OAuthTimeoutError } from './oauth.js';
+import { connectWithAuth, OAuthCompletedError, OAuthTimeoutError } from './oauth.js';
 import { resolveCommandArgument, resolveCommandArguments } from './utils.js';
 
 const STDIO_TRACE_ENABLED = process.env.MCPORTER_STDIO_TRACE === '1';
@@ -140,6 +140,26 @@ export async function createClientContext(
           } as ClientContext;
         } catch (error) {
           await closeTransportAndWait(logger, streamableTransport).catch(() => {});
+          if (error instanceof OAuthCompletedError) {
+            // OAuth flow completed and tokens were saved. Create a fresh
+            // Client + Transport pair and retry — the auth provider will
+            // supply the newly-acquired tokens automatically.
+            logger.info(`Reconnecting to '${activeDefinition.name}' with fresh transport after OAuth.`);
+            const freshClient = new Client(clientInfo);
+            const freshTransport = new StreamableHTTPClientTransport(command.url, baseOptions);
+            try {
+              await freshClient.connect(freshTransport);
+              return {
+                client: freshClient,
+                transport: freshTransport,
+                definition: activeDefinition,
+                oauthSession,
+              } as ClientContext;
+            } catch (retryError) {
+              await closeTransportAndWait(logger, freshTransport).catch(() => {});
+              throw retryError;
+            }
+          }
           throw error;
         }
       };
@@ -178,6 +198,25 @@ export async function createClientContext(
           return { client, transport: sseTransport, definition: activeDefinition, oauthSession };
         } catch (sseError) {
           await closeTransportAndWait(logger, sseTransport).catch(() => {});
+          if (sseError instanceof OAuthCompletedError) {
+            // OAuth flow completed via SSE transport. Retry with fresh transport.
+            logger.info(`Reconnecting to '${activeDefinition.name}' with fresh SSE transport after OAuth.`);
+            const freshClient = new Client(clientInfo);
+            const freshSseTransport = new SSEClientTransport(command.url, { ...baseOptions });
+            try {
+              await freshClient.connect(freshSseTransport);
+              return {
+                client: freshClient,
+                transport: freshSseTransport,
+                definition: activeDefinition,
+                oauthSession,
+              };
+            } catch (retryError) {
+              await closeTransportAndWait(logger, freshSseTransport).catch(() => {});
+              await oauthSession?.close().catch(() => {});
+              throw retryError;
+            }
+          }
           await oauthSession?.close().catch(() => {});
           if (sseError instanceof OAuthTimeoutError) {
             throw sseError;

--- a/tests/runtime-oauth-connect.test.ts
+++ b/tests/runtime-oauth-connect.test.ts
@@ -5,7 +5,7 @@ import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it, vi } from 'vitest';
 import type { Logger } from '../src/logging.js';
 import type { OAuthSession } from '../src/oauth.js';
-import { connectWithAuth } from '../src/runtime/oauth.js';
+import { connectWithAuth, OAuthCompletedError } from '../src/runtime/oauth.js';
 
 // Minimal mock transport that records finishAuth calls.
 class MockTransport implements Transport {
@@ -23,8 +23,9 @@ class MockTransport implements Transport {
 }
 
 describe('connectWithAuth', () => {
-  it('waits for authorization code and retries connection', async () => {
-    // First connect throws Unauthorized, second succeeds after finishAuth.
+  it('waits for authorization code then throws OAuthCompletedError for fresh retry', async () => {
+    // First connect throws Unauthorized; after finishAuth the function signals
+    // the caller to create a fresh Client + Transport via OAuthCompletedError.
     const connect = vi
       .fn()
       .mockRejectedValueOnce(new UnauthorizedError('auth needed'))
@@ -63,10 +64,33 @@ describe('connectWithAuth', () => {
     // Simulate browser callback arrival.
     resolveCode('oauth-code-123');
 
-    await promise;
+    // After finishAuth() succeeds, connectWithAuth throws OAuthCompletedError
+    // to signal the caller to create a fresh Client + Transport for retry.
+    await expect(promise).rejects.toThrow(OAuthCompletedError);
 
     expect(waitForAuthorizationCode).toHaveBeenCalledTimes(1);
     expect(transport.calls).toEqual(['oauth-code-123']);
-    expect(connect).toHaveBeenCalledTimes(2);
+    // connect is called only once — the initial attempt that triggers 401.
+    // The retry with a fresh transport is handled by the caller (createClientContext).
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves normally when connect succeeds on first attempt', async () => {
+    const connect = vi.fn().mockResolvedValueOnce(undefined);
+    const client = { connect } as unknown as Client;
+    const transport = new MockTransport();
+    const logger: Logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await connectWithAuth(client, transport, undefined, logger, {
+      serverName: 'test-server',
+      maxAttempts: 1,
+    });
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(transport.calls).toHaveLength(0);
   });
 });

--- a/tests/runtime-oauth-detection.test.ts
+++ b/tests/runtime-oauth-detection.test.ts
@@ -25,14 +25,79 @@ describe('maybeEnableOAuth', () => {
     expect(logger.info).toHaveBeenCalled();
   });
 
-  it('does not mutate non-ad-hoc servers', () => {
+  it('promotes configured HTTP servers on 401 (not just ad-hoc)', () => {
     const def: ServerDefinition = {
-      name: 'local-server',
+      name: 'configured-server',
       command: { kind: 'http', url: new URL('https://example.com') },
       source: { kind: 'local', path: '/tmp/config.json' },
     };
     const updated = maybeEnableOAuth(def, logger as never);
+    expect(updated).toBeDefined();
+    expect(updated?.auth).toBe('oauth');
+  });
+
+  it('promotes imported HTTP servers (e.g. from claude-code)', () => {
+    const def: ServerDefinition = {
+      name: 'datadog',
+      command: { kind: 'http', url: new URL('https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp') },
+      source: { kind: 'import', path: '~/.claude/settings.json', importKind: 'claude-code' },
+    };
+    const updated = maybeEnableOAuth(def, logger as never);
+    expect(updated).toBeDefined();
+    expect(updated?.auth).toBe('oauth');
+  });
+
+  it('does not promote servers that already have auth: oauth', () => {
+    const def: ServerDefinition = {
+      ...baseDefinition,
+      auth: 'oauth',
+    };
+    const updated = maybeEnableOAuth(def, logger as never);
     expect(updated).toBeUndefined();
+  });
+
+  it('does not promote stdio servers', () => {
+    const def: ServerDefinition = {
+      name: 'stdio-server',
+      command: { kind: 'stdio', command: 'node', args: ['server.js'], cwd: '/tmp' },
+    };
+    const updated = maybeEnableOAuth(def, logger as never);
+    expect(updated).toBeUndefined();
+  });
+
+  it('does not promote when autoOAuth is explicitly false', () => {
+    const def: ServerDefinition = {
+      name: 'no-auto-oauth',
+      command: { kind: 'http', url: new URL('https://example.com') },
+      autoOAuth: false,
+    };
+    const updated = maybeEnableOAuth(def, logger as never);
+    expect(updated).toBeUndefined();
+  });
+
+  it('promotes when autoOAuth is explicitly true', () => {
+    const def: ServerDefinition = {
+      name: 'yes-auto-oauth',
+      command: { kind: 'http', url: new URL('https://example.com') },
+      autoOAuth: true,
+    };
+    const updated = maybeEnableOAuth(def, logger as never);
+    expect(updated).toBeDefined();
+    expect(updated?.auth).toBe('oauth');
+  });
+
+  it('includes source info in log message', () => {
+    const infoSpy = vi.fn();
+    const testLogger = { info: infoSpy, warn: vi.fn(), error: vi.fn() };
+    const def: ServerDefinition = {
+      name: 'imported-server',
+      command: { kind: 'http', url: new URL('https://example.com') },
+      source: { kind: 'import', path: '~/.claude/settings.json', importKind: 'claude-code' },
+    };
+    maybeEnableOAuth(def, testLogger as never);
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining('claude-code')
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Fix critical bugs preventing HTTP MCP OAuth from working end-to-end. After this PR, MCPorter handles HTTP+OAuth natively — similar to Claude Code — for servers like Datadog, Notion, Linear, and Granola.

### Fixes

| Issue | Problem | Fix |
|-------|---------|-----|
| #86 | `connectWithAuth` crashes with "already started" after successful OAuth browser flow | After `finishAuth()` succeeds, throw `OAuthCompletedError` to signal `createClientContext` to create a fresh `Client` + `Transport` pair for the retry (SDK transport cannot be re-started) |
| #85 | Hardcoded `mcp:tools` scope breaks servers using standard OIDC scopes | Added `oauthScope` config option; when not set, scope is omitted so server/SDK can negotiate |
| #84 | OAuth auto-promotion only works for ad-hoc servers, skips imported configs | Removed ad-hoc restriction; any HTTP server returning 401/403 gets auto-promoted. Added `autoOAuth: false` opt-out |
| #79 | Browser never opens for OAuth | Side-effect of #86 — browser WAS opening but crash masked success |

### Changes

**Core logic:**
- `src/runtime/oauth.ts` — Added `OAuthCompletedError` class; `connectWithAuth` throws it after `finishAuth()` instead of looping
- `src/runtime/transport.ts` — Catches `OAuthCompletedError` in both Streamable HTTP and SSE paths; creates fresh Client + Transport for retry
- `src/runtime-oauth-support.ts` — Removed ad-hoc restriction from `maybeEnableOAuth`; added `autoOAuth` opt-out check
- `src/oauth.ts` — Replaced hardcoded `mcp:tools` with configurable `oauthScope`

**Config:**
- `src/config-schema.ts` — Added `oauthScope`/`oauth_scope` (string) and `autoOAuth`/`auto_oauth` (boolean)
- `src/config-normalize.ts` — Threads new fields through normalization
- `src/config/imports/external.ts` — Handles `autoOAuth` in external config imports

**Tests:**
- Updated `tests/runtime-oauth-connect.test.ts` for `OAuthCompletedError` behavior + added success case
- Expanded `tests/runtime-oauth-detection.test.ts` with 9 test cases covering all promotion scenarios

### New Config Options

```jsonc
{
  "mcpServers": {
    "datadog": {
      "url": "https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp"
      // OAuth auto-detected on 401, no "auth: oauth" needed
    },
    "granola": {
      "url": "https://mcp.granola.ai/mcp",
      "oauthScope": "openid email profile offline_access"  // override scope
    },
    "my-api": {
      "url": "https://api.example.com/mcp",
      "autoOAuth": false  // uses API key, not OAuth
    }
  }
}
```

### Validation

- ✅ TypeScript compiles cleanly (`tsc --noEmit`)
- ✅ All 384 tests pass (5 skipped — pre-existing)
- ✅ Lint clean (`oxlint`)