### PR TITLE
Add on-demand heavy MCP activation commands

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text eol=lf
 *.png binary
+dist-bun/*.tar.gz binary

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ npx mcporter heavy activate chrome-devtools
 npx mcporter heavy deactivate chrome-devtools
 ```
 
-Heavy definitions live next to your resolved `mcporter.json` under `heavy/available/`, and activation merges the selected definition into the main config while tracking its status under `heavy/active/`.
+Heavy definitions live next to your resolved `mcporter.json` under `heavy/available/`, and activation merges the selected definition into the main config while tracking its status under `heavy/active/`. If a heavy definition would overwrite an existing `mcpServers` entry with different settings, activation aborts instead of clobbering your config.
 
 
 ## Friendlier Tool Calls

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ MCPorter helps you lean into the "code execution" workflows highlighted in Anthr
 - **One-command CLI generation.** `mcporter generate-cli` turns any MCP server definition into a ready-to-run CLI, with optional bundling/compilation and metadata for easy regeneration.
 - **Typed tool clients.** `mcporter emit-ts` emits `.d.ts` interfaces or ready-to-run client wrappers so agents/tests can call MCP servers with strong TypeScript types without hand-writing plumbing.
 - **Friendly composable API.** `createServerProxy()` exposes tools as ergonomic camelCase methods, automatically applies JSON-schema defaults, validates required arguments, and hands back a `CallResult` with `.text()`, `.markdown()`, `.json()`, `.images()`, and `.content()` helpers.
+- **On-demand heavy MCPs.** Keep large schema payloads such as `chrome-devtools` out of your default config until you need them, then toggle them with `mcporter heavy list|activate|deactivate`.
 - **OAuth and stdio ergonomics.** Built-in OAuth caching, log tailing, and stdio wrappers let you work with HTTP, SSE, and stdio transports from the same interface.
 - **Ad-hoc connections.** Point the CLI at *any* MCP endpoint (HTTP or stdio) without touching config, then persist it later if you want. Hosted MCPs that expect a browser login (Supabase, Vercel, etc.) are auto-detected—just run `mcporter auth <url>` and the CLI promotes the definition to OAuth on the fly. See [docs/adhoc.md](docs/adhoc.md).
 
@@ -183,6 +184,18 @@ npx mcporter call --stdio "bun run ./local-server.ts" --name local-tools
 - All other servers stay ephemeral; add `"lifecycle": "keep-alive"` to a server entry (or set `MCPORTER_KEEPALIVE=name`) when you want the daemon to manage it. You can also set `"lifecycle": "ephemeral"` (or `MCPORTER_DISABLE_KEEPALIVE=name`) to opt out.
 - The daemon only manages named servers that come from your config/imports. Ad-hoc STDIO/HTTP targets invoked via `--stdio …`, `--http-url …`, or inline function-call syntax remain per-process today; persist them into `config/mcporter.json` (or use `--persist`) if you need them to participate in the shared daemon.
 - Troubleshooting? Run `mcporter daemon start --log` (or `--log-file /tmp/daemon.log`) to tee stdout/stderr into a file, and add `--log-servers chrome-devtools` when you only want call traces for a specific MCP. Per-server configs can also set `"logging": { "daemon": { "enabled": true } }` to force detailed logging for that entry.
+
+### Load heavy MCPs on demand
+
+If a server ships an unusually large schema payload, keep it out of your default config and enable it only when needed:
+
+```bash
+npx mcporter heavy list
+npx mcporter heavy activate chrome-devtools
+npx mcporter heavy deactivate chrome-devtools
+```
+
+Heavy definitions live next to your resolved `mcporter.json` under `heavy/available/`, and activation merges the selected definition into the main config while tracking its status under `heavy/active/`.
 
 
 ## Friendlier Tool Calls

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { handleDaemonCli } from './cli/daemon-command.js';
 import { handleEmitTs } from './cli/emit-ts-command.js';
 import { CliUsageError } from './cli/errors.js';
 import { handleGenerateCli } from './cli/generate-cli-runner.js';
+import { handleHeavyCli } from './cli/heavy-command.js';
 import { consumeHelpTokens, isHelpToken, isVersionToken, printHelp, printVersion } from './cli/help-output.js';
 import { handleInspectCli } from './cli/inspect-cli-command.js';
 import { handleList, printListHelp } from './cli/list-command.js';
@@ -23,6 +24,7 @@ export { handleAuth, printAuthHelp } from './cli/auth-command.js';
 export { parseCallArguments } from './cli/call-arguments.js';
 export { handleCall } from './cli/call-command.js';
 export { handleGenerateCli } from './cli/generate-cli-runner.js';
+export { handleHeavyCli } from './cli/heavy-command.js';
 export { handleInspectCli } from './cli/inspect-cli-command.js';
 export { extractListFlags, handleList } from './cli/list-command.js';
 export { resolveCallTimeout } from './cli/timeouts.js';
@@ -97,6 +99,11 @@ export async function runCli(argv: string[]): Promise<void> {
       },
       args
     );
+    return;
+  }
+
+  if (command === 'heavy') {
+    await handleHeavyCli(args, { configPath, rootDir: rootOverride });
     return;
   }
 

--- a/src/cli/heavy-command.ts
+++ b/src/cli/heavy-command.ts
@@ -14,6 +14,7 @@
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
+import { z } from 'zod';
 import { loadRawConfig, writeRawConfig } from '../config.js';
 import { assertValidHeavyMcpName, listHeavyMcpDefinitions, readHeavyMcpDefinition } from '../heavy/definition.js';
 import { type HeavyPaths, resolveHeavyPaths } from '../heavy/paths.js';
@@ -23,6 +24,13 @@ interface HeavyCliOptions {
   configPath?: string;
   rootDir?: string;
 }
+
+const ActiveHeavyMcpMarkerSchema = z.object({
+  activated: z.string(),
+  serverNames: z.array(z.string()).min(1),
+});
+
+type ActiveHeavyMcpMarker = z.infer<typeof ActiveHeavyMcpMarkerSchema>;
 
 export async function handleHeavyCli(args: string[], options: HeavyCliOptions): Promise<void> {
   const subcommand = args.shift();
@@ -71,8 +79,8 @@ Directory structure:
   └── heavy/
       ├── available/             # Heavy MCP definitions
       │   └── chrome-devtools.json
-      └── active/                # Tracks active heavy MCPs (symlinks)
-          └── chrome-devtools.json -> ../available/chrome-devtools.json
+      └── active/                # Tracks active heavy MCPs (marker files)
+          └── chrome-devtools.json
 
 Examples:
   mcporter heavy list
@@ -145,8 +153,7 @@ async function handleHeavyActivate(args: string[], paths: HeavyPaths, options: H
   // Create active marker (symlink)
   await fsPromises.mkdir(paths.activeDir, { recursive: true });
   const activePath = path.join(paths.activeDir, `${name}.json`);
-  const availablePath = path.join(paths.availableDir, `${name}.json`);
-  await writeActiveMarker(activePath, availablePath);
+  await writeActiveMarker(activePath, Object.keys(definition.mcpServers));
 
   console.log(`Activated: ${name}`);
 }
@@ -169,14 +176,9 @@ async function handleHeavyDeactivate(args: string[], paths: HeavyPaths, options:
   const { config, path: configPath } = await loadRawConfig(options);
 
   // Remove the server(s) from config
-  const definition = await readHeavyMcpDefinition(paths.availableDir, name);
-  if (definition) {
-    for (const serverName of Object.keys(definition.mcpServers)) {
-      delete config.mcpServers?.[serverName];
-    }
-  } else {
-    // Definition file was removed, try to remove by name
-    delete config.mcpServers?.[name];
+  const serverNames = await resolveServerNamesForDeactivation(paths, name);
+  for (const serverName of serverNames) {
+    delete config.mcpServers?.[serverName];
   }
 
   // Write back config
@@ -238,22 +240,63 @@ async function readHeavyDefinitionForActiveDetection(
   }
 }
 
-async function writeActiveMarker(activePath: string, availablePath: string): Promise<void> {
+async function resolveServerNamesForDeactivation(paths: HeavyPaths, name: string): Promise<string[]> {
+  const activePath = path.join(paths.activeDir, `${name}.json`);
+  const marker = await readActiveMarker(activePath);
+  if (marker) {
+    return marker.serverNames;
+  }
+
   try {
-    await fsPromises.symlink(availablePath, activePath);
+    const definition = await readHeavyMcpDefinition(paths.availableDir, name);
+    if (definition) {
+      return Object.keys(definition.mcpServers);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Cannot deactivate heavy MCP '${name}' because its marker metadata is missing and its definition is invalid: ${message}`
+    );
+  }
+
+  throw new Error(
+    `Cannot deactivate heavy MCP '${name}' because its marker metadata is missing and its definition file is unavailable.`
+  );
+}
+
+async function readActiveMarker(activePath: string): Promise<ActiveHeavyMcpMarker | null> {
+  try {
+    const buffer = await fsPromises.readFile(activePath, 'utf8');
+    const parsed = JSON.parse(buffer);
+    const validation = ActiveHeavyMcpMarkerSchema.safeParse(parsed);
+    if (!validation.success) {
+      return null;
+    }
+    return validation.data;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
+    return null;
+  }
+}
+
+async function writeActiveMarker(activePath: string, serverNames: string[]): Promise<void> {
+  const marker: ActiveHeavyMcpMarker = {
+    activated: new Date().toISOString(),
+    serverNames,
+  };
+
+  try {
+    await fsPromises.writeFile(activePath, `${JSON.stringify(marker, null, 2)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+    });
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     if (code === 'EEXIST') {
       return;
     }
-    if (!canFallbackToMarkerFile(code)) {
-      throw error;
-    }
-    // Fallback to a regular marker file on platforms where symlinks are restricted.
-    await fsPromises.writeFile(activePath, JSON.stringify({ activated: new Date().toISOString() }, null, 2), 'utf8');
+    throw error;
   }
-}
-
-function canFallbackToMarkerFile(code: string | undefined): boolean {
-  return code === 'EPERM' || code === 'EACCES' || code === 'ENOTSUP' || code === 'EINVAL' || code === 'UNKNOWN';
 }

--- a/src/cli/heavy-command.ts
+++ b/src/cli/heavy-command.ts
@@ -1,0 +1,218 @@
+/**
+ * Heavy MCP management commands.
+ *
+ * Some MCP servers (like chrome-devtools) have large tool schemas that consume
+ * significant context tokens. The "heavy" system allows on-demand loading of
+ * these servers to save context when they're not needed.
+ *
+ * Usage:
+ *   mcporter heavy list              - List available and active heavy MCPs
+ *   mcporter heavy activate <name>   - Activate a heavy MCP
+ *   mcporter heavy deactivate <name> - Deactivate a heavy MCP
+ */
+
+import fsPromises from 'node:fs/promises';
+import path from 'node:path';
+import { loadRawConfig, writeRawConfig } from '../config.js';
+import { listHeavyMcpDefinitions, readHeavyMcpDefinition } from '../heavy/definition.js';
+import { type HeavyPaths, resolveHeavyPaths } from '../heavy/paths.js';
+
+interface HeavyCliOptions {
+  configPath?: string;
+  rootDir?: string;
+}
+
+export async function handleHeavyCli(args: string[], options: HeavyCliOptions): Promise<void> {
+  const subcommand = args.shift();
+  if (!subcommand || subcommand === 'help' || subcommand === '--help' || subcommand === '-h') {
+    process.exitCode = 0;
+    printHeavyHelp();
+    return;
+  }
+
+  const { path: configPath } = await loadRawConfig(options);
+  const paths = resolveHeavyPaths(configPath);
+
+  if (subcommand === 'list') {
+    await handleHeavyList(paths, options);
+    return;
+  }
+  if (subcommand === 'activate') {
+    await handleHeavyActivate(args, paths, options);
+    return;
+  }
+  if (subcommand === 'deactivate') {
+    await handleHeavyDeactivate(args, paths, options);
+    return;
+  }
+
+  throw new Error(`Unknown heavy subcommand '${subcommand}'. Run 'mcporter heavy --help'.`);
+}
+
+function printHeavyHelp(): void {
+  console.error(`Usage: mcporter heavy <list|activate|deactivate>
+
+Manage "heavy" MCP servers that are loaded on-demand to save context.
+
+Heavy MCPs are servers with large tool schemas (e.g., chrome-devtools) that
+consume significant context tokens. By default, they are not loaded. Use this
+command to activate them when needed and deactivate when done.
+
+Commands:
+  list              List available and currently active heavy MCPs.
+  activate <name>   Activate a heavy MCP (adds to main config).
+  deactivate <name> Deactivate a heavy MCP (removes from main config).
+
+Directory structure:
+  ~/.mcporter/
+  ├── mcporter.json              # Main config (without heavy MCPs by default)
+  └── heavy/
+      ├── available/             # Heavy MCP definitions
+      │   └── chrome-devtools.json
+      └── active/                # Tracks active heavy MCPs (symlinks)
+          └── chrome-devtools.json -> ../available/chrome-devtools.json
+
+Examples:
+  mcporter heavy list
+  mcporter heavy activate chrome-devtools
+  mcporter heavy deactivate chrome-devtools`);
+}
+
+async function handleHeavyList(paths: HeavyPaths, options: HeavyCliOptions): Promise<void> {
+  const available = await listHeavyMcpDefinitions(paths.availableDir);
+  const active = await listActiveHeavyMcps(paths, options);
+
+  console.log('=== Available Heavy MCPs ===');
+  if (available.length === 0) {
+    console.log('(none)');
+    console.log('');
+    console.log(`Place JSON files in ${paths.availableDir}/ to add heavy MCPs.`);
+  } else {
+    for (const name of available) {
+      const isActive = active.includes(name);
+      const status = isActive ? ' [active]' : '';
+      console.log(`  ${name}${status}`);
+    }
+  }
+
+  console.log('');
+  console.log('=== Active Heavy MCPs ===');
+  if (active.length === 0) {
+    console.log('(none)');
+  } else {
+    for (const name of active) {
+      console.log(`  ${name}`);
+    }
+  }
+}
+
+async function handleHeavyActivate(args: string[], paths: HeavyPaths, options: HeavyCliOptions): Promise<void> {
+  const name = args.shift();
+  if (!name) {
+    throw new Error('Usage: mcporter heavy activate <name>');
+  }
+
+  // Check if the heavy MCP definition exists
+  const definition = await readHeavyMcpDefinition(paths.availableDir, name);
+  if (!definition) {
+    throw new Error(`Heavy MCP '${name}' not found in ${paths.availableDir}`);
+  }
+
+  // Check if already active
+  const active = await listActiveHeavyMcps(paths, options);
+  if (active.includes(name)) {
+    console.log(`Heavy MCP '${name}' is already active.`);
+    return;
+  }
+
+  // Load current config
+  const { config, path: configPath } = await loadRawConfig(options);
+
+  // Merge the heavy MCP servers into main config
+  if (!config.mcpServers) {
+    config.mcpServers = {};
+  }
+  for (const [serverName, serverDef] of Object.entries(definition.mcpServers)) {
+    config.mcpServers[serverName] = serverDef;
+  }
+
+  // Write back config
+  await writeRawConfig(configPath, config);
+
+  // Create active marker (symlink)
+  await fsPromises.mkdir(paths.activeDir, { recursive: true });
+  const activePath = path.join(paths.activeDir, `${name}.json`);
+  const availablePath = path.join(paths.availableDir, `${name}.json`);
+  try {
+    await fsPromises.symlink(availablePath, activePath);
+  } catch {
+    // Fallback to creating a marker file if symlink fails (e.g., on Windows)
+    await fsPromises.writeFile(activePath, JSON.stringify({ activated: new Date().toISOString() }, null, 2));
+  }
+
+  console.log(`Activated: ${name}`);
+}
+
+async function handleHeavyDeactivate(args: string[], paths: HeavyPaths, options: HeavyCliOptions): Promise<void> {
+  const name = args.shift();
+  if (!name) {
+    throw new Error('Usage: mcporter heavy deactivate <name>');
+  }
+
+  // Check if active
+  const active = await listActiveHeavyMcps(paths, options);
+  if (!active.includes(name)) {
+    console.log(`Heavy MCP '${name}' is not active.`);
+    return;
+  }
+
+  // Load current config
+  const { config, path: configPath } = await loadRawConfig(options);
+
+  // Remove the server(s) from config
+  const definition = await readHeavyMcpDefinition(paths.availableDir, name);
+  if (definition) {
+    for (const serverName of Object.keys(definition.mcpServers)) {
+      delete config.mcpServers?.[serverName];
+    }
+  } else {
+    // Definition file was removed, try to remove by name
+    delete config.mcpServers?.[name];
+  }
+
+  // Write back config
+  await writeRawConfig(configPath, config);
+
+  // Remove active marker
+  const activePath = path.join(paths.activeDir, `${name}.json`);
+  await fsPromises.unlink(activePath).catch(() => {});
+
+  console.log(`Deactivated: ${name}`);
+}
+
+async function listActiveHeavyMcps(paths: HeavyPaths, options: HeavyCliOptions): Promise<string[]> {
+  const active = await listHeavyMcpDefinitions(paths.activeDir);
+  if (active.length > 0) {
+    return active;
+  }
+
+  const { config } = await loadRawConfig(options);
+  const available = await listHeavyMcpDefinitions(paths.availableDir);
+  if (available.length === 0) {
+    return [];
+  }
+
+  const configuredServers = new Set(Object.keys(config.mcpServers ?? {}));
+  const configuredHeavyMcps = await Promise.all(
+    available.map(async (name) => {
+      const definition = await readHeavyMcpDefinition(paths.availableDir, name);
+      if (!definition) {
+        return null;
+      }
+      const serverNames = Object.keys(definition.mcpServers);
+      return serverNames.every((serverName) => configuredServers.has(serverName)) ? name : null;
+    })
+  );
+
+  return configuredHeavyMcps.filter((name): name is string => name !== null);
+}

