### PR TITLE
fix: parse object-type parameters as JSON in generated CLIs

### DIFF
--- a/src/cli/generate/template.ts
+++ b/src/cli/generate/template.ts
@@ -391,6 +391,8 @@ function optionParser(option: GeneratedOption): string | undefined {
       return '(value) => parseFloat(value)';
     case 'boolean':
       return "(value) => value !== 'false'";
+    case 'object':
+      return '(value) => JSON.parse(value)';
     case 'array':
       // Coerce array elements to their proper types based on schema
       switch (option.arrayItemType) {

--- a/src/cli/generate/tools.ts
+++ b/src/cli/generate/tools.ts
@@ -11,7 +11,7 @@ export interface GeneratedOption {
   cliName: string;
   description?: string;
   required: boolean;
-  type: 'string' | 'number' | 'boolean' | 'array' | 'unknown';
+  type: 'string' | 'number' | 'boolean' | 'array' | 'object' | 'unknown';
   arrayItemType?: 'string' | 'number' | 'boolean' | 'unknown';
   placeholder: string;
   exampleValue?: string;
@@ -228,7 +228,7 @@ export function inferType(descriptor: unknown): GeneratedOption['type'] {
     if (value === 'integer') {
       return 'number';
     }
-    if (value === 'string' || value === 'number' || value === 'boolean' || value === 'array') {
+    if (value === 'string' || value === 'number' || value === 'boolean' || value === 'array' || value === 'object') {
       return value;
     }
     return undefined;


### PR DESCRIPTION
## Summary

Fix generated CLIs not parsing `object`-type parameters as JSON, which causes MCP validation errors when calling tools like Atlassian's `editJiraIssue` with `--fields '{"description":"..."}'`.

Fixes #113

## Motivation

When an MCP tool schema declares a parameter with `"type": "object"`, the generated CLI passes the value as a raw string instead of parsing it as JSON. The MCP server then rejects it with a validation error:

```
MCP error -32602: Invalid arguments: [
  { "code": "invalid_type", "expected": "object", "received": "string", "path": ["fields"] }
]
```

This makes any MCP tool with object-type parameters unusable from generated CLIs without workarounds.

## Changes

### `src/cli/generate/tools.ts`

- Added `'object'` to the `GeneratedOption.type` union (line 14)
- Added `'object'` to the `resolveType` whitelist in `inferType()` (line 231) — previously `object` schemas silently mapped to `'unknown'`

### `src/cli/generate/template.ts`

- Added `case 'object'` to `optionParser()` (line 393) — returns `'(value) => JSON.parse(value)'`, so the generated Commander option parses the CLI string into a JSON object before passing it to the MCP tool
