### PR TITLE
fix: CLI args parsing for --key=value and tool misattribution

### DIFF
--- a/src/cli/call-arguments.ts
+++ b/src/cli/call-arguments.ts
@@ -154,6 +154,7 @@ export function parseCallArguments(args: string[]): CallArgsParseResult {
     nextPositional !== undefined &&
     !nextPositional.includes('=') &&
     !nextPositional.includes(':') &&
+    !nextPositional.startsWith('-') &&
     !callExpressionProvidedTool
   ) {
     result.tool = positional.shift();
@@ -205,7 +206,9 @@ interface ParsedKeyValueToken {
 function parseKeyValueToken(token: string, nextToken: string | undefined): ParsedKeyValueToken | undefined {
   const eqIndex = token.indexOf('=');
   if (eqIndex !== -1) {
-    const key = token.slice(0, eqIndex);
+    let key = token.slice(0, eqIndex);
+    if (key.startsWith('--')) key = key.slice(2);
+    else if (key.startsWith('-')) key = key.slice(1);
     const rawValue = token.slice(eqIndex + 1);
     if (!key) {
       return undefined;
@@ -215,7 +218,9 @@ function parseKeyValueToken(token: string, nextToken: string | undefined): Parse
 
   const colonIndex = token.indexOf(':');
   if (colonIndex !== -1) {
-    const key = token.slice(0, colonIndex);
+    let key = token.slice(0, colonIndex);
+    if (key.startsWith('--')) key = key.slice(2);
+    else if (key.startsWith('-')) key = key.slice(1);
     const remainder = token.slice(colonIndex + 1);
     if (!key) {
       return undefined;
@@ -228,6 +233,15 @@ function parseKeyValueToken(token: string, nextToken: string | undefined): Parse
     }
     warnMissingNamedArgumentValue(key);
     return { key, rawValue: '', consumed: 1 };
+  }
+
+  if (token.startsWith('--')) {
+    const key = token.slice(2);
+    if (!key) return undefined;
+    if (nextToken !== undefined && !nextToken.startsWith('-')) {
+      return { key, rawValue: nextToken, consumed: 2 };
+    }
+    return { key, rawValue: 'true', consumed: 1 };
   }
 
   return undefined;

--- a/tests/call-arguments.test.ts
+++ b/tests/call-arguments.test.ts
@@ -49,4 +49,19 @@ describe('parseCallArguments', () => {
     );
     warnSpy.mockRestore();
   });
+
+  it('tolerates LLM flag hallucinations (strips leading dashes)', () => {
+    const parsed = parseCallArguments(['linear.get_issue', '--id=VINC-1', '--includeRelations', 'true']);
+    expect(parsed.args.id).toBe('VINC-1');
+    expect(parsed.args.includeRelations).toBe(true);
+    expect(parsed.args['--id']).toBeUndefined();
+  });
+
+  it('tolerates LLM flag hallucinations spaced format', () => {
+    const parsed = parseCallArguments(['linear.get_issue', '--id', 'VINC-1', '--dryRun', '--team', 'ENG']);
+    expect(parsed.args.id).toBe('VINC-1');
+    expect(parsed.args.dryRun).toBe(true);
+    expect(parsed.args.team).toBe('ENG');
+    expect(parsed.args['--id']).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Description
Fixes critical argument parsing bugs when users or LLMs provide arguments in the `--key=value` or `--key value` format.

- Safely strips leading `--` or `-` from positional tokens that map to named arguments in `parseKeyValueToken`.
- Prevents `parseCallArguments` from incorrectly consuming the first `--flag` as the `tool` name when the selector hasn't been split yet.

## Testing
Added two regression tests in `tests/call-arguments.test.ts` which now pass reliably alongside the entire suite.