--- a/src/cli/heavy-command.ts
+++ b/src/cli/heavy-command.ts
@@ -144,7 +144,7 @@ async function handleHeavyActivate(args: string[], paths: HeavyPaths, options: H
 
   const activeDefinition = findActiveHeavyDefinition(
     config.mcpServers,
-    [markerDefinition, definition],
+    [definition, markerDefinition],
     marker?.serverNames
   );
   if (activeDefinition) {
@@ -203,7 +203,7 @@ async function handleHeavyDeactivate(args: string[], paths: HeavyPaths, options:
 
     const activeDefinition = findActiveHeavyDefinition(
       config.mcpServers,
-      [markerDefinition, currentDefinition],
+      [currentDefinition, markerDefinition],
       marker.serverNames
     );
     if (!activeDefinition) {
@@ -273,7 +273,7 @@ async function listActiveHeavyMcps(paths: HeavyPaths, options: HeavyCliOptions):
       const marker = await readActiveMarker(path.join(paths.activeDir, `${name}.json`));
       const activeDefinition = findActiveHeavyDefinition(
         config.mcpServers,
-        [marker ? getHeavyDefinitionFromMarker(marker) : null, definition],
+        [definition, marker ? getHeavyDefinitionFromMarker(marker) : null],
         marker?.serverNames
       );
       if (activeDefinition) {
@@ -288,10 +288,9 @@ async function listActiveHeavyMcps(paths: HeavyPaths, options: HeavyCliOptions):
 function isHeavyMcpDefinitionActiveInConfig(
   configuredServers: Record<string, unknown> | undefined,
   definition: HeavyMcpDefinition,
-  expectedServerNames: string[] = Object.keys(definition.mcpServers)
+  extraServerNamesMustBeAbsent: string[] = []
 ): boolean {
-  const definitionServerNames = Object.keys(definition.mcpServers);
-  if (!haveMatchingHeavyServerNames(definitionServerNames, expectedServerNames)) {
+  if (extraServerNamesMustBeAbsent.some((serverName) => configuredServers?.[serverName] !== undefined)) {
     return false;
   }
 
@@ -315,23 +314,18 @@ function findConflictingHeavyServerNames(
 function findActiveHeavyDefinition(
   configuredServers: Record<string, unknown> | undefined,
   definitions: Array<HeavyMcpDefinition | null>,
-  expectedServerNames?: string[]
+  relatedServerNames: string[] = []
 ): HeavyMcpDefinition | null {
   for (const definition of definitions) {
-    if (definition && isHeavyMcpDefinitionActiveInConfig(configuredServers, definition, expectedServerNames)) {
+    if (!definition) {
+      continue;
+    }
+    const extraRelatedServerNames = relatedServerNames.filter((serverName) => !(serverName in definition.mcpServers));
+    if (isHeavyMcpDefinitionActiveInConfig(configuredServers, definition, extraRelatedServerNames)) {
       return definition;
     }
   }
   return null;
-}
-
-function haveMatchingHeavyServerNames(definitionServerNames: string[], expectedServerNames: string[]): boolean {
-  if (definitionServerNames.length !== expectedServerNames.length) {
-    return false;
-  }
-
-  const expectedServerNameSet = new Set(expectedServerNames);
-  return definitionServerNames.every((serverName) => expectedServerNameSet.has(serverName));
 }
 
 function getHeavyDefinitionFromMarker(marker: ActiveHeavyMcpMarker): HeavyMcpDefinition | null {

--- a/src/cli/heavy-command.ts
+++ b/src/cli/heavy-command.ts
@@ -187,11 +187,28 @@ async function handleHeavyDeactivate(args: string[], paths: HeavyPaths, options:
   const marker = await readActiveMarker(activePath);
   let serverNames: string[];
   if (marker) {
-    if (!hasAnyConfiguredServers(config.mcpServers, marker.serverNames)) {
-      console.log(`Heavy MCP '${name}' is not active.`);
-      return;
+    try {
+      const definition = await readHeavyMcpDefinition(paths.availableDir, name);
+      if (definition) {
+        if (!isHeavyMcpDefinitionActiveInConfig(config.mcpServers, definition)) {
+          console.log(`Heavy MCP '${name}' is not active.`);
+          return;
+        }
+        serverNames = Object.keys(definition.mcpServers);
+      } else {
+        if (!hasAllConfiguredServers(config.mcpServers, marker.serverNames)) {
+          console.log(`Heavy MCP '${name}' is not active.`);
+          return;
+        }
+        serverNames = marker.serverNames;
+      }
+    } catch {
+      if (!hasAllConfiguredServers(config.mcpServers, marker.serverNames)) {
+        console.log(`Heavy MCP '${name}' is not active.`);
+        return;
+      }
+      serverNames = marker.serverNames;
     }
-    serverNames = marker.serverNames;
   } else {
     let definition: HeavyMcpDefinition | null;
     try {
@@ -294,13 +311,6 @@ function hasAllConfiguredServers(
   serverNames: string[]
 ): boolean {
   return serverNames.every((serverName) => configuredServers?.[serverName] !== undefined);
-}
-
-function hasAnyConfiguredServers(
-  configuredServers: Record<string, unknown> | undefined,
-  serverNames: string[]
-): boolean {
-  return serverNames.some((serverName) => configuredServers?.[serverName] !== undefined);
 }
 
 async function readHeavyDefinitionForActiveDetection(

--- a/src/cli/heavy-command.ts
+++ b/src/cli/heavy-command.ts
@@ -17,6 +17,7 @@ import { isDeepStrictEqual } from 'node:util';
 import { loadRawConfig, writeRawConfig } from '../config.js';
 import { assertValidHeavyMcpName, listHeavyMcpDefinitions, readHeavyMcpDefinition } from '../heavy/definition.js';
 import { type HeavyPaths, resolveHeavyPaths } from '../heavy/paths.js';
+import { logWarn } from './logger-context.js';
 
 interface HeavyCliOptions {
   configPath?: string;
@@ -145,12 +146,7 @@ async function handleHeavyActivate(args: string[], paths: HeavyPaths, options: H
   await fsPromises.mkdir(paths.activeDir, { recursive: true });
   const activePath = path.join(paths.activeDir, `${name}.json`);
   const availablePath = path.join(paths.availableDir, `${name}.json`);
-  try {
-    await fsPromises.symlink(availablePath, activePath);
-  } catch {
-    // Fallback to creating a marker file if symlink fails (e.g., on Windows)
-    await fsPromises.writeFile(activePath, JSON.stringify({ activated: new Date().toISOString() }, null, 2));
-  }
+  await writeActiveMarker(activePath, availablePath);
 
   console.log(`Activated: ${name}`);
 }
@@ -204,7 +200,7 @@ async function listActiveHeavyMcps(paths: HeavyPaths, options: HeavyCliOptions):
   const configuredServers = new Set(Object.keys(config.mcpServers ?? {}));
   const configuredHeavyMcps = await Promise.all(
     available.map(async (name) => {
-      const definition = await readHeavyMcpDefinition(paths.availableDir, name);
+      const definition = await readHeavyDefinitionForActiveDetection(paths.availableDir, name);
       if (!definition) {
         return null;
       }
@@ -227,4 +223,37 @@ async function listActiveHeavyMcps(paths: HeavyPaths, options: HeavyCliOptions):
   }
 
   return [...active];
+}
+
+async function readHeavyDefinitionForActiveDetection(
+  availableDir: string,
+  name: string
+): Promise<Awaited<ReturnType<typeof readHeavyMcpDefinition>>> {
+  try {
+    return await readHeavyMcpDefinition(availableDir, name);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logWarn(`Skipping invalid heavy MCP definition '${name}': ${message}`);
+    return null;
+  }
+}
+
+async function writeActiveMarker(activePath: string, availablePath: string): Promise<void> {
+  try {
+    await fsPromises.symlink(availablePath, activePath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'EEXIST') {
+      return;
+    }
+    if (!canFallbackToMarkerFile(code)) {
+      throw error;
+    }
+    // Fallback to a regular marker file on platforms where symlinks are restricted.
+    await fsPromises.writeFile(activePath, JSON.stringify({ activated: new Date().toISOString() }, null, 2), 'utf8');
+  }
+}
+
+function canFallbackToMarkerFile(code: string | undefined): boolean {
+  return code === 'EPERM' || code === 'EACCES' || code === 'ENOTSUP' || code === 'EINVAL' || code === 'UNKNOWN';
 }

--- a/src/cli/heavy-command.ts
+++ b/src/cli/heavy-command.ts
@@ -19,6 +19,7 @@ import { loadRawConfig, writeRawConfig } from '../config.js';
 import {
   assertValidHeavyMcpName,
   type HeavyMcpDefinition,
+  HeavyMcpServersSchema,
   listHeavyMcpDefinitions,
   readHeavyMcpDefinition,
 } from '../heavy/definition.js';
@@ -33,6 +34,7 @@ interface HeavyCliOptions {
 const ActiveHeavyMcpMarkerSchema = z.object({
   activated: z.string(),
   serverNames: z.array(z.string()).min(1),
+  mcpServers: HeavyMcpServersSchema.optional(),
 });
 
 type ActiveHeavyMcpMarker = z.infer<typeof ActiveHeavyMcpMarkerSchema>;
@@ -136,12 +138,11 @@ async function handleHeavyActivate(args: string[], paths: HeavyPaths, options: H
 
   // Load current config
   const { config, path: configPath } = await loadRawConfig(options);
-  const serverNames = Object.keys(definition.mcpServers);
   const activePath = path.join(paths.activeDir, `${name}.json`);
 
   if (isHeavyMcpDefinitionActiveInConfig(config.mcpServers, definition)) {
     await fsPromises.mkdir(paths.activeDir, { recursive: true });
-    await writeActiveMarker(activePath, serverNames);
+    await writeActiveMarker(activePath, definition);
     console.log(`Heavy MCP '${name}' is already active.`);
     return;
   }
@@ -168,7 +169,7 @@ async function handleHeavyActivate(args: string[], paths: HeavyPaths, options: H
 
   // Refresh active marker metadata
   await fsPromises.mkdir(paths.activeDir, { recursive: true });
-  await writeActiveMarker(activePath, serverNames);
+  await writeActiveMarker(activePath, definition);
 
   console.log(`Activated: ${name}`);
 }
@@ -187,28 +188,20 @@ async function handleHeavyDeactivate(args: string[], paths: HeavyPaths, options:
   const marker = await readActiveMarker(activePath);
   let serverNames: string[];
   if (marker) {
+    const markerDefinition = getHeavyDefinitionFromMarker(marker);
+    let currentDefinition: HeavyMcpDefinition | null = null;
     try {
-      const definition = await readHeavyMcpDefinition(paths.availableDir, name);
-      if (definition) {
-        if (!isHeavyMcpDefinitionActiveInConfig(config.mcpServers, definition)) {
-          console.log(`Heavy MCP '${name}' is not active.`);
-          return;
-        }
-        serverNames = Object.keys(definition.mcpServers);
-      } else {
-        if (!hasAllConfiguredServers(config.mcpServers, marker.serverNames)) {
-          console.log(`Heavy MCP '${name}' is not active.`);
-          return;
-        }
-        serverNames = marker.serverNames;
-      }
-    } catch {
-      if (!hasAllConfiguredServers(config.mcpServers, marker.serverNames)) {
-        console.log(`Heavy MCP '${name}' is not active.`);
-        return;
-      }
-      serverNames = marker.serverNames;
+      currentDefinition = await readHeavyMcpDefinition(paths.availableDir, name);
+    } catch {}
+
+    const activeDefinition =
+      findActiveHeavyDefinition(config.mcpServers, currentDefinition) ??
+      findActiveHeavyDefinition(config.mcpServers, markerDefinition);
+    if (!activeDefinition) {
+      console.log(`Heavy MCP '${name}' is not active.`);
+      return;
     }
+    serverNames = Object.keys(activeDefinition.mcpServers);
   } else {
     let definition: HeavyMcpDefinition | null;
     try {
@@ -276,7 +269,7 @@ async function listActiveHeavyMcps(paths: HeavyPaths, options: HeavyCliOptions):
       }
 
       const marker = await readActiveMarker(path.join(paths.activeDir, `${name}.json`));
-      if (marker && hasAllConfiguredServers(config.mcpServers, marker.serverNames)) {
+      if (marker && findActiveHeavyDefinition(config.mcpServers, getHeavyDefinitionFromMarker(marker))) {
         active.add(name);
       }
     })
@@ -306,11 +299,15 @@ function findConflictingHeavyServerNames(
     .map(([serverName]) => serverName);
 }
 
-function hasAllConfiguredServers(
+function findActiveHeavyDefinition(
   configuredServers: Record<string, unknown> | undefined,
-  serverNames: string[]
-): boolean {
-  return serverNames.every((serverName) => configuredServers?.[serverName] !== undefined);
+  definition: HeavyMcpDefinition | null
+): HeavyMcpDefinition | null {
+  return definition && isHeavyMcpDefinitionActiveInConfig(configuredServers, definition) ? definition : null;
+}
+
+function getHeavyDefinitionFromMarker(marker: ActiveHeavyMcpMarker): HeavyMcpDefinition | null {
+  return marker.mcpServers ? { mcpServers: marker.mcpServers } : null;
 }
 
 async function readHeavyDefinitionForActiveDetection(
@@ -343,10 +340,11 @@ async function readActiveMarker(activePath: string): Promise<ActiveHeavyMcpMarke
   }
 }
 
-async function writeActiveMarker(activePath: string, serverNames: string[]): Promise<void> {
+async function writeActiveMarker(activePath: string, definition: HeavyMcpDefinition): Promise<void> {
   const marker: ActiveHeavyMcpMarker = {
     activated: new Date().toISOString(),
-    serverNames,
+    serverNames: Object.keys(definition.mcpServers),
+    mcpServers: definition.mcpServers,
   };
 
   await fsPromises.unlink(activePath).catch((error) => {

--- a/src/cli/heavy-command.ts
+++ b/src/cli/heavy-command.ts
@@ -139,10 +139,17 @@ async function handleHeavyActivate(args: string[], paths: HeavyPaths, options: H
   // Load current config
   const { config, path: configPath } = await loadRawConfig(options);
   const activePath = path.join(paths.activeDir, `${name}.json`);
+  const marker = await readActiveMarker(activePath);
+  const markerDefinition = marker ? getHeavyDefinitionFromMarker(marker) : null;
 
-  if (isHeavyMcpDefinitionActiveInConfig(config.mcpServers, definition)) {
+  const activeDefinition = findActiveHeavyDefinition(
+    config.mcpServers,
+    [markerDefinition, definition],
+    marker?.serverNames
+  );
+  if (activeDefinition) {
     await fsPromises.mkdir(paths.activeDir, { recursive: true });
-    await writeActiveMarker(activePath, definition);
+    await writeActiveMarker(activePath, activeDefinition);
     console.log(`Heavy MCP '${name}' is already active.`);
     return;
   }
@@ -194,9 +201,11 @@ async function handleHeavyDeactivate(args: string[], paths: HeavyPaths, options:
       currentDefinition = await readHeavyMcpDefinition(paths.availableDir, name);
     } catch {}
 
-    const activeDefinition =
-      findActiveHeavyDefinition(config.mcpServers, currentDefinition) ??
-      findActiveHeavyDefinition(config.mcpServers, markerDefinition);
+    const activeDefinition = findActiveHeavyDefinition(
+      config.mcpServers,
+      [markerDefinition, currentDefinition],
+      marker.serverNames
+    );
     if (!activeDefinition) {
       console.log(`Heavy MCP '${name}' is not active.`);
       return;
@@ -262,9 +271,11 @@ async function listActiveHeavyMcps(paths: HeavyPaths, options: HeavyCliOptions):
       }
 
       const marker = await readActiveMarker(path.join(paths.activeDir, `${name}.json`));
-      const activeDefinition =
-        findActiveHeavyDefinition(config.mcpServers, definition) ??
-        findActiveHeavyDefinition(config.mcpServers, marker ? getHeavyDefinitionFromMarker(marker) : null);
+      const activeDefinition = findActiveHeavyDefinition(
+        config.mcpServers,
+        [marker ? getHeavyDefinitionFromMarker(marker) : null, definition],
+        marker?.serverNames
+      );
       if (activeDefinition) {
         active.add(name);
       }
@@ -276,8 +287,14 @@ async function listActiveHeavyMcps(paths: HeavyPaths, options: HeavyCliOptions):
 
 function isHeavyMcpDefinitionActiveInConfig(
   configuredServers: Record<string, unknown> | undefined,
-  definition: HeavyMcpDefinition
+  definition: HeavyMcpDefinition,
+  expectedServerNames: string[] = Object.keys(definition.mcpServers)
 ): boolean {
+  const definitionServerNames = Object.keys(definition.mcpServers);
+  if (!haveMatchingHeavyServerNames(definitionServerNames, expectedServerNames)) {
+    return false;
+  }
+
   return Object.entries(definition.mcpServers).every(([serverName, definitionEntry]) =>
     isDeepStrictEqual(configuredServers?.[serverName], definitionEntry)
   );
@@ -297,9 +314,24 @@ function findConflictingHeavyServerNames(
 
 function findActiveHeavyDefinition(
   configuredServers: Record<string, unknown> | undefined,
-  definition: HeavyMcpDefinition | null
+  definitions: Array<HeavyMcpDefinition | null>,
+  expectedServerNames?: string[]
 ): HeavyMcpDefinition | null {
-  return definition && isHeavyMcpDefinitionActiveInConfig(configuredServers, definition) ? definition : null;
+  for (const definition of definitions) {
+    if (definition && isHeavyMcpDefinitionActiveInConfig(configuredServers, definition, expectedServerNames)) {
+      return definition;
+    }
+  }
+  return null;
+}
+
+function haveMatchingHeavyServerNames(definitionServerNames: string[], expectedServerNames: string[]): boolean {
+  if (definitionServerNames.length !== expectedServerNames.length) {
+    return false;
+  }
+
+  const expectedServerNameSet = new Set(expectedServerNames);
+  return definitionServerNames.every((serverName) => expectedServerNameSet.has(serverName));
 }
 
 function getHeavyDefinitionFromMarker(marker: ActiveHeavyMcpMarker): HeavyMcpDefinition | null {

--- a/src/cli/heavy-command.ts
+++ b/src/cli/heavy-command.ts
@@ -261,15 +261,11 @@ async function listActiveHeavyMcps(paths: HeavyPaths, options: HeavyCliOptions):
         definitions.set(name, definition);
       }
 
-      if (definition) {
-        if (isHeavyMcpDefinitionActiveInConfig(config.mcpServers, definition)) {
-          active.add(name);
-        }
-        return;
-      }
-
       const marker = await readActiveMarker(path.join(paths.activeDir, `${name}.json`));
-      if (marker && findActiveHeavyDefinition(config.mcpServers, getHeavyDefinitionFromMarker(marker))) {
+      const activeDefinition =
+        findActiveHeavyDefinition(config.mcpServers, definition) ??
+        findActiveHeavyDefinition(config.mcpServers, marker ? getHeavyDefinitionFromMarker(marker) : null);
+      if (activeDefinition) {
         active.add(name);
       }
     })

--- a/src/cli/heavy-command.ts
+++ b/src/cli/heavy-command.ts
@@ -16,7 +16,12 @@ import path from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
 import { z } from 'zod';
 import { loadRawConfig, writeRawConfig } from '../config.js';
-import { assertValidHeavyMcpName, listHeavyMcpDefinitions, readHeavyMcpDefinition } from '../heavy/definition.js';
+import {
+  assertValidHeavyMcpName,
+  type HeavyMcpDefinition,
+  listHeavyMcpDefinitions,
+  readHeavyMcpDefinition,
+} from '../heavy/definition.js';
 import { type HeavyPaths, resolveHeavyPaths } from '../heavy/paths.js';
 import { logWarn } from './logger-context.js';
 
@@ -129,15 +134,26 @@ async function handleHeavyActivate(args: string[], paths: HeavyPaths, options: H
     throw new Error(`Heavy MCP '${name}' not found in ${paths.availableDir}`);
   }
 
-  // Check if already active
-  const active = await listActiveHeavyMcps(paths, options);
-  if (active.includes(name)) {
+  // Load current config
+  const { config, path: configPath } = await loadRawConfig(options);
+  const serverNames = Object.keys(definition.mcpServers);
+  const activePath = path.join(paths.activeDir, `${name}.json`);
+
+  if (isHeavyMcpDefinitionActiveInConfig(config.mcpServers, definition)) {
+    await fsPromises.mkdir(paths.activeDir, { recursive: true });
+    await writeActiveMarker(activePath, serverNames);
     console.log(`Heavy MCP '${name}' is already active.`);
     return;
   }
 
-  // Load current config
-  const { config, path: configPath } = await loadRawConfig(options);
+  const conflictingServerNames = findConflictingHeavyServerNames(config.mcpServers, definition);
+  if (conflictingServerNames.length > 0) {
+    throw new Error(
+      `Cannot activate heavy MCP '${name}' because these server entries already exist with different settings: ${conflictingServerNames
+        .map((serverName) => `'${serverName}'`)
+        .join(', ')}.`
+    );
+  }
 
   // Merge the heavy MCP servers into main config
   if (!config.mcpServers) {
@@ -150,10 +166,9 @@ async function handleHeavyActivate(args: string[], paths: HeavyPaths, options: H
   // Write back config
   await writeRawConfig(configPath, config);
 
-  // Create active marker (symlink)
+  // Refresh active marker metadata
   await fsPromises.mkdir(paths.activeDir, { recursive: true });
-  const activePath = path.join(paths.activeDir, `${name}.json`);
-  await writeActiveMarker(activePath, Object.keys(definition.mcpServers));
+  await writeActiveMarker(activePath, serverNames);
 
   console.log(`Activated: ${name}`);
 }
@@ -165,18 +180,38 @@ async function handleHeavyDeactivate(args: string[], paths: HeavyPaths, options:
   }
   assertValidHeavyMcpName(name);
 
-  // Check if active
-  const active = await listActiveHeavyMcps(paths, options);
-  if (!active.includes(name)) {
-    console.log(`Heavy MCP '${name}' is not active.`);
-    return;
-  }
-
   // Load current config
   const { config, path: configPath } = await loadRawConfig(options);
+  const activePath = path.join(paths.activeDir, `${name}.json`);
+
+  const marker = await readActiveMarker(activePath);
+  let serverNames: string[];
+  if (marker) {
+    if (!hasAnyConfiguredServers(config.mcpServers, marker.serverNames)) {
+      console.log(`Heavy MCP '${name}' is not active.`);
+      return;
+    }
+    serverNames = marker.serverNames;
+  } else {
+    let definition: HeavyMcpDefinition | null;
+    try {
+      definition = await readHeavyMcpDefinition(paths.availableDir, name);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Cannot deactivate heavy MCP '${name}' because its marker metadata is missing and its definition is invalid: ${message}`
+      );
+    }
+
+    if (!definition || !isHeavyMcpDefinitionActiveInConfig(config.mcpServers, definition)) {
+      console.log(`Heavy MCP '${name}' is not active.`);
+      return;
+    }
+
+    serverNames = Object.keys(definition.mcpServers);
+  }
 
   // Remove the server(s) from config
-  const serverNames = await resolveServerNamesForDeactivation(paths, name);
   for (const serverName of serverNames) {
     delete config.mcpServers?.[serverName];
   }
@@ -185,46 +220,87 @@ async function handleHeavyDeactivate(args: string[], paths: HeavyPaths, options:
   await writeRawConfig(configPath, config);
 
   // Remove active marker
-  const activePath = path.join(paths.activeDir, `${name}.json`);
   await fsPromises.unlink(activePath).catch(() => {});
 
   console.log(`Deactivated: ${name}`);
 }
 
 async function listActiveHeavyMcps(paths: HeavyPaths, options: HeavyCliOptions): Promise<string[]> {
-  const active = new Set(await listHeavyMcpDefinitions(paths.activeDir));
   const { config } = await loadRawConfig(options);
+  const active = new Set<string>();
+  const definitions = new Map<string, HeavyMcpDefinition | null>();
   const available = await listHeavyMcpDefinitions(paths.availableDir);
-  if (available.length === 0) {
-    return [...active];
-  }
-
-  const configuredServers = new Set(Object.keys(config.mcpServers ?? {}));
-  const configuredHeavyMcps = await Promise.all(
+  await Promise.all(
     available.map(async (name) => {
       const definition = await readHeavyDefinitionForActiveDetection(paths.availableDir, name);
-      if (!definition) {
-        return null;
+      definitions.set(name, definition);
+      if (definition && isHeavyMcpDefinitionActiveInConfig(config.mcpServers, definition)) {
+        active.add(name);
       }
-      const serverEntries = Object.entries(definition.mcpServers);
-      return serverEntries.every(([serverName, definitionEntry]) => {
-        if (!configuredServers.has(serverName)) {
-          return false;
-        }
-        return isDeepStrictEqual(config.mcpServers?.[serverName], definitionEntry);
-      })
-        ? name
-        : null;
     })
   );
 
-  for (const name of configuredHeavyMcps) {
-    if (name) {
-      active.add(name);
-    }
-  }
+  const marked = await listHeavyMcpDefinitions(paths.activeDir);
+  await Promise.all(
+    marked.map(async (name) => {
+      let definition: HeavyMcpDefinition | null;
+      if (definitions.has(name)) {
+        definition = definitions.get(name) ?? null;
+      } else {
+        definition = await readHeavyDefinitionForActiveDetection(paths.availableDir, name);
+        definitions.set(name, definition);
+      }
+
+      if (definition) {
+        if (isHeavyMcpDefinitionActiveInConfig(config.mcpServers, definition)) {
+          active.add(name);
+        }
+        return;
+      }
+
+      const marker = await readActiveMarker(path.join(paths.activeDir, `${name}.json`));
+      if (marker && hasAllConfiguredServers(config.mcpServers, marker.serverNames)) {
+        active.add(name);
+      }
+    })
+  );
 
   return [...active];
+}
+
+function isHeavyMcpDefinitionActiveInConfig(
+  configuredServers: Record<string, unknown> | undefined,
+  definition: HeavyMcpDefinition
+): boolean {
+  return Object.entries(definition.mcpServers).every(([serverName, definitionEntry]) =>
+    isDeepStrictEqual(configuredServers?.[serverName], definitionEntry)
+  );
+}
+
+function findConflictingHeavyServerNames(
+  configuredServers: Record<string, unknown> | undefined,
+  definition: HeavyMcpDefinition
+): string[] {
+  return Object.entries(definition.mcpServers)
+    .filter(([serverName, definitionEntry]) => {
+      const configuredEntry = configuredServers?.[serverName];
+      return configuredEntry !== undefined && !isDeepStrictEqual(configuredEntry, definitionEntry);
+    })
+    .map(([serverName]) => serverName);
+}
+
+function hasAllConfiguredServers(
+  configuredServers: Record<string, unknown> | undefined,
+  serverNames: string[]
+): boolean {
+  return serverNames.every((serverName) => configuredServers?.[serverName] !== undefined);
+}
+
+function hasAnyConfiguredServers(
+  configuredServers: Record<string, unknown> | undefined,
+  serverNames: string[]
+): boolean {
+  return serverNames.some((serverName) => configuredServers?.[serverName] !== undefined);
 }
 
 async function readHeavyDefinitionForActiveDetection(
@@ -238,30 +314,6 @@ async function readHeavyDefinitionForActiveDetection(
     logWarn(`Skipping invalid heavy MCP definition '${name}': ${message}`);
     return null;
   }
-}
-
-async function resolveServerNamesForDeactivation(paths: HeavyPaths, name: string): Promise<string[]> {
-  const activePath = path.join(paths.activeDir, `${name}.json`);
-  const marker = await readActiveMarker(activePath);
-  if (marker) {
-    return marker.serverNames;
-  }
-
-  try {
-    const definition = await readHeavyMcpDefinition(paths.availableDir, name);
-    if (definition) {
-      return Object.keys(definition.mcpServers);
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `Cannot deactivate heavy MCP '${name}' because its marker metadata is missing and its definition is invalid: ${message}`
-    );
-  }
-
-  throw new Error(
-    `Cannot deactivate heavy MCP '${name}' because its marker metadata is missing and its definition file is unavailable.`
-  );
 }
 
 async function readActiveMarker(activePath: string): Promise<ActiveHeavyMcpMarker | null> {
@@ -287,16 +339,10 @@ async function writeActiveMarker(activePath: string, serverNames: string[]): Pro
     serverNames,
   };
 
-  try {
-    await fsPromises.writeFile(activePath, `${JSON.stringify(marker, null, 2)}\n`, {
-      encoding: 'utf8',
-      flag: 'wx',
-    });
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === 'EEXIST') {
-      return;
+  await fsPromises.unlink(activePath).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
     }
-    throw error;
-  }
+  });
+  await fsPromises.writeFile(activePath, `${JSON.stringify(marker, null, 2)}\n`, 'utf8');
 }

--- a/src/cli/heavy-command.ts
+++ b/src/cli/heavy-command.ts
@@ -13,8 +13,9 @@
 
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
 import { loadRawConfig, writeRawConfig } from '../config.js';
-import { listHeavyMcpDefinitions, readHeavyMcpDefinition } from '../heavy/definition.js';
+import { assertValidHeavyMcpName, listHeavyMcpDefinitions, readHeavyMcpDefinition } from '../heavy/definition.js';
 import { type HeavyPaths, resolveHeavyPaths } from '../heavy/paths.js';
 
 interface HeavyCliOptions {
@@ -111,6 +112,7 @@ async function handleHeavyActivate(args: string[], paths: HeavyPaths, options: H
   if (!name) {
     throw new Error('Usage: mcporter heavy activate <name>');
   }
+  assertValidHeavyMcpName(name);
 
   // Check if the heavy MCP definition exists
   const definition = await readHeavyMcpDefinition(paths.availableDir, name);
@@ -158,6 +160,7 @@ async function handleHeavyDeactivate(args: string[], paths: HeavyPaths, options:
   if (!name) {
     throw new Error('Usage: mcporter heavy deactivate <name>');
   }
+  assertValidHeavyMcpName(name);
 
   // Check if active
   const active = await listActiveHeavyMcps(paths, options);
@@ -205,8 +208,15 @@ async function listActiveHeavyMcps(paths: HeavyPaths, options: HeavyCliOptions):
       if (!definition) {
         return null;
       }
-      const serverNames = Object.keys(definition.mcpServers);
-      return serverNames.every((serverName) => configuredServers.has(serverName)) ? name : null;
+      const serverEntries = Object.entries(definition.mcpServers);
+      return serverEntries.every(([serverName, definitionEntry]) => {
+        if (!configuredServers.has(serverName)) {
+          return false;
+        }
+        return isDeepStrictEqual(config.mcpServers?.[serverName], definitionEntry);
+      })
+        ? name
+        : null;
     })
   );
 

--- a/src/cli/heavy-command.ts
+++ b/src/cli/heavy-command.ts
@@ -191,15 +191,11 @@ async function handleHeavyDeactivate(args: string[], paths: HeavyPaths, options:
 }
 
 async function listActiveHeavyMcps(paths: HeavyPaths, options: HeavyCliOptions): Promise<string[]> {
-  const active = await listHeavyMcpDefinitions(paths.activeDir);
-  if (active.length > 0) {
-    return active;
-  }
-
+  const active = new Set(await listHeavyMcpDefinitions(paths.activeDir));
   const { config } = await loadRawConfig(options);
   const available = await listHeavyMcpDefinitions(paths.availableDir);
   if (available.length === 0) {
-    return [];
+    return [...active];
   }
 
   const configuredServers = new Set(Object.keys(config.mcpServers ?? {}));
@@ -214,5 +210,11 @@ async function listActiveHeavyMcps(paths: HeavyPaths, options: HeavyCliOptions):
     })
   );
 
-  return configuredHeavyMcps.filter((name): name is string => name !== null);
+  for (const name of configuredHeavyMcps) {
+    if (name) {
+      active.add(name);
+    }
+  }
+
+  return [...active];
 }

--- a/src/cli/help-output.ts
+++ b/src/cli/help-output.ts
@@ -92,6 +92,11 @@ function buildCommandSections(colorize: boolean): string[] {
           summary: 'Inspect or edit config files (list, get, add, remove, import, login, logout)',
           usage: 'mcporter config <command> [options]',
         },
+        {
+          name: 'heavy',
+          summary: 'Manage large MCP definitions with on-demand activation',
+          usage: 'mcporter heavy <list|activate|deactivate>',
+        },
       ],
     },
     {

--- a/src/heavy/definition.ts
+++ b/src/heavy/definition.ts
@@ -25,8 +25,12 @@ export interface HeavyMcpDefinition {
   mcpServers: Record<string, RawEntry>;
 }
 
+export const HeavyMcpServersSchema = z
+  .record(z.string(), RawEntrySchema)
+  .refine((mcpServers) => Object.keys(mcpServers).length > 0, 'must contain at least one server');
+
 const HeavyMcpDefinitionSchema = z.object({
-  mcpServers: z.record(z.string(), RawEntrySchema),
+  mcpServers: HeavyMcpServersSchema,
 });
 
 export function assertValidHeavyMcpName(name: string): void {

--- a/src/heavy/definition.ts
+++ b/src/heavy/definition.ts
@@ -29,6 +29,20 @@ const HeavyMcpDefinitionSchema = z.object({
   mcpServers: z.record(z.string(), RawEntrySchema),
 });
 
+export function assertValidHeavyMcpName(name: string): void {
+  const isSafeBasename =
+    name.length > 0 &&
+    name !== '.' &&
+    name !== '..' &&
+    name === path.posix.basename(name) &&
+    name === path.win32.basename(name) &&
+    !name.includes('\0');
+
+  if (!isSafeBasename) {
+    throw new Error(`Invalid heavy MCP name '${name}'. Use a simple basename without path separators.`);
+  }
+}
+
 /**
  * Read a heavy MCP definition file.
  *
@@ -37,6 +51,7 @@ const HeavyMcpDefinitionSchema = z.object({
  * @returns The definition or null if not found
  */
 export async function readHeavyMcpDefinition(availableDir: string, name: string): Promise<HeavyMcpDefinition | null> {
+  assertValidHeavyMcpName(name);
   const definitionPath = path.join(availableDir, `${name}.json`);
 
   try {
@@ -70,6 +85,7 @@ export async function writeHeavyMcpDefinition(
   name: string,
   definition: HeavyMcpDefinition
 ): Promise<void> {
+  assertValidHeavyMcpName(name);
   await fsPromises.mkdir(availableDir, { recursive: true });
   const definitionPath = path.join(availableDir, `${name}.json`);
   const content = `${JSON.stringify(definition, null, 2)}\n`;
@@ -101,6 +117,7 @@ export async function listHeavyMcpDefinitions(availableDir: string): Promise<str
  * @param name - Name of the heavy MCP (without .json extension)
  */
 export async function deleteHeavyMcpDefinition(availableDir: string, name: string): Promise<void> {
+  assertValidHeavyMcpName(name);
   const definitionPath = path.join(availableDir, `${name}.json`);
   await fsPromises.unlink(definitionPath).catch((error) => {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {

--- a/src/heavy/definition.ts
+++ b/src/heavy/definition.ts
@@ -17,11 +17,17 @@
 
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
+import { z } from 'zod';
 import type { RawEntry } from '../config-schema.js';
+import { RawEntrySchema } from '../config-schema.js';
 
 export interface HeavyMcpDefinition {
   mcpServers: Record<string, RawEntry>;
 }
+
+const HeavyMcpDefinitionSchema = z.object({
+  mcpServers: z.record(z.string(), RawEntrySchema),
+});
 
 /**
  * Read a heavy MCP definition file.
@@ -36,7 +42,14 @@ export async function readHeavyMcpDefinition(availableDir: string, name: string)
   try {
     const content = await fsPromises.readFile(definitionPath, 'utf8');
     const parsed = JSON.parse(content);
-    return parsed as HeavyMcpDefinition;
+    const validation = HeavyMcpDefinitionSchema.safeParse(parsed);
+    if (!validation.success) {
+      const firstIssue = validation.error.issues[0];
+      const issuePath = firstIssue?.path.length ? ` at ${firstIssue.path.join('.')}` : '';
+      const issueMessage = firstIssue?.message ?? 'expected an object with mcpServers';
+      throw new Error(`Invalid heavy MCP definition '${name}' in ${definitionPath}${issuePath}: ${issueMessage}`);
+    }
+    return validation.data;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return null;

--- a/src/heavy/definition.ts
+++ b/src/heavy/definition.ts
@@ -1,0 +1,97 @@
+/**
+ * Heavy MCP definition file handling.
+ *
+ * A heavy MCP definition file is a JSON file containing MCP server configurations
+ * that are stored separately from the main mcporter.json to save context tokens.
+ *
+ * Example (chrome-devtools.json):
+ * {
+ *   "mcpServers": {
+ *     "chrome-devtools": {
+ *       "command": "npx",
+ *       "args": ["-y", "chrome-devtools-mcp@latest"]
+ *     }
+ *   }
+ * }
+ */
+
+import fsPromises from 'node:fs/promises';
+import path from 'node:path';
+import type { RawEntry } from '../config-schema.js';
+
+export interface HeavyMcpDefinition {
+  mcpServers: Record<string, RawEntry>;
+}
+
+/**
+ * Read a heavy MCP definition file.
+ *
+ * @param availableDir - Directory containing available heavy MCPs
+ * @param name - Name of the heavy MCP (without .json extension)
+ * @returns The definition or null if not found
+ */
+export async function readHeavyMcpDefinition(availableDir: string, name: string): Promise<HeavyMcpDefinition | null> {
+  const definitionPath = path.join(availableDir, `${name}.json`);
+
+  try {
+    const content = await fsPromises.readFile(definitionPath, 'utf8');
+    const parsed = JSON.parse(content);
+    return parsed as HeavyMcpDefinition;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Write a heavy MCP definition file.
+ *
+ * @param availableDir - Directory containing available heavy MCPs
+ * @param name - Name of the heavy MCP (without .json extension)
+ * @param definition - The definition to write
+ */
+export async function writeHeavyMcpDefinition(
+  availableDir: string,
+  name: string,
+  definition: HeavyMcpDefinition
+): Promise<void> {
+  await fsPromises.mkdir(availableDir, { recursive: true });
+  const definitionPath = path.join(availableDir, `${name}.json`);
+  const content = `${JSON.stringify(definition, null, 2)}\n`;
+  await fsPromises.writeFile(definitionPath, content, 'utf8');
+}
+
+/**
+ * List all available heavy MCP definitions.
+ *
+ * @param availableDir - Directory containing available heavy MCPs
+ * @returns Array of heavy MCP names (without .json extension)
+ */
+export async function listHeavyMcpDefinitions(availableDir: string): Promise<string[]> {
+  try {
+    const files = await fsPromises.readdir(availableDir);
+    return files.filter((file) => file.endsWith('.json')).map((file) => file.replace(/\.json$/, ''));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+}
+
+/**
+ * Delete a heavy MCP definition file.
+ *
+ * @param availableDir - Directory containing available heavy MCPs
+ * @param name - Name of the heavy MCP (without .json extension)
+ */
+export async function deleteHeavyMcpDefinition(availableDir: string, name: string): Promise<void> {
+  const definitionPath = path.join(availableDir, `${name}.json`);
+  await fsPromises.unlink(definitionPath).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  });
+}

--- a/src/heavy/index.ts
+++ b/src/heavy/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Heavy MCP management module.
+ *
+ * Provides on-demand loading for large MCP servers that consume significant
+ * context tokens when loaded.
+ */
+
+export {
+  deleteHeavyMcpDefinition,
+  type HeavyMcpDefinition,
+  listHeavyMcpDefinitions,
+  readHeavyMcpDefinition,
+  writeHeavyMcpDefinition,
+} from './definition.js';
+export { getDefaultHeavyPaths, type HeavyPaths, resolveHeavyPaths } from './paths.js';

--- a/src/heavy/paths.ts
+++ b/src/heavy/paths.ts
@@ -1,0 +1,49 @@
+/**
+ * Path resolution for heavy MCP management.
+ *
+ * Heavy MCPs are servers with large tool schemas that consume significant
+ * context tokens. This module provides path resolution for managing them.
+ */
+
+import os from 'node:os';
+import path from 'node:path';
+
+export interface HeavyPaths {
+  /** Base directory for heavy MCP management (~/.mcporter/heavy) */
+  heavyDir: string;
+  /** Directory containing available heavy MCP definitions */
+  availableDir: string;
+  /** Directory tracking active heavy MCPs */
+  activeDir: string;
+}
+
+/**
+ * Get the default heavy paths based on home directory.
+ */
+export function getDefaultHeavyPaths(): HeavyPaths {
+  const homeDir = os.homedir();
+  const mcporterDir = path.join(homeDir, '.mcporter');
+
+  return {
+    heavyDir: path.join(mcporterDir, 'heavy'),
+    availableDir: path.join(mcporterDir, 'heavy', 'available'),
+    activeDir: path.join(mcporterDir, 'heavy', 'active'),
+  };
+}
+
+/**
+ * Resolve paths for heavy MCP management based on config path.
+ *
+ * @param configPath - Path to the main mcporter.json file
+ * @returns HeavyPaths object with resolved paths
+ */
+export function resolveHeavyPaths(configPath: string): HeavyPaths {
+  // Determine the mcporter directory from config path
+  const mcporterDir = path.dirname(configPath);
+
+  return {
+    heavyDir: path.join(mcporterDir, 'heavy'),
+    availableDir: path.join(mcporterDir, 'heavy', 'available'),
+    activeDir: path.join(mcporterDir, 'heavy', 'active'),
+  };
+}

--- a/tests/cli-help-shortcuts.test.ts
+++ b/tests/cli-help-shortcuts.test.ts
@@ -26,6 +26,8 @@ describe('mcporter help shortcuts (hidden)', () => {
     { args: ['call', 'help'], expectSnippet: 'Usage: mcporter call' },
     { args: ['auth', '--help'], expectSnippet: 'Usage: mcporter auth' },
     { args: ['auth', 'help'], expectSnippet: 'Usage: mcporter auth' },
+    { args: ['heavy', '--help'], expectSnippet: 'Usage: mcporter heavy' },
+    { args: ['heavy', 'help'], expectSnippet: 'Usage: mcporter heavy' },
     { args: ['list', '--help'], expectSnippet: 'Usage: mcporter list' },
     { args: ['list', 'help'], expectSnippet: 'Usage: mcporter list' },
   ];

--- a/tests/heavy-command.test.ts
+++ b/tests/heavy-command.test.ts
@@ -413,6 +413,36 @@ describe('mcporter heavy CLI', () => {
     logSpy.mockRestore();
   });
 
+  it('treats a marker-backed heavy MCP as already active when the current definition shrinks', async () => {
+    await writeHeavyDefinition('browser-suite', ['playwright', 'chrome-devtools']);
+    await handleHeavyCli(['activate', 'browser-suite'], { configPath, rootDir: tempDir });
+    await writeHeavyDefinition('browser-suite', ['playwright']);
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await expect(
+      handleHeavyCli(['activate', 'browser-suite'], { configPath, rootDir: tempDir })
+    ).resolves.toBeUndefined();
+
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, { command: string }>;
+    };
+    expect(config.mcpServers.playwright?.command).toBe('npx');
+    expect(config.mcpServers['chrome-devtools']?.command).toBe('npx');
+    const marker = JSON.parse(
+      await fs.readFile(path.join(tempDir, 'config', 'heavy', 'active', 'browser-suite.json'), 'utf8')
+    ) as { serverNames: string[] };
+    expect(marker.serverNames).toEqual(['playwright', 'chrome-devtools']);
+    expect(logs).toContain("Heavy MCP 'browser-suite' is already active.");
+
+    logSpy.mockRestore();
+  });
+
   it('rejects activation when it would overwrite an existing server config', async () => {
     await fs.writeFile(
       configPath,
@@ -561,6 +591,33 @@ describe('mcporter heavy CLI', () => {
       fs.readFile(path.join(tempDir, 'config', 'heavy', 'active', 'chrome-devtools.json'), 'utf8')
     ).resolves.toContain('chrome-devtools');
     expect(logs).toContain("Heavy MCP 'chrome-devtools' is not active.");
+
+    logSpy.mockRestore();
+  });
+
+  it('deactivates all originally activated servers when the current definition shrinks', async () => {
+    await writeHeavyDefinition('browser-suite', ['playwright', 'chrome-devtools']);
+    await handleHeavyCli(['activate', 'browser-suite'], { configPath, rootDir: tempDir });
+    await writeHeavyDefinition('browser-suite', ['playwright']);
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await expect(
+      handleHeavyCli(['deactivate', 'browser-suite'], { configPath, rootDir: tempDir })
+    ).resolves.toBeUndefined();
+
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(config.mcpServers.playwright).toBeUndefined();
+    expect(config.mcpServers['chrome-devtools']).toBeUndefined();
+    await expect(fs.access(path.join(tempDir, 'config', 'heavy', 'active', 'browser-suite.json'))).rejects.toThrow();
+    expect(logs).toContain('Deactivated: browser-suite');
 
     logSpy.mockRestore();
   });

--- a/tests/heavy-command.test.ts
+++ b/tests/heavy-command.test.ts
@@ -289,6 +289,14 @@ describe('mcporter heavy CLI', () => {
     );
   });
 
+  it('rejects empty heavy definitions with a validation error', async () => {
+    await fs.writeFile(path.join(availableDir, 'empty.json'), JSON.stringify({ mcpServers: {} }, null, 2), 'utf8');
+
+    await expect(handleHeavyCli(['activate', 'empty'], { configPath, rootDir: tempDir })).rejects.toThrow(
+      /Invalid heavy MCP definition 'empty'.*must contain at least one server/
+    );
+  });
+
   it('ignores unrelated invalid heavy definitions during activation and listing', async () => {
     await fs.writeFile(path.join(availableDir, 'broken.json'), JSON.stringify({ nope: true }, null, 2), 'utf8');
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -469,6 +477,56 @@ describe('mcporter heavy CLI', () => {
     expect(config.mcpServers['chrome-devtools']).toBeUndefined();
     await expect(fs.access(path.join(tempDir, 'config', 'heavy', 'active', 'chrome-devtools.json'))).rejects.toThrow();
     expect(logs).toContain('Deactivated: chrome-devtools');
+
+    logSpy.mockRestore();
+  });
+
+  it('does not deactivate drifted marker-backed configs when the definition becomes malformed', async () => {
+    await handleHeavyCli(['activate', 'chrome-devtools'], { configPath, rootDir: tempDir });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            'chrome-devtools': {
+              command: 'node',
+              args: ['custom-devtools.js'],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+    await fs.writeFile(
+      path.join(availableDir, 'chrome-devtools.json'),
+      JSON.stringify({ nope: true }, null, 2),
+      'utf8'
+    );
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await expect(
+      handleHeavyCli(['deactivate', 'chrome-devtools'], { configPath, rootDir: tempDir })
+    ).resolves.toBeUndefined();
+
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, { command: string; args: string[] }>;
+    };
+    expect(config.mcpServers['chrome-devtools']).toEqual({
+      command: 'node',
+      args: ['custom-devtools.js'],
+    });
+    await expect(
+      fs.readFile(path.join(tempDir, 'config', 'heavy', 'active', 'chrome-devtools.json'), 'utf8')
+    ).resolves.toContain('chrome-devtools');
+    expect(logs).toContain("Heavy MCP 'chrome-devtools' is not active.");
 
     logSpy.mockRestore();
   });

--- a/tests/heavy-command.test.ts
+++ b/tests/heavy-command.test.ts
@@ -242,6 +242,40 @@ describe('mcporter heavy CLI', () => {
     logSpy.mockRestore();
   });
 
+  it('lists marker-backed heavy MCPs as active when the available definition drifts', async () => {
+    await handleHeavyCli(['activate', 'playwright'], { configPath, rootDir: tempDir });
+    await fs.writeFile(
+      path.join(availableDir, 'playwright.json'),
+      JSON.stringify(
+        {
+          mcpServers: {
+            playwright: {
+              command: 'npx',
+              args: ['-y', 'playwright-mcp@next'],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await handleHeavyCli(['list'], { configPath, rootDir: tempDir });
+
+    const output = logs.join('\n');
+    expect(output).toContain('playwright [active]');
+
+    logSpy.mockRestore();
+  });
+
   it('does not delete same-name custom configs during deactivate fallback', async () => {
     await fs.writeFile(
       configPath,

--- a/tests/heavy-command.test.ts
+++ b/tests/heavy-command.test.ts
@@ -182,12 +182,95 @@ describe('mcporter heavy CLI', () => {
     logSpy.mockRestore();
   });
 
+  it('does not treat same-name custom configs as active heavy MCPs', async () => {
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            playwright: {
+              command: 'node',
+              args: ['custom-playwright.js'],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await handleHeavyCli(['list'], { configPath, rootDir: tempDir });
+
+    const output = logs.join('\n');
+    expect(output).toContain('  playwright');
+    expect(output).not.toContain('playwright [active]');
+
+    logSpy.mockRestore();
+  });
+
+  it('does not delete same-name custom configs during deactivate fallback', async () => {
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            playwright: {
+              command: 'node',
+              args: ['custom-playwright.js'],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await handleHeavyCli(['deactivate', 'playwright'], { configPath, rootDir: tempDir });
+
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, { command: string; args: string[] }>;
+    };
+    expect(config.mcpServers.playwright).toEqual({
+      command: 'node',
+      args: ['custom-playwright.js'],
+    });
+    expect(logs).toContain("Heavy MCP 'playwright' is not active.");
+
+    logSpy.mockRestore();
+  });
+
   it('rejects malformed heavy definitions with a validation error', async () => {
     await fs.writeFile(path.join(availableDir, 'broken.json'), JSON.stringify({ nope: true }, null, 2), 'utf8');
 
     await expect(handleHeavyCli(['activate', 'broken'], { configPath, rootDir: tempDir })).rejects.toThrow(
       /Invalid heavy MCP definition 'broken'/
     );
+  });
+
+  it('rejects unsafe heavy MCP names before any filesystem writes', async () => {
+    const originalConfig = await fs.readFile(configPath, 'utf8');
+
+    await expect(handleHeavyCli(['activate', '../../mcporter'], { configPath, rootDir: tempDir })).rejects.toThrow(
+      /Invalid heavy MCP name/
+    );
+
+    await expect(fs.readFile(configPath, 'utf8')).resolves.toBe(originalConfig);
   });
 
   async function writeHeavyDefinition(name: 'chrome-devtools' | 'playwright'): Promise<void> {

--- a/tests/heavy-command.test.ts
+++ b/tests/heavy-command.test.ts
@@ -263,6 +263,50 @@ describe('mcporter heavy CLI', () => {
     );
   });
 
+  it('ignores unrelated invalid heavy definitions during activation and listing', async () => {
+    await fs.writeFile(path.join(availableDir, 'broken.json'), JSON.stringify({ nope: true }, null, 2), 'utf8');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await expect(
+      handleHeavyCli(['activate', 'chrome-devtools'], { configPath, rootDir: tempDir })
+    ).resolves.toBeUndefined();
+    await expect(handleHeavyCli(['list'], { configPath, rootDir: tempDir })).resolves.toBeUndefined();
+
+    expect(logs.join('\n')).toContain('chrome-devtools [active]');
+    expect(warnSpy).toHaveBeenCalled();
+
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('ignores unrelated invalid heavy definitions during deactivate', async () => {
+    await handleHeavyCli(['activate', 'chrome-devtools'], { configPath, rootDir: tempDir });
+    await fs.writeFile(path.join(availableDir, 'broken.json'), JSON.stringify({ nope: true }, null, 2), 'utf8');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await expect(
+      handleHeavyCli(['deactivate', 'chrome-devtools'], { configPath, rootDir: tempDir })
+    ).resolves.toBeUndefined();
+
+    expect(logs).toContain('Deactivated: chrome-devtools');
+    expect(warnSpy).toHaveBeenCalled();
+
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
   it('rejects unsafe heavy MCP names before any filesystem writes', async () => {
     const originalConfig = await fs.readFile(configPath, 'utf8');
 
@@ -271,6 +315,31 @@ describe('mcporter heavy CLI', () => {
     );
 
     await expect(fs.readFile(configPath, 'utf8')).resolves.toBe(originalConfig);
+  });
+
+  it('does not clobber heavy definitions when symlink creation races with an existing marker', async () => {
+    const activePath = path.join(tempDir, 'config', 'heavy', 'active', 'chrome-devtools.json');
+    const availablePath = path.join(availableDir, 'chrome-devtools.json');
+    const originalDefinition = await fs.readFile(availablePath, 'utf8');
+    const originalSymlink = fs.symlink.bind(fs);
+    const symlinkSpy = vi.spyOn(fs, 'symlink').mockImplementation(async (target, destination, type) => {
+      const destinationPath = destination.toString();
+      await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+      await originalSymlink(target, destinationPath, type);
+      const error = new Error('marker already exists') as NodeJS.ErrnoException;
+      error.code = 'EEXIST';
+      throw error;
+    });
+
+    await expect(
+      handleHeavyCli(['activate', 'chrome-devtools'], { configPath, rootDir: tempDir })
+    ).resolves.toBeUndefined();
+
+    await expect(fs.readFile(availablePath, 'utf8')).resolves.toBe(originalDefinition);
+    const stat = await fs.lstat(activePath);
+    expect(stat.isSymbolicLink()).toBe(true);
+
+    symlinkSpy.mockRestore();
   });
 
   async function writeHeavyDefinition(name: 'chrome-devtools' | 'playwright'): Promise<void> {

--- a/tests/heavy-command.test.ts
+++ b/tests/heavy-command.test.ts
@@ -217,6 +217,31 @@ describe('mcporter heavy CLI', () => {
     logSpy.mockRestore();
   });
 
+  it('does not list stale markers as active heavy MCPs', async () => {
+    const activePath = path.join(tempDir, 'config', 'heavy', 'active', 'chrome-devtools.json');
+    await fs.mkdir(path.dirname(activePath), { recursive: true });
+    await fs.writeFile(
+      activePath,
+      JSON.stringify({ activated: 'already', serverNames: ['chrome-devtools'] }, null, 2),
+      'utf8'
+    );
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await handleHeavyCli(['list'], { configPath, rootDir: tempDir });
+
+    const output = logs.join('\n');
+    expect(output).toContain('  chrome-devtools');
+    expect(output).not.toContain('chrome-devtools [active]');
+
+    logSpy.mockRestore();
+  });
+
   it('does not delete same-name custom configs during deactivate fallback', async () => {
     await fs.writeFile(
       configPath,
@@ -289,7 +314,6 @@ describe('mcporter heavy CLI', () => {
   it('ignores unrelated invalid heavy definitions during deactivate', async () => {
     await handleHeavyCli(['activate', 'chrome-devtools'], { configPath, rootDir: tempDir });
     await fs.writeFile(path.join(availableDir, 'broken.json'), JSON.stringify({ nope: true }, null, 2), 'utf8');
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const logs: string[] = [];
     const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
       if (typeof value === 'string') {
@@ -302,10 +326,8 @@ describe('mcporter heavy CLI', () => {
     ).resolves.toBeUndefined();
 
     expect(logs).toContain('Deactivated: chrome-devtools');
-    expect(warnSpy).toHaveBeenCalled();
 
     logSpy.mockRestore();
-    warnSpy.mockRestore();
   });
 
   it('rejects unsafe heavy MCP names before any filesystem writes', async () => {
@@ -318,17 +340,63 @@ describe('mcporter heavy CLI', () => {
     await expect(fs.readFile(configPath, 'utf8')).resolves.toBe(originalConfig);
   });
 
-  it('does not clobber heavy definitions when symlink creation races with an existing marker', async () => {
+  it('reactivates when only a stale marker file remains', async () => {
     const activePath = path.join(tempDir, 'config', 'heavy', 'active', 'chrome-devtools.json');
-    const existingMarker = JSON.stringify({ activated: 'already', serverNames: ['chrome-devtools'] }, null, 2);
     await fs.mkdir(path.dirname(activePath), { recursive: true });
-    await fs.writeFile(activePath, existingMarker, 'utf8');
+    await fs.writeFile(
+      activePath,
+      JSON.stringify({ activated: 'already', serverNames: ['stale-server'] }, null, 2),
+      'utf8'
+    );
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
 
     await expect(
       handleHeavyCli(['activate', 'chrome-devtools'], { configPath, rootDir: tempDir })
     ).resolves.toBeUndefined();
 
-    await expect(fs.readFile(activePath, 'utf8')).resolves.toBe(existingMarker);
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, { command: string }>;
+    };
+    expect(config.mcpServers['chrome-devtools']?.command).toBe('npx');
+    const marker = JSON.parse(await fs.readFile(activePath, 'utf8')) as { serverNames: string[] };
+    expect(marker.serverNames).toEqual(['chrome-devtools']);
+    expect(logs).toContain('Activated: chrome-devtools');
+
+    logSpy.mockRestore();
+  });
+
+  it('rejects activation when it would overwrite an existing server config', async () => {
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            'chrome-devtools': {
+              command: 'node',
+              args: ['custom-devtools.js'],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const originalConfig = await fs.readFile(configPath, 'utf8');
+
+    await expect(handleHeavyCli(['activate', 'chrome-devtools'], { configPath, rootDir: tempDir })).rejects.toThrow(
+      /Cannot activate heavy MCP 'chrome-devtools' because these server entries already exist with different settings: 'chrome-devtools'/
+    );
+
+    await expect(fs.readFile(configPath, 'utf8')).resolves.toBe(originalConfig);
+    await expect(fs.access(path.join(tempDir, 'config', 'heavy', 'active', 'chrome-devtools.json'))).rejects.toThrow();
   });
 
   it('deactivates an active heavy MCP even when its definition file becomes malformed', async () => {

--- a/tests/heavy-command.test.ts
+++ b/tests/heavy-command.test.ts
@@ -16,8 +16,8 @@ describe('mcporter heavy CLI', () => {
     await fs.mkdir(path.dirname(configPath), { recursive: true });
     await fs.writeFile(configPath, JSON.stringify({ mcpServers: {} }, null, 2), 'utf8');
     await fs.mkdir(availableDir, { recursive: true });
-    await writeHeavyDefinition('chrome-devtools');
-    await writeHeavyDefinition('playwright');
+    await writeHeavyDefinition('chrome-devtools', ['chrome-devtools']);
+    await writeHeavyDefinition('playwright', ['playwright']);
   });
 
   afterEach(async () => {
@@ -39,9 +39,10 @@ describe('mcporter heavy CLI', () => {
       mcpServers: Record<string, { command: string }>;
     };
     expect(config.mcpServers['chrome-devtools']?.command).toBe('npx');
-    await expect(
-      fs.lstat(path.join(tempDir, 'config', 'heavy', 'active', 'chrome-devtools.json'))
-    ).resolves.toBeTruthy();
+    const marker = JSON.parse(
+      await fs.readFile(path.join(tempDir, 'config', 'heavy', 'active', 'chrome-devtools.json'), 'utf8')
+    ) as { serverNames: string[] };
+    expect(marker.serverNames).toEqual(['chrome-devtools']);
     expect(logs).toContain('Activated: chrome-devtools');
 
     logSpy.mockRestore();
@@ -319,41 +320,86 @@ describe('mcporter heavy CLI', () => {
 
   it('does not clobber heavy definitions when symlink creation races with an existing marker', async () => {
     const activePath = path.join(tempDir, 'config', 'heavy', 'active', 'chrome-devtools.json');
-    const availablePath = path.join(availableDir, 'chrome-devtools.json');
-    const originalDefinition = await fs.readFile(availablePath, 'utf8');
-    const originalSymlink = fs.symlink.bind(fs);
-    const symlinkSpy = vi.spyOn(fs, 'symlink').mockImplementation(async (target, destination, type) => {
-      const destinationPath = destination.toString();
-      await fs.mkdir(path.dirname(destinationPath), { recursive: true });
-      await originalSymlink(target, destinationPath, type);
-      const error = new Error('marker already exists') as NodeJS.ErrnoException;
-      error.code = 'EEXIST';
-      throw error;
-    });
+    const existingMarker = JSON.stringify({ activated: 'already', serverNames: ['chrome-devtools'] }, null, 2);
+    await fs.mkdir(path.dirname(activePath), { recursive: true });
+    await fs.writeFile(activePath, existingMarker, 'utf8');
 
     await expect(
       handleHeavyCli(['activate', 'chrome-devtools'], { configPath, rootDir: tempDir })
     ).resolves.toBeUndefined();
 
-    await expect(fs.readFile(availablePath, 'utf8')).resolves.toBe(originalDefinition);
-    const stat = await fs.lstat(activePath);
-    expect(stat.isSymbolicLink()).toBe(true);
-
-    symlinkSpy.mockRestore();
+    await expect(fs.readFile(activePath, 'utf8')).resolves.toBe(existingMarker);
   });
 
-  async function writeHeavyDefinition(name: 'chrome-devtools' | 'playwright'): Promise<void> {
-    const args = name === 'chrome-devtools' ? ['-y', 'chrome-devtools-mcp@latest'] : ['-y', 'playwright-mcp@latest'];
+  it('deactivates an active heavy MCP even when its definition file becomes malformed', async () => {
+    await handleHeavyCli(['activate', 'chrome-devtools'], { configPath, rootDir: tempDir });
+    await fs.writeFile(
+      path.join(availableDir, 'chrome-devtools.json'),
+      JSON.stringify({ nope: true }, null, 2),
+      'utf8'
+    );
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await expect(
+      handleHeavyCli(['deactivate', 'chrome-devtools'], { configPath, rootDir: tempDir })
+    ).resolves.toBeUndefined();
+
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(config.mcpServers['chrome-devtools']).toBeUndefined();
+    await expect(fs.access(path.join(tempDir, 'config', 'heavy', 'active', 'chrome-devtools.json'))).rejects.toThrow();
+    expect(logs).toContain('Deactivated: chrome-devtools');
+
+    logSpy.mockRestore();
+  });
+
+  it('deactivates using marker metadata when the definition file is missing and names differ from the basename', async () => {
+    await writeHeavyDefinition('browser-suite', ['playwright', 'chrome-devtools']);
+    await handleHeavyCli(['activate', 'browser-suite'], { configPath, rootDir: tempDir });
+    await fs.unlink(path.join(availableDir, 'browser-suite.json'));
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await expect(
+      handleHeavyCli(['deactivate', 'browser-suite'], { configPath, rootDir: tempDir })
+    ).resolves.toBeUndefined();
+
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(config.mcpServers['chrome-devtools']).toBeUndefined();
+    expect(config.mcpServers.playwright).toBeUndefined();
+    expect(logs).toContain('Deactivated: browser-suite');
+
+    logSpy.mockRestore();
+  });
+
+  async function writeHeavyDefinition(name: string, serverNames: string[]): Promise<void> {
     await fs.writeFile(
       path.join(availableDir, `${name}.json`),
       JSON.stringify(
         {
-          mcpServers: {
-            [name]: {
-              command: 'npx',
-              args,
-            },
-          },
+          mcpServers: Object.fromEntries(
+            serverNames.map((serverName) => [
+              serverName,
+              {
+                command: 'npx',
+                args: [`-y`, `${serverName}-mcp@latest`],
+              },
+            ])
+          ),
         },
         null,
         2

--- a/tests/heavy-command.test.ts
+++ b/tests/heavy-command.test.ts
@@ -399,6 +399,51 @@ describe('mcporter heavy CLI', () => {
     await expect(fs.access(path.join(tempDir, 'config', 'heavy', 'active', 'chrome-devtools.json'))).rejects.toThrow();
   });
 
+  it('does not deactivate drifted marker-backed configs when the definition still exists', async () => {
+    await handleHeavyCli(['activate', 'playwright'], { configPath, rootDir: tempDir });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            playwright: {
+              command: 'node',
+              args: ['custom-playwright.js'],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await expect(
+      handleHeavyCli(['deactivate', 'playwright'], { configPath, rootDir: tempDir })
+    ).resolves.toBeUndefined();
+
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, { command: string; args: string[] }>;
+    };
+    expect(config.mcpServers.playwright).toEqual({
+      command: 'node',
+      args: ['custom-playwright.js'],
+    });
+    await expect(
+      fs.readFile(path.join(tempDir, 'config', 'heavy', 'active', 'playwright.json'), 'utf8')
+    ).resolves.toContain('playwright');
+    expect(logs).toContain("Heavy MCP 'playwright' is not active.");
+
+    logSpy.mockRestore();
+  });
+
   it('deactivates an active heavy MCP even when its definition file becomes malformed', async () => {
     await handleHeavyCli(['activate', 'chrome-devtools'], { configPath, rootDir: tempDir });
     await fs.writeFile(

--- a/tests/heavy-command.test.ts
+++ b/tests/heavy-command.test.ts
@@ -7,29 +7,17 @@ import { handleHeavyCli } from '../src/cli/heavy-command.js';
 describe('mcporter heavy CLI', () => {
   let tempDir: string;
   let configPath: string;
+  let availableDir: string;
 
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-heavy-'));
     configPath = path.join(tempDir, 'config', 'mcporter.json');
+    availableDir = path.join(tempDir, 'config', 'heavy', 'available');
     await fs.mkdir(path.dirname(configPath), { recursive: true });
     await fs.writeFile(configPath, JSON.stringify({ mcpServers: {} }, null, 2), 'utf8');
-    await fs.mkdir(path.join(tempDir, 'config', 'heavy', 'available'), { recursive: true });
-    await fs.writeFile(
-      path.join(tempDir, 'config', 'heavy', 'available', 'chrome-devtools.json'),
-      JSON.stringify(
-        {
-          mcpServers: {
-            'chrome-devtools': {
-              command: 'npx',
-              args: ['-y', 'chrome-devtools-mcp@latest'],
-            },
-          },
-        },
-        null,
-        2
-      ),
-      'utf8'
-    );
+    await fs.mkdir(availableDir, { recursive: true });
+    await writeHeavyDefinition('chrome-devtools');
+    await writeHeavyDefinition('playwright');
   });
 
   afterEach(async () => {
@@ -91,6 +79,45 @@ describe('mcporter heavy CLI', () => {
     logSpy.mockRestore();
   });
 
+  it('merges marker-based and config-backed heavy MCPs in mixed states', async () => {
+    await handleHeavyCli(['activate', 'chrome-devtools'], { configPath, rootDir: tempDir });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            'chrome-devtools': {
+              command: 'npx',
+              args: ['-y', 'chrome-devtools-mcp@latest'],
+            },
+            playwright: {
+              command: 'npx',
+              args: ['-y', 'playwright-mcp@latest'],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await handleHeavyCli(['list'], { configPath, rootDir: tempDir });
+
+    const output = logs.join('\n');
+    expect(output).toContain('chrome-devtools [active]');
+    expect(output).toContain('playwright [active]');
+
+    logSpy.mockRestore();
+  });
+
   it('deactivates a heavy MCP and removes its config entry', async () => {
     await handleHeavyCli(['activate', 'chrome-devtools'], { configPath, rootDir: tempDir });
 
@@ -112,4 +139,74 @@ describe('mcporter heavy CLI', () => {
 
     logSpy.mockRestore();
   });
+
+  it('deactivates config-backed heavy MCPs even when another heavy MCP has a marker', async () => {
+    await handleHeavyCli(['activate', 'chrome-devtools'], { configPath, rootDir: tempDir });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            'chrome-devtools': {
+              command: 'npx',
+              args: ['-y', 'chrome-devtools-mcp@latest'],
+            },
+            playwright: {
+              command: 'npx',
+              args: ['-y', 'playwright-mcp@latest'],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await handleHeavyCli(['deactivate', 'playwright'], { configPath, rootDir: tempDir });
+
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(config.mcpServers.playwright).toBeUndefined();
+    expect(config.mcpServers['chrome-devtools']).toBeDefined();
+    expect(logs).toContain('Deactivated: playwright');
+
+    logSpy.mockRestore();
+  });
+
+  it('rejects malformed heavy definitions with a validation error', async () => {
+    await fs.writeFile(path.join(availableDir, 'broken.json'), JSON.stringify({ nope: true }, null, 2), 'utf8');
+
+    await expect(handleHeavyCli(['activate', 'broken'], { configPath, rootDir: tempDir })).rejects.toThrow(
+      /Invalid heavy MCP definition 'broken'/
+    );
+  });
+
+  async function writeHeavyDefinition(name: 'chrome-devtools' | 'playwright'): Promise<void> {
+    const args = name === 'chrome-devtools' ? ['-y', 'chrome-devtools-mcp@latest'] : ['-y', 'playwright-mcp@latest'];
+    await fs.writeFile(
+      path.join(availableDir, `${name}.json`),
+      JSON.stringify(
+        {
+          mcpServers: {
+            [name]: {
+              command: 'npx',
+              args,
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+  }
 });

--- a/tests/heavy-command.test.ts
+++ b/tests/heavy-command.test.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleHeavyCli } from '../src/cli/heavy-command.js';
+
+describe('mcporter heavy CLI', () => {
+  let tempDir: string;
+  let configPath: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-heavy-'));
+    configPath = path.join(tempDir, 'config', 'mcporter.json');
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(configPath, JSON.stringify({ mcpServers: {} }, null, 2), 'utf8');
+    await fs.mkdir(path.join(tempDir, 'config', 'heavy', 'available'), { recursive: true });
+    await fs.writeFile(
+      path.join(tempDir, 'config', 'heavy', 'available', 'chrome-devtools.json'),
+      JSON.stringify(
+        {
+          mcpServers: {
+            'chrome-devtools': {
+              command: 'npx',
+              args: ['-y', 'chrome-devtools-mcp@latest'],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('activates a heavy MCP and writes an active marker', async () => {
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await handleHeavyCli(['activate', 'chrome-devtools'], { configPath, rootDir: tempDir });
+
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, { command: string }>;
+    };
+    expect(config.mcpServers['chrome-devtools']?.command).toBe('npx');
+    await expect(
+      fs.lstat(path.join(tempDir, 'config', 'heavy', 'active', 'chrome-devtools.json'))
+    ).resolves.toBeTruthy();
+    expect(logs).toContain('Activated: chrome-devtools');
+
+    logSpy.mockRestore();
+  });
+
+  it('lists config-backed heavy MCPs as active even without marker files', async () => {
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            'chrome-devtools': {
+              command: 'npx',
+              args: ['-y', 'chrome-devtools-mcp@latest'],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await handleHeavyCli(['list'], { configPath, rootDir: tempDir });
+
+    expect(logs.join('\n')).toContain('chrome-devtools [active]');
+
+    logSpy.mockRestore();
+  });
+
+  it('deactivates a heavy MCP and removes its config entry', async () => {
+    await handleHeavyCli(['activate', 'chrome-devtools'], { configPath, rootDir: tempDir });
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await handleHeavyCli(['deactivate', 'chrome-devtools'], { configPath, rootDir: tempDir });
+
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(config.mcpServers['chrome-devtools']).toBeUndefined();
+    await expect(fs.access(path.join(tempDir, 'config', 'heavy', 'active', 'chrome-devtools.json'))).rejects.toThrow();
+    expect(logs).toContain('Deactivated: chrome-devtools');
+
+    logSpy.mockRestore();
+  });
+});

--- a/tests/heavy-command.test.ts
+++ b/tests/heavy-command.test.ts
@@ -622,6 +622,48 @@ describe('mcporter heavy CLI', () => {
     logSpy.mockRestore();
   });
 
+  it('deactivates the current definition when marker metadata still lists removed servers', async () => {
+    await writeHeavyDefinition('browser-suite', ['playwright', 'chrome-devtools']);
+    await handleHeavyCli(['activate', 'browser-suite'], { configPath, rootDir: tempDir });
+    await writeHeavyDefinition('browser-suite', ['playwright']);
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            playwright: {
+              command: 'npx',
+              args: ['-y', 'playwright-mcp@latest'],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      if (typeof value === 'string') {
+        logs.push(value);
+      }
+    });
+
+    await expect(
+      handleHeavyCli(['deactivate', 'browser-suite'], { configPath, rootDir: tempDir })
+    ).resolves.toBeUndefined();
+
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8')) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(config.mcpServers.playwright).toBeUndefined();
+    await expect(fs.access(path.join(tempDir, 'config', 'heavy', 'active', 'browser-suite.json'))).rejects.toThrow();
+    expect(logs).toContain('Deactivated: browser-suite');
+
+    logSpy.mockRestore();
+  });
+
   it('deactivates using marker metadata when the definition file is missing and names differ from the basename', async () => {
     await writeHeavyDefinition('browser-suite', ['playwright', 'chrome-devtools']);
     await handleHeavyCli(['activate', 'browser-suite'], { configPath, rootDir: tempDir });


### PR DESCRIPTION
## Summary

This adds a `heavy` CLI command group for managing large MCP definitions that should only be loaded when needed.

Commands added:
- `mcporter heavy list`
- `mcporter heavy activate <name>`
- `mcporter heavy deactivate <name>`

## What changed

- Wired `heavy` into the top-level CLI router
- Added help output for the new command group
- Added a small `src/heavy/` module for heavy definition/path handling
- Implemented activation/deactivation logic in `src/cli/heavy-command.ts`
- Merged marker-backed and config-backed heavy activation detection so mixed states are handled correctly
- Validate heavy definition JSON before use and surface a clear error for malformed `<name>.json` files
- Documented the new command group in the README
- Marked `dist-bun/*.tar.gz` as binary in `.gitattributes` to avoid false dirty-state reports from line-ending normalization
- Added tests for:
  - activate flow
  - deactivate flow
  - mixed marker/config active state detection
  - mixed-state deactivate behavior
  - malformed heavy definition handling
  - CLI help shortcuts

## Behavior

Heavy MCP definitions live next to the resolved mcporter config:

```text
<config dir>/
├── mcporter.json
└── heavy/
    ├── available/
    └── active/
```

`activate` merges the selected heavy definition into `mcporter.json`.
`deactivate` removes the corresponding server entries.
`list` shows available definitions and marks active ones.

Active heavy MCPs are detected from both `heavy/active/` markers and config-backed definitions already present in `mcporter.json`, so mixed states still list and deactivate correctly.

## Verification

Ran:
- `pnpm exec vitest run tests/heavy-command.test.ts tests/cli-help-shortcuts.test.ts`
- `pnpm check`

## Motivation

Some MCP servers, such as `chrome-devtools`, have large tool schemas that take up significant context. This makes them a good fit for on-demand activation rather than always-on config.

Closes #109
