### PR TITLE
fix: quote emit-ts member names for non-identifier tool names

### DIFF
--- a/src/cli/emit-ts-templates.ts
+++ b/src/cli/emit-ts-templates.ts
@@ -32,7 +32,7 @@ export function renderTypesModule(input: EmitTypesTemplateInput): string {
   lines.push(`export interface ${input.interfaceName} {`);
   input.docs.forEach((entry, index) => {
     lines.push(...renderDocComment(entry.doc.docLines, '  '));
-    const methodSignature = toInterfaceSignature(entry.doc.tsSignature, { wrapInPromise: true });
+    const methodSignature = toInterfaceSignature(entry.doc.tsSignature, entry.toolName, { wrapInPromise: true });
     lines.push(`  ${methodSignature}`);
     if (entry.doc.optionalSummary) {
       lines.push(`  // ${entry.doc.optionalSummary.replace(/^\/\//, '').trim()}`);
@@ -76,10 +76,11 @@ export function renderClientModule(input: EmitClientTemplateInput): string {
   lines.push(`  const proxy = createServerProxy(runtime, ${JSON.stringify(serverName)});`);
   lines.push(`  const client: ${clientType} = {`);
   input.docs.forEach((entry, _index) => {
-    const methodName = entry.doc.tsSignature.match(/^function\s+([^()]+)/)?.[1] ?? entry.toolName;
-    lines.push(`    async ${methodName}(params: Parameters<${input.interfaceName}['${methodName}']>[0]) {`);
+    const memberName = toMemberName(entry.toolName);
+    const indexKey = toIndexKey(entry.toolName);
+    lines.push(`    async ${memberName}(params: Parameters<${input.interfaceName}[${indexKey}]>[0]) {`);
     lines.push(
-      `      const tool = proxy.${entry.methodName} as (args: Parameters<${input.interfaceName}['${methodName}']>[0]) => Promise<unknown>;`
+      `      const tool = proxy.${entry.methodName} as (args: Parameters<${input.interfaceName}[${indexKey}]>[0]) => Promise<unknown>;`
     );
     lines.push('      const raw = await tool(params);');
     lines.push('      return wrapCallResult(raw).callResult;');
@@ -126,16 +127,30 @@ function renderDocComment(docLines: string[] | undefined, indent: string): strin
   return docLines.map((line) => `${indent}${line}`);
 }
 
-function toInterfaceSignature(signature: string, options?: { wrapInPromise?: boolean }): string {
+function toInterfaceSignature(signature: string, toolName: string, options?: { wrapInPromise?: boolean }): string {
   const trimmed = signature.trim();
   const match = trimmed.match(/^function\s+([^(]+)\((.*)\)\s*(?::\s*([^;]+))?;?$/);
   if (!match) {
     return trimmed.replace(/^function\s+/, '');
   }
-  const [, name, params, returnTypeRaw] = match;
+  const [, , params, returnTypeRaw] = match;
   const returnType = (returnTypeRaw ?? 'void').trim();
   const finalReturn = options?.wrapInPromise ? `Promise<${returnType}>` : returnType;
-  return `${name}(${params}): ${finalReturn};`;
+  return `${toMemberName(toolName)}(${params}): ${finalReturn};`;
+}
+
+// Tool names are free-form strings (MCP spec allows dashes etc.) but TypeScript
+// interface members and object-literal method shorthand require valid
+// identifiers. Quote the name when it is not a bare identifier so emitted
+// modules stay compilable for servers like Notion (`API-post-page`).
+const SAFE_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+function toMemberName(name: string): string {
+  return SAFE_IDENTIFIER.test(name) ? name : JSON.stringify(name);
+}
+
+function toIndexKey(name: string): string {
+  return JSON.stringify(name);
 }
 
 function describeTransport(definition: ServerDefinition): string | undefined {

--- a/tests/emit-ts.test.ts
+++ b/tests/emit-ts.test.ts
@@ -1,12 +1,27 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import ts from 'typescript';
 import { describe, expect, it, vi } from 'vitest';
 import { __test as emitTsTestInternals, handleEmitTs } from '../src/cli/emit-ts-command.js';
 import { renderClientModule, renderTypesModule } from '../src/cli/emit-ts-templates.js';
 import { buildToolMetadata } from '../src/cli/generate/tools.js';
 import type { Runtime } from '../src/runtime.js';
+import type { ServerToolInfo } from '../src/runtime.js';
 import { integrationDefinition, listCommentsTool } from './fixtures/tool-fixtures.js';
+
+const dashedTool: ServerToolInfo = {
+  name: 'API-post-page',
+  description: 'Create a Notion page',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      parent: { type: 'string', description: 'Parent id' },
+    },
+    required: ['parent'],
+  },
+  outputSchema: { title: 'Page' },
+};
 
 function createRuntimeStub(): Runtime {
   return {
@@ -41,6 +56,73 @@ describe('emit-ts templates', () => {
     expect(source).toContain('export interface IntegrationTools');
     expect(source).toContain('Promise<CommentList>');
     expect(source).toContain('Issue identifier');
+  });
+
+  it('quotes interface members when tool names are not valid identifiers', () => {
+    const docs = emitTsTestInternals.buildDocEntries('integration', [buildToolMetadata(dashedTool)], false);
+    const metadata = {
+      server: integrationDefinition,
+      generatorLabel: 'mcporter@test',
+      generatedAt: new Date('2025-11-07T00:00:00Z'),
+    };
+    const source = renderTypesModule({ interfaceName: 'IntegrationTools', docs, metadata });
+    expect(source).toContain(`"API-post-page"(parent: string): Promise<Page>;`);
+    expect(source).not.toMatch(/^\s+API-post-page\(/m);
+  });
+
+  it('quotes client method shorthand when tool names contain dashes', () => {
+    const docs = emitTsTestInternals.buildDocEntries('integration', [buildToolMetadata(dashedTool)], true);
+    const metadata = {
+      server: integrationDefinition,
+      generatorLabel: 'mcporter@test',
+      generatedAt: new Date('2025-11-07T00:00:00Z'),
+    };
+    const source = renderClientModule({
+      interfaceName: 'IntegrationTools',
+      docs,
+      metadata,
+      typesImportPath: './integration-client',
+    });
+    expect(source).toContain(`async "API-post-page"(params: Parameters<IntegrationTools["API-post-page"]>[0])`);
+    expect(source).toContain('proxy.aPIPostPage');
+    expect(source).not.toMatch(/async API-post-page\(/);
+  });
+
+  it('emits syntactically valid TypeScript for tool names with dashes', () => {
+    const docs = emitTsTestInternals.buildDocEntries('integration', [buildToolMetadata(dashedTool)], true);
+    const metadata = {
+      server: integrationDefinition,
+      generatorLabel: 'mcporter@test',
+      generatedAt: new Date('2025-11-07T00:00:00Z'),
+    };
+    const types = renderTypesModule({ interfaceName: 'IntegrationTools', docs, metadata });
+    const client = renderClientModule({
+      interfaceName: 'IntegrationTools',
+      docs,
+      metadata,
+      typesImportPath: './integration-client',
+    });
+    for (const source of [types, client]) {
+      const parsed = ts.createSourceFile('emit.ts', source, ts.ScriptTarget.ES2022, false, ts.ScriptKind.TS);
+      const diagnostics = (parsed as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? [];
+      expect(diagnostics.map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n'))).toEqual([]);
+    }
+  });
+
+  it('leaves identifier-safe tool names unquoted in the client object', () => {
+    const docs = emitTsTestInternals.buildDocEntries('integration', [buildToolMetadata(listCommentsTool)], true);
+    const metadata = {
+      server: integrationDefinition,
+      generatorLabel: 'mcporter@test',
+      generatedAt: new Date('2025-11-07T00:00:00Z'),
+    };
+    const source = renderClientModule({
+      interfaceName: 'IntegrationTools',
+      docs,
+      metadata,
+      typesImportPath: './integration-client',
+    });
+    expect(source).toContain('async list_comments(params: Parameters<IntegrationTools["list_comments"]>[0])');
   });
 
   it('renders client module that wraps proxy calls', () => {


### PR DESCRIPTION
Closes #30.

## Problem

MCP tool names are free-form strings, and servers like Notion (`API-post-page`, `API-patch-block`, ...) expose tools whose names are valid MCP identifiers but invalid JavaScript/TypeScript identifiers. The `emit-ts` command embedded these raw names as bare identifiers in both the generated interface member and the client object-literal method shorthand, which produced TypeScript that fails to parse:

```ts
export interface NotionTools {
  API-post-page(parent: string): Promise<Page>;   // syntax error
}

const client: NotionTools = {
  async API-post-page(params: ...) { ... }        // syntax error
};
```

## Fix

`src/cli/emit-ts-templates.ts` now checks whether the tool name is a bare JS/TS identifier (`/^[A-Za-z_\$][A-Za-z0-9_\$]*\$/`). When it is not, the name is JSON-stringified so the emitted output uses a quoted member name and a bracket-string index access:

```ts
export interface NotionTools {
  "API-post-page"(parent: string): Promise<Page>;
}

const client: NotionTools = {
  async "API-post-page"(params: Parameters<NotionTools["API-post-page"]>[0]) { ... }
};
```

Identifier-safe tool names keep the previous bare-name output, so existing servers see no change. The proxy method name (`entry.methodName`, derived via `toProxyMethodName`) was already sanitized and is untouched.

## Tests

Four new cases in `tests/emit-ts.test.ts`, including one that parses the emitted output with the TypeScript compiler API and asserts zero parse diagnostics. Full suite: 475 passed, 3 skipped. Verified on Linux and Windows 11.

## Scope note

This patch fixes method/type names specifically, which is what the issue reports. Parameter names (schema property names) are emitted verbatim as well, so a tool with a dashed input property would still need quoting. No Notion tool in the referenced list has dashed property names, and handling that cleanly requires a more invasive signature shape, so it is left for a follow-up if someone hits it in the wild.