### PR TITLE
fix: detect auth errors from error.code property (StreamableHTTPError…

### DIFF
--- a/src/error-classifier.ts
+++ b/src/error-classifier.ts
@@ -47,7 +47,8 @@ export function analyzeConnectionError(error: unknown): ConnectionIssue {
   if (stdio) {
     return { kind: 'stdio-exit', rawMessage, ...stdio };
   }
-  const statusCode = extractStatusCode(rawMessage);
+  const errorCode = extractErrorCode(error);
+  const statusCode = errorCode ?? extractStatusCode(rawMessage);
   const normalized = rawMessage.toLowerCase();
   if (AUTH_STATUSES.has(statusCode ?? -1) || containsAuthToken(normalized)) {
     return { kind: 'auth', rawMessage, statusCode };
@@ -80,6 +81,16 @@ function extractMessage(error: unknown): string {
   } catch {
     return '';
   }
+}
+
+function extractErrorCode(error: unknown): number | undefined {
+  if (typeof error === 'object' && error !== null && 'code' in error) {
+    const code = (error as Record<string, unknown>).code;
+    if (typeof code === 'number' && Number.isFinite(code) && code >= 100 && code < 600) {
+      return code;
+    }
+  }
+  return undefined;
 }
 
 function extractStatusCode(message: string): number | undefined {

--- a/tests/error-classifier.test.ts
+++ b/tests/error-classifier.test.ts
@@ -43,4 +43,40 @@ describe('analyzeConnectionError', () => {
     expect(issue.kind).toBe('http');
     expect(issue.statusCode).toBe(503);
   });
+
+  describe('error.code property (StreamableHTTPError / SseError)', () => {
+    it('classifies code=401 as auth even when message lacks 401', () => {
+      const err = Object.assign(new Error('Error POSTing to endpoint: {}'), { code: 401 });
+      const issue = analyzeConnectionError(err);
+      expect(issue.kind).toBe('auth');
+      expect(issue.statusCode).toBe(401);
+    });
+
+    it('classifies code=403 as auth', () => {
+      const err = Object.assign(new Error('Forbidden'), { code: 403 });
+      const issue = analyzeConnectionError(err);
+      expect(issue.kind).toBe('auth');
+      expect(issue.statusCode).toBe(403);
+    });
+
+    it('classifies code=404 as http (not auth)', () => {
+      const err = Object.assign(new Error('Not Found'), { code: 404 });
+      const issue = analyzeConnectionError(err);
+      expect(issue.kind).toBe('http');
+      expect(issue.statusCode).toBe(404);
+    });
+
+    it('classifies code=500 as http', () => {
+      const err = Object.assign(new Error('Internal Server Error'), { code: 500 });
+      const issue = analyzeConnectionError(err);
+      expect(issue.kind).toBe('http');
+      expect(issue.statusCode).toBe(500);
+    });
+
+    it('falls back to message parsing when code is absent', () => {
+      const issue = analyzeConnectionError(new Error('network timeout'));
+      expect(issue.kind).toBe('offline');
+      expect(issue.statusCode).toBeUndefined();
+    });
+  });
 });

--- a/tests/runtime-oauth-detection.test.ts
+++ b/tests/runtime-oauth-detection.test.ts
@@ -69,4 +69,9 @@ describe('isUnauthorizedError helper', () => {
   it('ignores unrelated errors', () => {
     expect(isUnauthorizedError(new Error('network timeout'))).toBe(false);
   });
+
+  it('matches errors with code=401 even when message lacks 401', () => {
+    const err = Object.assign(new Error('Error POSTing to endpoint: {}'), { code: 401 });
+    expect(isUnauthorizedError(err)).toBe(true);
+  });
 });


### PR DESCRIPTION
  ## Summary

  - MCP SDK's `StreamableHTTPError(401, ...)` and `SseError` store the HTTP status code in `error.code`, but the message
   text may not contain the numeric status code (e.g., `"Error POSTing to endpoint: {}"`)
  - `analyzeConnectionError` previously only parsed the message string to extract status codes, missing `error.code`
  entirely
  - This caused OAuth promotion to not trigger for Streamable HTTP 401 responses, falling back to legacy SSE transport
  (GET), which the server doesn't support — resulting in a confusing 404 error

  ## Changes

  - **`src/error-classifier.ts`**: Add `extractErrorCode()` helper that reads `error.code` as a numeric HTTP status
  (100–599). This source takes priority over message-text parsing in `analyzeConnectionError`
  - **`tests/error-classifier.test.ts`**: Add tests for `error.code` extraction — 401/403 → auth, 404 → http, 500 →
  http, no code → regression check
  - **`tests/runtime-oauth-detection.test.ts`**: Add test confirming `isUnauthorizedError` returns true for errors with
  `code: 401` even when message lacks "401"

  ## Test plan

  - [x] `npx vitest run tests/error-classifier.test.ts tests/runtime-oauth-detection.test.ts` — 21 tests pass
  - [x] Full test suite — no regressions from this change