### PR TITLE
fix: accept key:=value as an alias for key=value so values are not silently dropped

### DIFF
--- a/docs/call-syntax.md
+++ b/docs/call-syntax.md
@@ -67,7 +67,7 @@ Key details:
 
 ## Flag-Based Syntax Details
 
-- `key=value`, `key:value`, and `key: value` all map to the same named-argument handling, so you can type whichever feels most natural for your shell.
+- `key=value`, `key:value`, `key: value`, and `key:=value` all map to the same named-argument handling, so you can type whichever feels most natural for your shell. The `:=` form is accepted as a compatibility alias for `=`; it does not enable any typed-value semantics like httpie's `:=`.
 - By default, arguments keep the same validation pipeline as the function-call syntax—enums, numbers, and booleans are coerced automatically, and missing required fields raise errors.
 - Numeric-looking `key=value` arguments are restored to their original string spelling when the tool schema declares that parameter as a string, which keeps timestamp-like IDs such as Slack `thread_ts=1234567890.123456` intact.
 - `--raw-strings` disables numeric coercion for flag-style and positional values so IDs/codes stay literal strings (`code=12345` stays `"12345"`).

--- a/src/cli/call-argument-values.ts
+++ b/src/cli/call-argument-values.ts
@@ -9,7 +9,8 @@ export interface ParsedKeyValueToken {
 export function parseKeyValueToken(token: string, nextToken: string | undefined): ParsedKeyValueToken | undefined {
   const eqIndex = token.indexOf('=');
   if (eqIndex !== -1) {
-    const key = token.slice(0, eqIndex);
+    const keyEnd = eqIndex > 0 && token[eqIndex - 1] === ':' ? eqIndex - 1 : eqIndex;
+    const key = token.slice(0, keyEnd);
     const rawValue = token.slice(eqIndex + 1);
     if (!key) {
       return undefined;

--- a/tests/call-arguments.test.ts
+++ b/tests/call-arguments.test.ts
@@ -61,6 +61,33 @@ describe('parseCallArguments', () => {
     );
   });
 
+  it('treats key:=value as an alias for key=value so the key does not keep a trailing colon', () => {
+    const parsed = parseCallArguments(['schwab.placeOrder', 'price:=5.20', 'orderType=LIMIT']);
+    expect(parsed.args.price).toBe('5.20');
+    expect(parsed.args.orderType).toBe('LIMIT');
+    expect(parsed.args).not.toHaveProperty('price:');
+  });
+
+  it('coerces numerics that round-trip cleanly when using key:=value syntax', () => {
+    const parsed = parseCallArguments(['schwab.placeOrder', 'quantity:=0', 'limit:=10']);
+    expect(parsed.args.quantity).toBe(0);
+    expect(parsed.args.limit).toBe(10);
+    expect(parsed.args).not.toHaveProperty('quantity:');
+    expect(parsed.args).not.toHaveProperty('limit:');
+  });
+
+  it('registers schema string-coercion candidates for key:=value just like key=value', () => {
+    const parsed = parseCallArguments(['schwab.placeOrder', 'limit:=10']);
+    expect(parsed.args.limit).toBe(10);
+    expect(parsed.schemaStringCoercionCandidates).toEqual({ limit: '10' });
+  });
+
+  it('only strips the colon that immediately precedes =, leaving values that contain := untouched', () => {
+    const parsed = parseCallArguments(['server.tool', 'expr=value:=x']);
+    expect(parsed.args.expr).toBe('value:=x');
+    expect(parsed.args).not.toHaveProperty('expr:');
+  });
+
   it('warns when colon-style arguments omit a value', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const parsed = parseCallArguments(['iterm-mcp.write_to_terminal', 'command:']);


### PR DESCRIPTION
Closes #100.

When a user passes `price:=5.20` (the syntax `httpie` users reach for to send a typed value), mcporter currently calls `indexOf('=')` first in `parseKeyValueToken`, which slices the key as `"price:"` with a trailing colon and stores the value under that malformed key. The MCP server's Zod schema has no `price:` field, so the entry is ignored and the tool behaves as if `price` were never provided.

This change detects a `:` immediately before the first `=` and excludes it from the key, so `key:=value` is parsed the same way as `key=value`. It does not introduce any httpie-style typed-value semantics - the string-coercion candidate registration (used for IDs like Slack `thread_ts=...`) still applies, and `key=value`, `key:value`, `key: value` are unaffected. `:` inside the value is also unaffected because only the character immediately preceding `=` is checked.

### Changes
- `src/cli/call-argument-values.ts` - one-line parser fix: trim a trailing `:` from the key when it sits immediately before `=`.
- `tests/call-arguments.test.ts` - four new cases: the reported Schwab repro, zero/integer coercion, schema string-coercion candidate parity, and a non-regression for `:=` appearing inside a value (`expr=value:=x` stays as `value:=x`).
- `docs/call-syntax.md` - document `:=` as a compatibility alias and call out that it does not enable typed-value semantics.

### Verification
- `pnpm check` - oxfmt, oxlint type-aware, tsgo all clean.
- `pnpm test` - 472 passed, 3 skipped, 0 failed.
- Built and smoke-tested `parseCallArguments` with the exact tokens from the issue repro (`price:=5.20`, `quantity:=0`, `limit:=10`); args object now contains the expected keys.