### PR TITLE
fix: avoid truncating stdout before forced exit

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,8 @@ export { handleInspectCli } from './cli/inspect-cli-command.js';
 export { extractListFlags, handleList } from './cli/list-command.js';
 export { resolveCallTimeout } from './cli/timeouts.js';
 
+const FORCE_EXIT_GRACE_MS = 50;
+
 export async function runCli(argv: string[]): Promise<void> {
   const args = [...argv];
   if (args.length === 0) {
@@ -195,7 +197,10 @@ export async function runCli(argv: string[]): Promise<void> {
       } else {
         const scheduleExit = () => {
           if (!disableForceExit || process.env.MCPORTER_FORCE_EXIT === '1') {
-            process.exit(0);
+            process.exitCode = 0;
+            setTimeout(() => {
+              process.exit(0);
+            }, FORCE_EXIT_GRACE_MS);
           }
         };
         setImmediate(scheduleExit);

--- a/tests/cli-force-exit-flush.integration.test.ts
+++ b/tests/cli-force-exit-flush.integration.test.ts
@@ -1,0 +1,135 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const CLI_ENTRY = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
+const PNPM_COMMAND = process.platform === 'win32' ? 'cmd.exe' : 'pnpm';
+const PNPM_ARGS_PREFIX = process.platform === 'win32' ? ['/d', '/s', '/c', 'pnpm'] : [];
+const testRequire = createRequire(import.meta.url);
+const MCP_SERVER_MODULE = pathToFileURL(testRequire.resolve('@modelcontextprotocol/sdk/server/mcp.js')).href;
+const STDIO_SERVER_MODULE = pathToFileURL(testRequire.resolve('@modelcontextprotocol/sdk/server/stdio.js')).href;
+const ZOD_MODULE = pathToFileURL(path.join(process.cwd(), 'node_modules', 'zod', 'index.js')).href;
+
+function pnpmArgs(args: string[]): string[] {
+  return [...PNPM_ARGS_PREFIX, ...args];
+}
+
+async function ensureDistBuilt(): Promise<void> {
+  try {
+    await fs.access(CLI_ENTRY);
+  } catch {
+    await new Promise<void>((resolve, reject) => {
+      execFile(PNPM_COMMAND, pnpmArgs(['build']), { cwd: process.cwd(), env: process.env }, (error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
+describe('mcporter forced exit flush', () => {
+  let tempDir: string;
+  let configPath: string;
+
+  beforeAll(async () => {
+    await ensureDistBuilt();
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-force-exit-flush-'));
+    const serverScriptPath = path.join(tempDir, 'large-schema-server.mjs');
+    configPath = path.join(tempDir, 'config.json');
+
+    const toolCount = 64;
+    const longDescription = 'Large schema tool description. '.repeat(30);
+    await fs.writeFile(
+      serverScriptPath,
+      `import { McpServer } from ${JSON.stringify(MCP_SERVER_MODULE)};
+import { StdioServerTransport } from ${JSON.stringify(STDIO_SERVER_MODULE)};
+import { z } from ${JSON.stringify(ZOD_MODULE)};
+
+const server = new McpServer({ name: 'large-schema', version: '1.0.0' });
+
+for (let index = 0; index < ${toolCount}; index += 1) {
+  server.registerTool(
+    \`tool_\${index}\`,
+    {
+      title: \`Tool \${index}\`,
+      description: ${JSON.stringify(longDescription)} + index,
+      inputSchema: {
+        alpha: z.string().describe(${JSON.stringify(longDescription)}),
+        beta: z.string().optional().describe(${JSON.stringify(longDescription)}),
+      },
+      outputSchema: {
+        ok: z.boolean(),
+      },
+    },
+    async () => ({
+      content: [{ type: 'text', text: 'ok' }],
+      structuredContent: { ok: true },
+    })
+  );
+}
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+`,
+      'utf8'
+    );
+
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            'large-schema': {
+              command: process.execPath,
+              args: [serverScriptPath],
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+  });
+
+  afterAll(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('does not truncate large JSON output when force exit is enabled', async () => {
+    const { stdout, stderr } = await new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+      execFile(
+        process.execPath,
+        [CLI_ENTRY, '--config', configPath, 'list', 'large-schema', '--schema', '--output', 'json'],
+        {
+          cwd: process.cwd(),
+          env: process.env,
+          maxBuffer: 1024 * 1024,
+        },
+        (error, childStdout, childStderr) => {
+          if (error) {
+            reject(new Error(`${error.message}\nSTDOUT:\n${childStdout}\nSTDERR:\n${childStderr}`));
+            return;
+          }
+          resolve({ stdout: childStdout, stderr: childStderr });
+        }
+      );
+    });
+
+    expect(stderr).toBe('');
+    expect(Buffer.byteLength(stdout)).toBeGreaterThan(8192);
+
+    const payload = JSON.parse(stdout);
+    expect(payload.tools).toHaveLength(64);
+    expect(payload.tools[0]?.name).toBe('tool_0');
+    expect(payload.tools.at(-1)?.name).toBe('tool_63');
+  }, 20000);
+});


### PR DESCRIPTION
## Summary
- avoid truncating large stdout/stderr when `mcporter` is invoked via `child_process`
- replace the immediate forced exit with a short grace period before the fallback `process.exit(0)`
- add a regression test covering large JSON output under the default force-exit path
## Why
The CLI currently forces `process.exit(0)` immediately after cleanup unless `MCPORTER_NO_FORCE_EXIT=1` is set.
On macOS, this can race with stdio pipe flushing when `mcporter` is called from Node via `child_process.exec` / `execFile`, which can truncate large outputs. In the reported real-world case, `mcporter list ... --schema --output json` produced about 200 KB of JSON from a private MCP service and the parent process sometimes only received the first chunk.
This change keeps the anti-hang workaround in place while giving Node a short chance to flush buffered output naturally before the fallback forced exit runs.
## Issues
Closes #145.
## Changes
- add `FORCE_EXIT_GRACE_MS = 50` in `src/cli.ts`
- change the default forced-exit path to:
  - set `process.exitCode = 0`
  - schedule a short fallback `process.exit(0)` instead of exiting immediately on the next tick
- add `tests/cli-force-exit-flush.integration.test.ts`
  - starts a local stdio MCP server
  - generates a large `--schema --output json` payload
  - verifies the output is not truncated and remains valid JSON when called through `execFile`
## Testing
- `./runner pnpm build`
- `./runner pnpm exec vitest run tests/cli-force-exit-flush.integration.test.ts`
- `./runner pnpm exec vitest run tests/stdio-servers.integration.test.ts tests/cli-list-verbose-e2e.test.ts`
## Notes
- I reproduced the truncation on macOS
- I have not reproduced the same issue on Linux so far
- `./runner pnpm check` could not complete in this environment because `oxfmt` is not available (`sh: oxfmt: command not found`)