### PR TITLE
feat(oauth): add oauthScope config option to override hardcoded scope

### DIFF
--- a/src/config-normalize.ts
+++ b/src/config-normalize.ts
@@ -15,6 +15,7 @@ export function normalizeServerEntry(
   const tokenCacheDir = normalizePath(raw.tokenCacheDir ?? raw.token_cache_dir);
   const clientName = raw.clientName ?? raw.client_name;
   const oauthRedirectUrl = raw.oauthRedirectUrl ?? raw.oauth_redirect_url ?? undefined;
+  const oauthScope = raw.oauthScope ?? raw.oauth_scope ?? undefined;
   const oauthCommandRaw = raw.oauthCommand ?? raw.oauth_command;
   const oauthCommand = oauthCommandRaw ? { args: [...oauthCommandRaw.args] } : undefined;
   const headers = buildHeaders(raw);
@@ -58,6 +59,7 @@ export function normalizeServerEntry(
     tokenCacheDir,
     clientName,
     oauthRedirectUrl,
+    oauthScope,
     oauthCommand: defaultedOauthCommand,
     source,
     sources,

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -62,6 +62,8 @@ export const RawEntrySchema = z.object({
   client_name: z.string().optional(),
   oauthRedirectUrl: z.string().optional(),
   oauth_redirect_url: z.string().optional(),
+  oauthScope: z.string().optional(),
+  oauth_scope: z.string().optional(),
   oauthCommand: z
     .object({
       args: z.array(z.string()),
@@ -133,6 +135,7 @@ export interface ServerDefinition {
   readonly tokenCacheDir?: string;
   readonly clientName?: string;
   readonly oauthRedirectUrl?: string;
+  readonly oauthScope?: string;
   readonly oauthCommand?: {
     readonly args: string[];
   };

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -79,7 +79,9 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
       grant_types: ['authorization_code', 'refresh_token'],
       response_types: ['code'],
       token_endpoint_auth_method: 'none',
-      scope: 'mcp:tools',
+      // Use oauthScope from config if provided, otherwise let MCP SDK derive
+      // from server's metadata. This allows overriding scopes_supported.
+      ...(definition.oauthScope ? { scope: definition.oauthScope } : {}),
     };
   }
 


### PR DESCRIPTION
## Summary

This PR adds support for configuring OAuth scope via the `oauthScope` config option.

**Problem:** The current implementation hardcodes `scope: 'mcp:tools'` in the OAuth client metadata. This breaks authentication with standard OIDC providers (like Clerk) that don't recognize `mcp:tools` as a valid scope.

**Solution:** Allow users to specify custom OAuth scopes via `oauthScope` (or `oauth_scope`) in their server configuration. When not specified, the scope is omitted from client metadata, allowing the MCP SDK to derive it from the server's resource metadata.

## Changes

- `src/config-schema.ts`: Add `oauthScope` and `oauth_scope` to `RawEntrySchema` and `ServerDefinition` interface
- `src/config-normalize.ts`: Extract and pass `oauthScope` from raw config to server definition
- `src/oauth.ts`: Replace hardcoded `scope: 'mcp:tools'` with conditional spread using `definition.oauthScope`

## Usage

```json
{
  "mcpServers": {
    "my-server": {
      "baseUrl": "https://example.com/mcp",
      "auth": "oauth",
      "oauthScope": "openid email profile offline_access"
    }
  }
}
```

## Related Issues

- Fixes #85 (Hardcoded `mcp:tools` scope breaks OIDC-compliant servers)
- Fixes #73 (OAuth fails with hardcoded scope)
- Related to #72, #52

## Test Plan

1. Configure a server with `"oauthScope": "email openid profile offline_access"`
2. Run `mcporter auth <server-name>`
3. Verify OAuth flow completes successfully with the configured scopes
4. Verify tokens are obtained with correct scope values
