### PR TITLE
fix: return non-zero exit code on MCP tool errors

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -190,12 +190,12 @@ export async function runCli(argv: string[]): Promise<void> {
       if (DEBUG_HANG) {
         dumpActiveHandles('after terminateChildProcesses');
         if (!disableForceExit || process.env.MCPORTER_FORCE_EXIT === '1') {
-          process.exit(0);
+          process.exit(process.exitCode ?? 0);
         }
       } else {
         const scheduleExit = () => {
           if (!disableForceExit || process.env.MCPORTER_FORCE_EXIT === '1') {
-            process.exit(0);
+            process.exit(process.exitCode ?? 0);
           }
         };
         setImmediate(scheduleExit);

--- a/src/cli/call-command.ts
+++ b/src/cli/call-command.ts
@@ -167,6 +167,9 @@ async function invokePreparedCall(
 
 function renderCallResult(result: unknown, parsed: CallArgsParseResult): void {
   const { callResult: wrapped } = wrapCallResult(result);
+  if (result && typeof result === 'object' && 'isError' in result && result.isError) {
+    process.exitCode = 1;
+  }
   printCallOutput(wrapped, result, parsed.output);
   saveCallImagesIfRequested(wrapped, parsed.saveImagesDir);
   tailLogIfRequested(result, parsed.tailLog);


### PR DESCRIPTION
Fixes #153

When a tool returns `isError: true`, the CLI should exit with a non-zero exit code so that orchestrators (like LLM agents) can detect the failure. This also patches an issue in `cli.ts` where `process.exit(0)` was overriding `process.exitCode`.