### PR TITLE
feat: add brief single-server list output

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ npx mcporter call --stdio "bun run ./local-server.ts" --name local-tools
 - **Unknown long flags fail fast.** `mcporter call server.tool --source import` now errors instead of silently turning `--source` into a positional tool argument. Use `source=import`, `--args '{"source":"import"}'`, or insert `--` before literal positional values that begin with `--`.
 - **Cheatsheet.** See [docs/tool-calling.md](docs/tool-calling.md) for a quick comparison of every supported call style (auto-inferred verbs, flags, function-calls, and ad-hoc URLs).
 - **Auto-correct.** If you typo a tool name, MCPorter inspects the server’s tool catalog, retries when the edit distance is tiny, and otherwise prints a `Did you mean …?` hint. The heuristic (and how to tune it) is captured in [docs/call-heuristic.md](docs/call-heuristic.md).
-- **Richer single-server output.** `mcporter list <server>` now prints TypeScript-style signatures, inline comments, return-shape hints, and command examples that mirror the new call syntax. Optional parameters stay hidden by default—add `--all-parameters` or `--schema` whenever you need the full JSON schema.
+- **Richer single-server output.** `mcporter list <server>` now prints TypeScript-style signatures, inline comments, return-shape hints, and command examples that mirror the new call syntax. Optional parameters stay hidden by default—add `--all-parameters` or `--schema` whenever you need the full JSON schema. Prefer a tighter scan? `mcporter list <server> --brief` keeps just the compact signatures and optional summaries.
 
 ## Installation
 
@@ -298,7 +298,7 @@ Friendly ergonomics baked into the proxy and result helpers:
 
 Drop down to `runtime.callTool()` whenever you need explicit control over arguments, metadata, or streaming options.
 
-Call `mcporter list <server>` any time you need the TypeScript-style signature, optional parameter hints, and sample invocations that match the CLI's function-call syntax.
+Call `mcporter list <server>` any time you need the TypeScript-style signature, optional parameter hints, and sample invocations that match the CLI's function-call syntax. Add `--brief` when you only want the compact signatures.
 
 ## Generate a Standalone CLI
 

--- a/docs/call-syntax.md
+++ b/docs/call-syntax.md
@@ -40,6 +40,7 @@ Key details:
 - Run `mcporter list <server> --all-parameters` whenever you want the full signature; the footer repeats `Optional parameters hidden; run with --all-parameters to view all fields.` any time truncation occurs.
 - Return types come from each tool’s output schema, so you’ll see concrete names when providers include `title` metadata (e.g. `DocumentConnection`). When no schema is advertised we omit the `: Type` suffix entirely instead of showing `unknown`.
 - Each server concludes with a short `Examples:` block that mirrors the preferred function-call syntax.
+- Run `mcporter list <server> --brief` when you only want the compact signatures and optional summaries without the doc block or examples.
 
 ## Function-Call Syntax Details
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -15,9 +15,13 @@ A quick reference for the primary `mcporter` subcommands. Each command inherits
   status).
 - With a server name, prints TypeScript-style signatures for each tool, doc
   comments, and optional summaries.
+- Add `--brief` with a server name to suppress doc comments/examples and keep
+  only compact signatures plus optional summaries.
 - Hidden alias: `list-tools` (kept for muscle memory; not advertised in help output).
 - Hidden ad-hoc flag aliases: `--sse` for `--http-url`, `--insecure` for `--allow-http` (for plain HTTP testing).
 - Flags:
+  - `--brief` – compact single-server output; cannot be combined with `--json`,
+    `--schema`, `--verbose`, or `--all-parameters`.
   - `--all-parameters` – include every optional parameter in the signature.
   - `--schema` – pretty-print the JSON schema for each tool.
   - `--timeout <ms>` – per-server timeout when enumerating all servers.

