### PR TITLE
fix: quote OAuth URL for cmd.exe on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### CLI
 
+- Quote OAuth browser URLs when launching `cmd.exe` on Windows, preserving query parameters such as `redirect_uri`. (PR #136, thanks @cosminilie)
 - Document OAuth-protected server config setup with `mcporter config add --auth oauth` and `mcporter auth`. (PR #34, thanks @prateek)
 - Respect schema-declared string parameters when coercing numeric-looking `mcporter call` key=value arguments, so Slack timestamps like `thread_ts` stay strings. (PR #141, thanks @Hamzaa6296)
 

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -40,9 +40,10 @@ function openExternal(url: string, platform: NodeJS.Platform = process.platform,
       const child = launch('open', [url], { stdio, detached: true });
       child.unref();
     } else if (platform === 'win32') {
-      const child = launch('cmd', ['/c', 'start', '""', url], {
+      const child = launch('cmd', ['/s', '/c', `start "" "${url}"`], {
         stdio,
         detached: true,
+        windowsVerbatimArguments: true,
       });
       child.unref();
     } else {

--- a/tests/oauth-open-external.test.ts
+++ b/tests/oauth-open-external.test.ts
@@ -26,4 +26,20 @@ describe('openExternal', () => {
     expect(() => child.emit('error', Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))).not.toThrow();
     expect(child.unref).toHaveBeenCalled();
   });
+
+  it('quotes OAuth URLs when launching cmd.exe on Windows', () => {
+    const child = new EventEmitter() as EventEmitter & { unref: () => void };
+    child.unref = vi.fn();
+    const launch = vi.fn(() => child as unknown as ReturnType<typeof import('node:child_process').spawn>);
+    const url = 'https://example.com/auth?client_id=abc&redirect_uri=http://127.0.0.1:1234/callback';
+
+    __oauthInternals.openExternal(url, 'win32', launch as unknown as typeof import('node:child_process').spawn);
+
+    expect(launch).toHaveBeenCalledWith('cmd', ['/s', '/c', `start "" "${url}"`], {
+      stdio: 'ignore',
+      detached: true,
+      windowsVerbatimArguments: true,
+    });
+    expect(child.unref).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
cmd.exe interprets & as a command separator, truncating the authorize URL at the first query parameter. 

Use windowsVerbatimArguments and /s to pass the quoted URL through without shell mangling.

fixes issue: https://github.com/steipete/mcporter/issues/135