### PR TITLE
fix: emit valid JSON when --output json falls through to raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### CLI
+- Keep `mcporter call --output json` parseable by emitting valid JSON even when the command falls back to raw output. (PR #128, thanks @armanddp)
 - Ignore static `Authorization` headers once OAuth is active so imported editor configs cannot override fresh OAuth tokens. (PR #123, thanks @ahonn)
 - Preserve full JSON/error payloads when `data` is just one field instead of collapsing the response to `data` alone. (PR #106, thanks @AielloChan)
 - Render `resource` content blocks in call output helpers instead of dropping them, including markdown resources and JSON text payloads. (PR #124, thanks @mvanhorn)

--- a/src/cli/output-utils.ts
+++ b/src/cli/output-utils.ts
@@ -24,7 +24,7 @@ const PREFERRED_OUTPUT_BY_FORMAT: Record<OutputFormat, RenderableKind[]> = {
 export function printCallOutput<T>(wrapped: CallResult<T>, raw: T, format: OutputFormat): void {
   const preferredKinds = PREFERRED_OUTPUT_BY_FORMAT[format];
   const renderable = resolveRenderableOutput(wrapped, raw, preferredKinds);
-  emitRenderableOutput(renderable);
+  emitRenderableOutput(renderable, format);
 }
 
 export function tailLogIfRequested(result: unknown, enabled: boolean): void {
@@ -105,10 +105,10 @@ function resolveRenderableOutput<T>(
   return { kind: 'raw', value: raw };
 }
 
-function emitRenderableOutput(renderable: RenderableOutput): void {
+function emitRenderableOutput(renderable: RenderableOutput, requestedFormat?: OutputFormat): void {
   if (renderable.kind === 'json') {
     if (!attemptPrintJson(renderable.value)) {
-      printRaw(renderable.value);
+      printRaw(renderable.value, requestedFormat);
     }
     return;
   }
@@ -116,7 +116,7 @@ function emitRenderableOutput(renderable: RenderableOutput): void {
     console.log(String(renderable.value));
     return;
   }
-  printRaw(renderable.value);
+  printRaw(renderable.value, requestedFormat);
 }
 
 function attemptPrintJson(value: unknown): boolean {
@@ -135,7 +135,17 @@ function attemptPrintJson(value: unknown): boolean {
   }
 }
 
-function printRaw(raw: unknown): void {
+function printRaw(raw: unknown, requestedFormat?: OutputFormat): void {
+  if (requestedFormat === 'json') {
+    try {
+      const serialized = JSON.stringify(raw, null, 2);
+      console.log(typeof serialized === 'string' ? serialized : 'null');
+    } catch {
+      console.log(JSON.stringify(String(raw)));
+    }
+    return;
+  }
+
   if (typeof raw === 'string') {
     console.log(raw);
     return;

--- a/tests/cli-output-utils.test.ts
+++ b/tests/cli-output-utils.test.ts
@@ -76,7 +76,36 @@ describe('printCallOutput format selection', () => {
       'json',
       'raw-only-string',
       (logged: unknown) => {
-        expect(logged).toBe('raw-only-string');
+        expect(logged).toBe('"raw-only-string"');
+      },
+    ],
+    [
+      'json emits valid JSON for object raw fallback instead of inspect output',
+      'json',
+      { content: [{ type: 'text', text: 'no json here' }] },
+      (logged: unknown) => {
+        expect(JSON.parse(String(logged))).toEqual({ content: [{ type: 'text', text: 'no json here' }] });
+      },
+    ],
+    [
+      'json emits null for undefined raw fallback',
+      'json',
+      undefined,
+      (logged: unknown) => {
+        expect(logged).toBe('null');
+      },
+    ],
+    [
+      'json emits a JSON string when raw fallback is circular',
+      'json',
+      (() => {
+        const circular: { self?: unknown } = {};
+        circular.self = circular;
+        return circular;
+      })(),
+      (logged: unknown) => {
+        expect(typeof logged).toBe('string');
+        expect(() => JSON.parse(String(logged))).not.toThrow();
       },
     ],
     [


### PR DESCRIPTION
## Problem

When `--output json` is requested and `wrapped.json()` returns `null` (e.g. an MCP tool returns content without a `json`-typed entry), `printRaw()` is called as the last-resort fallback. This uses `util.inspect(depth: 8)`, which produces output like:

```
{ content: [ { type: 'text', text: '...' } ] }
```

This looks like JS object notation but **isn't valid JSON** — single quotes, no quoting rules, truncation markers. Downstream JSON parsers (e.g. OpenClaw's mcporter bridge) then fail with:

```
Expected property name or '}' in JSON at position 2
```

## Fix

When the requested format is `json`, `printRaw()` now uses `JSON.stringify()` instead of `util.inspect()`, guaranteeing the output is always valid JSON. Falls back to `JSON.stringify(String(raw))` for non-serializable values (circular references, etc.).

## Changes

- `printRaw()` accepts an optional `requestedFormat` parameter
- When `requestedFormat === 'json'`, uses `JSON.stringify` instead of `inspect`
- Updated existing test expectation to match (string raw now emits `"raw-only-string"` instead of unquoted)
- Added new test: object raw fallback emits valid JSON, not `util.inspect`

## Testing

All 419 tests pass (103 test files).

Companion to openclaw/openclaw#54728 (QMD 1.1+ mcporter compatibility).

**AI-assisted**: Built with Claude (Opus 4.6) via OpenClaw. Fully tested.