### PR TITLE
fix(daemon): skip Bun virtual entry path in detached child spawn

### DIFF
--- a/src/daemon/launch.ts
+++ b/src/daemon/launch.ts
@@ -15,7 +15,7 @@ export function launchDaemonDetached(options: DaemonLaunchOptions): void {
   const configArgs = options.configExplicit ? ['--config', options.configPath] : [];
   const args = [
     ...process.execArgv,
-    cliEntry,
+    ...(cliEntry ? [cliEntry] : []),
     ...configArgs,
     ...(options.rootDir ? ['--root', options.rootDir] : []),
     'daemon',
@@ -36,10 +36,16 @@ export function launchDaemonDetached(options: DaemonLaunchOptions): void {
   child.unref();
 }
 
-function resolveCliEntry(): string {
+function resolveCliEntry(): string | undefined {
   const entry = process.argv[1];
   if (!entry) {
     throw new Error('Unable to resolve mcporter entry script.');
+  }
+  // In Bun compiled binaries, argv[1] is a virtual /$bunfs/... path that Bun
+  // auto-injects into every spawned child.  Including it explicitly would
+  // duplicate it and break CLI argument parsing in the child process.
+  if (entry.startsWith('/$bunfs/')) {
+    return undefined;
   }
   return path.resolve(entry);
 }


### PR DESCRIPTION
## Problem

`mcporter daemon start` fails with "Failed to start daemon before timeout expired" when running from a Bun compiled binary (Homebrew install). The `--foreground` mode works fine.

The daemon launcher uses `process.argv[1]` as the CLI entry script when spawning the detached child process. In Node.js this is the script path, but in Bun compiled binaries it's a virtual `/$bunfs/root/...` path that Bun auto-injects into every spawned child. Including it explicitly duplicates it in the child's argv:

```
// Child sees:
process.argv = ["bun", "/$bunfs/root/mcporter", "/$bunfs/root/mcporter", "daemon", "start", "--foreground"]
//                                               ^^^^^^^^^^^^^^^^^^^^^^^^ duplicate
```

`process.argv.slice(2)` then parses the duplicate path as the CLI command instead of `daemon`, so the child silently fails to start.

This also affects `mcporter list` and `mcporter call` for keep-alive servers, since the `DaemonClient` auto-launches the daemon in the background.

## Fix

Detect the `/$bunfs/` prefix in `resolveCliEntry()` and omit it from spawn args — Bun already injects it automatically in the child.

## Testing

- `pnpm test` — all 418 tests pass
- Compiled binary: `bun run scripts/build-bun.ts` then `daemon start/status/stop` cycle works
- Node.js: `node dist/cli.js daemon start` still works (no regression)

Fixes #78