--- a/src/cli/list-command.ts
+++ b/src/cli/list-command.ts
@@ -16,6 +16,7 @@ import {
   createEmptyStatusCounts,
   createUnknownResult,
   type ListJsonServerEntry,
+  printBriefTool,
   printSingleServerHeader,
   printToolDetail,
   summarizeStatusCounts,
@@ -34,12 +35,14 @@ export function extractListFlags(args: string[]): {
   format: ListOutputFormat;
   verbose: boolean;
   includeSources: boolean;
+  brief: boolean;
 } {
   let schema = false;
   let timeoutMs: number | undefined;
   let requiredOnly = true;
   let verbose = false;
   let includeSources = false;
+  let brief = false;
   const format = consumeOutputFormat(args, {
     defaultFormat: 'text',
     allowed: ['text', 'json'],
@@ -74,13 +77,36 @@ export function extractListFlags(args: string[]): {
       args.splice(index, 1);
       continue;
     }
+    if (token === '--brief') {
+      brief = true;
+      args.splice(index, 1);
+      continue;
+    }
     if (token === '--timeout') {
       timeoutMs = consumeTimeoutFlag(args, index, { flagName: '--timeout' });
       continue;
     }
     index += 1;
   }
-  return { schema, timeoutMs, requiredOnly, ephemeral, format, verbose, includeSources };
+  if (brief) {
+    const conflicts: string[] = [];
+    if (format === 'json') {
+      conflicts.push('--json');
+    }
+    if (schema) {
+      conflicts.push('--schema');
+    }
+    if (verbose) {
+      conflicts.push('--verbose');
+    }
+    if (!requiredOnly) {
+      conflicts.push('--all-parameters');
+    }
+    if (conflicts.length > 0) {
+      throw new Error(`--brief cannot be used with ${conflicts.join(', ')}`);
+    }
+  }
+  return { schema, timeoutMs, requiredOnly, ephemeral, format, verbose, includeSources, brief };
 }
 
 type ListOutputFormat = 'text' | 'json';
@@ -315,6 +341,20 @@ export async function handleList(
       console.log('');
       return;
     }
+    if (flags.brief) {
+      let optionalOmitted = false;
+      for (const entry of metadataEntries) {
+        const detail = printBriefTool(definition, entry, flags.requiredOnly);
+        optionalOmitted ||= detail.optionalOmitted;
+      }
+      if (flags.requiredOnly && optionalOmitted) {
+        console.log(`  ${extraDimText('Optional parameters hidden; run with --all-parameters to view all fields.')}`);
+        console.log('');
+      }
+      console.log(summaryLine);
+      console.log('');
+      return;
+    }
     const examples: string[] = [];
     let optionalOmitted = false;
     for (const entry of metadataEntries) {
@@ -372,6 +412,7 @@ export function printListHelp(): void {
     '  --yes                  Skip confirmation prompts when persisting.',
     '',
     'Display flags:',
+    '  --brief                Show compact function signatures only for a single server.',
     '  --schema               Show tool schemas when listing servers.',
     '  --all-parameters       Include optional parameters in tool docs.',
     '  --json                 Emit a JSON summary instead of text.',
@@ -382,6 +423,7 @@ export function printListHelp(): void {
     'Examples:',
     '  mcporter list',
     '  mcporter list linear --schema',
+    '  mcporter list linear --brief',
     '  mcporter list https://mcp.example.com/mcp',
     '  mcporter list --http-url https://localhost:3333/mcp --schema',
   ];

--- a/src/cli/list-output.ts
+++ b/src/cli/list-output.ts
@@ -13,6 +13,10 @@ export interface ToolDetailResult {
   optionalOmitted: boolean;
 }
 
+export interface ToolBriefResult {
+  optionalOmitted: boolean;
+}
+
 export interface ListJsonServerEntry {
   name: string;
   status: StatusCategory;
@@ -102,6 +106,30 @@ export function printToolDetail(
   console.log('');
   return {
     examples: doc.examples,
+    optionalOmitted: doc.hiddenOptions.length > 0,
+  };
+}
+
+export function printBriefTool(
+  definition: ReturnType<Awaited<ReturnType<(typeof import('../runtime.js'))['createRuntime']>>['getDefinition']>,
+  metadata: ToolMetadata,
+  requiredOnly: boolean
+): ToolBriefResult {
+  const doc = buildToolDoc({
+    serverName: definition.name,
+    toolName: metadata.tool.name,
+    description: metadata.tool.description,
+    outputSchema: metadata.tool.outputSchema,
+    options: metadata.options,
+    requiredOnly,
+    colorize: true,
+  });
+  console.log(`  ${doc.signature}`);
+  if (doc.optionalSummary && requiredOnly) {
+    console.log(`  ${doc.optionalSummary}`);
+  }
+  console.log('');
+  return {
     optionalOmitted: doc.hiddenOptions.length > 0,
   };
 }

--- a/tests/cli-list-flags.test.ts
+++ b/tests/cli-list-flags.test.ts
@@ -8,6 +8,7 @@ describe('CLI list flag parsing', () => {
     const args = ['--timeout', '7500', '--schema', 'server'];
     const flags = extractListFlags(args);
     expect(flags).toEqual({
+      brief: false,
       schema: true,
       timeoutMs: 7500,
       requiredOnly: true,
@@ -24,6 +25,7 @@ describe('CLI list flag parsing', () => {
     const args = ['--all-parameters', 'server'];
     const flags = extractListFlags(args);
     expect(flags).toEqual({
+      brief: false,
       schema: false,
       timeoutMs: undefined,
       requiredOnly: false,
@@ -40,7 +42,44 @@ describe('CLI list flag parsing', () => {
     const args = ['--json', 'server'];
     const flags = extractListFlags(args);
     expect(flags.format).toBe('json');
+    expect(flags.brief).toBe(false);
     expect(args).toEqual(['server']);
+  });
+
+  it('parses --brief flag and removes it from args', async () => {
+    const { extractListFlags } = await cliModulePromise;
+    const args = ['--brief', 'server'];
+    const flags = extractListFlags(args);
+    expect(flags.brief).toBe(true);
+    expect(args).toEqual(['server']);
+  });
+
+  it('rejects --brief with --json', async () => {
+    const { extractListFlags } = await cliModulePromise;
+    expect(() => extractListFlags(['--brief', '--json', 'server'])).toThrow(
+      '--brief cannot be used with --json'
+    );
+  });
+
+  it('rejects --brief with --schema', async () => {
+    const { extractListFlags } = await cliModulePromise;
+    expect(() => extractListFlags(['--brief', '--schema', 'server'])).toThrow(
+      '--brief cannot be used with --schema'
+    );
+  });
+
+  it('rejects --brief with --verbose', async () => {
+    const { extractListFlags } = await cliModulePromise;
+    expect(() => extractListFlags(['--brief', '--verbose', 'server'])).toThrow(
+      '--brief cannot be used with --verbose'
+    );
+  });
+
+  it('rejects --brief with --all-parameters', async () => {
+    const { extractListFlags } = await cliModulePromise;
+    expect(() => extractListFlags(['--brief', '--all-parameters', 'server'])).toThrow(
+      '--brief cannot be used with --all-parameters'
+    );
   });
 
   it('treats --sse as a hidden alias for --http-url in ad-hoc mode', async () => {

--- a/tests/cli-list-formatting.test.ts
+++ b/tests/cli-list-formatting.test.ts
@@ -175,6 +175,36 @@ describe('CLI list formatting', () => {
     logSpy.mockRestore();
   });
 
+  it('prints compact signatures for single server listings with --brief', async () => {
+    const { handleList } = await cliModulePromise;
+    const listToolsSpy = vi.fn((_name: string, options?: { includeSchema?: boolean }) =>
+      Promise.resolve([buildLinearDocumentsTool(options?.includeSchema)])
+    );
+    const runtime = {
+      getDefinition: () => linearDefinition,
+      listTools: listToolsSpy,
+    } as unknown as Awaited<ReturnType<(typeof import('../src/runtime.js'))['createRuntime']>>;
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handleList(runtime, ['linear', '--brief']);
+
+    const lines = logSpy.mock.calls.map((call) => stripAnsi(call.join(' ')));
+    expect(lines.some((line) => line.trim().startsWith('/**'))).toBe(false);
+    expect(lines.some((line) => line.includes('Examples:'))).toBe(false);
+    expect(lines.some((line) => line.includes('@param'))).toBe(false);
+    expect(lines.some((line) => line.includes('function list_documents('))).toBe(true);
+    expect(
+      lines.some((line) => line.includes('// optional (4): projectId, initiativeId, creatorId, includeArchived'))
+    ).toBe(true);
+    expect(
+      lines.some((line) => line.includes('Optional parameters hidden; run with --all-parameters to view all fields'))
+    ).toBe(true);
+    expect(listToolsSpy).toHaveBeenCalledWith('linear', expect.objectContaining({ includeSchema: true }));
+
+    logSpy.mockRestore();
+  });
+
   it('truncates long examples for readability', async () => {
     const { handleList } = await cliModulePromise;
     const listToolsSpy = vi.fn((_name: string, options?: { includeSchema?: boolean }) =>

--- a/tests/cli-list-help.test.ts
+++ b/tests/cli-list-help.test.ts
@@ -28,6 +28,7 @@ describe('mcporter list help shortcut', () => {
     await runCli(['list', '--help']);
 
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Usage: mcporter list'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--brief'));
     expect(process.exitCode).toBe(0);
   });
 

--- a/tests/list-output.test.ts
+++ b/tests/list-output.test.ts
@@ -5,6 +5,7 @@ import {
   buildAuthCommandHint,
   buildJsonListEntry,
   createEmptyStatusCounts,
+  printBriefTool,
   printSingleServerHeader,
   printToolDetail,
 } from '../src/cli/list-output.js';
@@ -51,6 +52,35 @@ describe('list output helpers', () => {
     const detail = printToolDetail(definition, metadata, true, true);
     expect(detail.optionalOmitted).toBe(true);
     expect(detail.examples.length).toBeGreaterThan(0);
+    logSpy.mockRestore();
+  });
+
+  it('prints brief tool signatures without examples or doc comments', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const tool: ServerToolInfo = {
+      name: 'add',
+      description: 'Add numbers',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          a: { type: 'number', description: 'First operand' },
+          b: { type: 'number', description: 'Second operand' },
+          format: { type: 'string', enum: ['json', 'markdown'], description: 'Format' },
+          projectId: { type: 'string', description: 'Project context' },
+          initiativeId: { type: 'string', description: 'Initiative context' },
+          creatorId: { type: 'string', description: 'Creator filter' },
+        },
+        required: ['a', 'b'],
+      },
+      outputSchema: { type: 'number' },
+    };
+    const metadata = buildToolMetadata(tool);
+    const detail = printBriefTool(definition, metadata, true);
+    const lines = logSpy.mock.calls.map((call) => call[0]);
+    expect(lines.some((line) => line.includes('function add('))).toBe(true);
+    expect(lines.some((line) => line.includes('@param a'))).toBe(false);
+    expect(lines.some((line) => line.includes('Examples:'))).toBe(false);
+    expect(detail.optionalOmitted).toBe(true);
     logSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
- add `--brief` to `mcporter list <server>` for compact single-server output
- keep the output focused on function signatures and optional-parameter summaries
- document the new flag and add focused tests around parsing, conflicts, help text, and output shape
This PR is a follow-up to #62.

## Why
Some MCP servers expose large tool catalogs, and the default single-server `list` output can be verbose for both humans and LLMs. This PR adds a compact `--brief` mode for `mcporter list <server>` so callers can inspect tool signatures quickly while reducing output noise.

## Behavior
`mcporter list <server> --brief` now:
- prints compact function signatures
- keeps inline optional summaries when parameters are hidden
- keeps the existing footer hint for `--all-parameters`
It intentionally does not print:
- doc comments
- `@param` sections
- examples
- schemas
## Scope
This PR is intentionally narrow:
- only affects single-server `list` output
- does not add tool-name filtering
- does not change config-level `allowedTools` / `blockedTools`
- does not add new dependencies
`--brief` is rejected when combined with:
- `--json`
- `--schema`
- `--verbose`
- `--all-parameters`
## Tests
Added focused coverage for:
- `--brief` flag parsing
- conflict handling
- help text
- brief output formatting
- list output helper behavior
## Verification
```bash
pnpm exec vitest run tests/cli-list-flags.test.ts tests/cli-list-help.test.ts tests/list-output.test.ts tests/cli-list-formatting.test.ts
Passed locally after merging upstream/main.


