### PR TITLE
feat: support custom HTTP headers via ENVHEADER environment variable

### DIFF
--- a/src/runtime/transport.ts
+++ b/src/runtime/transport.ts
@@ -117,8 +117,14 @@ function createHttpTransportOptions(
         // Only add headers that don't already exist (case-insensitive check)
         const existingHeadersLower = new Set(Object.keys(finalHeaders).map(k => k.toLowerCase()));
         for (const [key, value] of Object.entries(envHeaders)) {
+          // Skip Authorization header if OAuth is being established to prevent conflicts
+          if (shouldEstablishOAuth && key.toLowerCase() === 'authorization') {
+            continue;
+          }
           if (!existingHeadersLower.has(key.toLowerCase()) && typeof value === 'string') {
             finalHeaders[key] = value;
+            // Update the set to prevent duplicate headers with different casing
+            existingHeadersLower.add(key.toLowerCase());
           }
         }
       }

--- a/src/runtime/transport.ts
+++ b/src/runtime/transport.ts
@@ -105,8 +105,30 @@ function createHttpTransportOptions(
   }
   const resolvedHeaders = materializeHeaders(command.headers, definition.name);
   const effectiveHeaders = shouldEstablishOAuth ? removeAuthorizationHeader(resolvedHeaders) : resolvedHeaders;
+
+  // Auto-inject headers from ENVHEADER environment variable if present (JSON format)
+  // This enables distributed tracing and custom headers when mcporter is called from OpenClaw or other systems
+  // Example: ENVHEADER='{"traceparent":"00-xxx-xxx-01","x-request-id":"abc"}'
+  const finalHeaders: Record<string, string> = effectiveHeaders ? { ...effectiveHeaders } : {};
+  if (process.env.ENVHEADER) {
+    try {
+      const envHeaders = JSON.parse(process.env.ENVHEADER);
+      if (typeof envHeaders === 'object' && envHeaders !== null) {
+        // Only add headers that don't already exist (case-insensitive check)
+        const existingHeadersLower = new Set(Object.keys(finalHeaders).map(k => k.toLowerCase()));
+        for (const [key, value] of Object.entries(envHeaders)) {
+          if (!existingHeadersLower.has(key.toLowerCase()) && typeof value === 'string') {
+            finalHeaders[key] = value;
+          }
+        }
+      }
+    } catch (error) {
+      // Silently ignore invalid JSON to avoid breaking existing behavior
+    }
+  }
+
   return {
-    requestInit: effectiveHeaders ? { headers: effectiveHeaders as HeadersInit } : undefined,
+    requestInit: Object.keys(finalHeaders).length > 0 ? { headers: finalHeaders as HeadersInit } : undefined,
     authProvider: oauthSession?.provider,
   };
 }


### PR DESCRIPTION
Add support for injecting custom HTTP headers through the ENVHEADER environment variable using JSON format. This enables distributed tracing and other observability features when mcporter is called from external systems like OpenClaw.

The ENVHEADER variable accepts a JSON object where each key-value pair represents a header name and value:

  ENVHEADER='{"traceparent":"00-xxx-xxx-01","x-request-id":"abc123"}'

Features:
- Case-insensitive header name collision detection
- Silent failure on invalid JSON to maintain backward compatibility
- Only string values are accepted as header values
- Environment headers don't override existing configured headers

This change enables seamless integration with observability systems without requiring users to modify mcporter configuration files or pass headers explicitly on every call.