### PR TITLE
fix(oauth): log manual-completion URL at warn level so headless users can copy it

### DIFF
--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -256,7 +256,10 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
     this.logger.info(`Authorization required for ${this.definition.name}. Opening browser...`);
     this.ensureAuthorizationDeferred();
     __oauthInternals.openExternal(authorizationUrl.toString());
-    this.logger.info(`If the browser did not open, visit ${authorizationUrl.toString()} manually.`);
+    // warn level because this is the manual-completion fallback: on headless servers / CI
+    // where the browser never opens, the user has no other way to recover the URL, so it
+    // must survive the default 'warn' log threshold set by logging.ts.
+    this.logger.warn(`If the browser did not open, visit ${authorizationUrl.toString()} manually.`);
   }
 
   async saveCodeVerifier(codeVerifier: string): Promise<void> {

--- a/tests/oauth-session.test.ts
+++ b/tests/oauth-session.test.ts
@@ -213,4 +213,43 @@ describe('FileOAuthClientProvider session lifecycle', () => {
     await expect(waitPromise).resolves.toBe('stable-deferred-code');
     await session.close();
   });
+
+  it('logs the manual-completion URL at warn level so headless/CI users can copy it (#139)', async () => {
+    const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
+    tempDirs.push(tokenCacheDir);
+    const definition: ServerDefinition = {
+      name: 'test-oauth-headless-url',
+      description: 'Test OAuth server',
+      command: { kind: 'http', url: new URL('https://example.com/mcp') },
+      auth: 'oauth',
+      tokenCacheDir,
+    };
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const session = await createOAuthSession(definition, logger);
+    const provider = session.provider as StatefulProvider;
+    vi.spyOn(__oauthInternals, 'openExternal').mockImplementation(() => {});
+    const authorizationUrl = new URL('https://example.com/auth?code=xyz');
+    // redirectToAuthorization creates a pending wait promise internally; consume it so
+    // session.close() doesn't surface an uncaught rejection for the unresolved deferred.
+    const waitPromise = session.waitForAuthorizationCode().catch(() => undefined);
+    await provider.redirectToAuthorization(authorizationUrl);
+
+    // The manual-completion hint must go through warn, not info, because the logger
+    // threshold defaults to 'warn' (see logging.ts) — routing this line at info silently
+    // strips the URL for every headless / CI user, leaving them with no way to finish
+    // the flow.
+    const warnCall = logger.warn.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].includes(authorizationUrl.toString())
+    );
+    expect(warnCall, 'expected logger.warn to receive the manual OAuth URL').toBeDefined();
+    expect(warnCall?.[0]).toMatch(/If the browser did not open, visit/);
+
+    await session.close();
+    await waitPromise;
+  });
 });


### PR DESCRIPTION
Closes #139.

## Root cause

`logging.ts` defaults the log threshold to `warn`. The fallback URL line
in `redirectToAuthorization` is logged at `info`, so it silently drops
for every headless / CI user running with the default config:

| file:line | message | level |
|---|---|---|
| `src/oauth.ts:256` | `Authorization required for X. Opening browser...` | `info` (suppressed) |
| `src/oauth.ts:259` | `If the browser did not open, visit <url> manually.` | `info` (suppressed) |
| `src/runtime/oauth.ts:107` | `OAuth authorization required... Waiting for browser approval...` | `warn` (shown) |

The user sees only the "waiting" message and is stranded -- exactly the
symptom reported in #139 and corroborated by [@gaieges](https://github.com/gaieges).

## Fix

Elevate only the fallback-URL line to `warn`. That line is actionable
instruction (without it, a headless user cannot complete the flow), not
diagnostic status. The adjacent `"Opening browser..."` line stays at
`info` because it is purely informational.

Regression test in `tests/oauth-session.test.ts` asserts `logger.warn`
receives the URL-containing line.

## Intentionally out of scope (follow-ups)

- **`--headless` / `--print-url` flag.** The reporter asked for an
  explicit opt-in. Warn elevation covers the default-config case, which
  is what strands new headless users today. A fully level-independent
  path (direct `process.stderr.write`) would also help anyone running
  `MCPORTER_LOG_LEVEL=error`; happy to send that as a follow-up if you'd
  like.
- **`--browser none` documentation vs implementation.** `docs/config.md:139`
  promises `--browser none` suppresses the browser launch, but `grep`
  across `src/` finds no implementation -- flagged by @gaieges on the
  issue thread. Worth filing as its own bug (docs-only or implement the
  flag).

## Verification

- `pnpm check` -- format, oxlint, tsgo clean on touched files
- `pnpm test` -- 469 passed, 3 skipped (pre-existing), 0 failed
- Targeted: `pnpm exec vitest run tests/oauth-session.test.ts` -- 7 passed