### PR TITLE
fix: resolve env placeholders across config fields

### DIFF
--- a/src/config-normalize.ts
+++ b/src/config-normalize.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { CommandSpec, RawEntry, ServerDefinition, ServerLoggingOptions, ServerSource } from './config-schema.js';
-import { expandHome } from './env.js';
+import { expandHome, resolveEnvPlaceholders } from './env.js';
 import { resolveLifecycle } from './lifecycle.js';
 
 export function normalizeServerEntry(
@@ -11,24 +11,25 @@ export function normalizeServerEntry(
   source: ServerSource,
   sources: readonly ServerSource[]
 ): ServerDefinition {
-  const description = raw.description;
-  const env = raw.env ? { ...raw.env } : undefined;
-  const auth = normalizeAuth(raw.auth);
-  const tokenCacheDir = normalizePath(raw.tokenCacheDir ?? raw.token_cache_dir);
-  const clientName = raw.clientName ?? raw.client_name;
-  const oauthClientId = raw.oauthClientId ?? raw.oauth_client_id ?? undefined;
-  const oauthClientSecret = raw.oauthClientSecret ?? raw.oauth_client_secret ?? undefined;
-  const oauthClientSecretEnv = raw.oauthClientSecretEnv ?? raw.oauth_client_secret_env ?? undefined;
+  const entry = resolveEntryEnv(raw, name);
+  const description = entry.description;
+  const env = entry.env ? { ...entry.env } : undefined;
+  const auth = normalizeAuth(entry.auth);
+  const tokenCacheDir = normalizePath(entry.tokenCacheDir ?? entry.token_cache_dir);
+  const clientName = entry.clientName ?? entry.client_name;
+  const oauthClientId = entry.oauthClientId ?? entry.oauth_client_id ?? undefined;
+  const oauthClientSecret = entry.oauthClientSecret ?? entry.oauth_client_secret ?? undefined;
+  const oauthClientSecretEnv = entry.oauthClientSecretEnv ?? entry.oauth_client_secret_env ?? undefined;
   const oauthTokenEndpointAuthMethod =
-    raw.oauthTokenEndpointAuthMethod ?? raw.oauth_token_endpoint_auth_method ?? undefined;
-  const oauthRedirectUrl = raw.oauthRedirectUrl ?? raw.oauth_redirect_url ?? undefined;
-  const oauthScope = raw.oauthScope ?? raw.oauth_scope ?? undefined;
-  const oauthCommandRaw = raw.oauthCommand ?? raw.oauth_command;
+    entry.oauthTokenEndpointAuthMethod ?? entry.oauth_token_endpoint_auth_method ?? undefined;
+  const oauthRedirectUrl = entry.oauthRedirectUrl ?? entry.oauth_redirect_url ?? undefined;
+  const oauthScope = entry.oauthScope ?? entry.oauth_scope ?? undefined;
+  const oauthCommandRaw = entry.oauthCommand ?? entry.oauth_command;
   const oauthCommand = oauthCommandRaw ? { args: [...oauthCommandRaw.args] } : undefined;
-  const headers = buildHeaders(raw);
+  const headers = buildHeaders(entry);
 
-  const httpUrl = getUrl(raw);
-  const stdio = getCommand(raw, baseDir);
+  const httpUrl = getUrl(entry);
+  const stdio = getCommand(entry, baseDir);
 
   let command: CommandSpec;
 
@@ -43,16 +44,16 @@ export function normalizeServerEntry(
       kind: 'stdio',
       command: stdio.command,
       args: stdio.args,
-      cwd: resolveCwd(raw.cwd, baseDir),
+      cwd: resolveCwd(entry.cwd, baseDir),
     };
   } else {
     throw new Error(`Server '${name}' is missing a baseUrl/url or command definition in mcporter.json`);
   }
 
-  const lifecycle = resolveLifecycle(name, raw.lifecycle, command);
-  const logging = normalizeLogging(raw.logging);
-  const allowedTools = raw.allowedTools ?? raw.allowed_tools;
-  const blockedTools = raw.blockedTools ?? raw.blocked_tools;
+  const lifecycle = resolveLifecycle(name, entry.lifecycle, command);
+  const logging = normalizeLogging(entry.logging);
+  const allowedTools = entry.allowedTools ?? entry.allowed_tools;
+  const blockedTools = entry.blockedTools ?? entry.blocked_tools;
 
   const defaultedOauthCommand =
     !oauthCommand && name.toLowerCase() === 'gmail' && command.kind === 'stdio'
@@ -86,6 +87,36 @@ export function normalizeServerEntry(
 export const __configInternals = {
   ensureHttpAcceptHeader,
 };
+
+function resolveEntryEnv(raw: RawEntry, serverName: string): RawEntry {
+  return resolveConfigValue(raw, serverName, []) as RawEntry;
+}
+
+function resolveConfigValue(value: unknown, serverName: string, pathSegments: string[]): unknown {
+  if (typeof value === 'string') {
+    try {
+      return resolveEnvPlaceholders(value);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const field = pathSegments.length > 0 ? pathSegments.join('.') : '<root>';
+      throw new Error(`Failed to resolve config field '${field}' for server '${serverName}': ${message}`, {
+        cause: error,
+      });
+    }
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item, index) => resolveConfigValue(item, serverName, [...pathSegments, String(index)]));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, resolveConfigValue(item, serverName, [...pathSegments, key])])
+    );
+  }
+
+  return value;
+}
 
 function normalizeAuth(auth: string | undefined): string | undefined {
   if (!auth) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -2,7 +2,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 const ENV_DEFAULT_PATTERN = /^\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-|:|-)?([^}]*)\}$/;
-const ENV_INTERPOLATION_PATTERN = /\\?\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g;
+const ENV_INTERPOLATION_PATTERN = /\\?\$\{([A-Za-z_][A-Za-z0-9_]*)(?:(:-)([^}]*))?\}/g;
 const ENV_DIRECT_PREFIX = '$env:';
 
 // expandHome replaces a leading '~' with the current user's home directory.
@@ -59,14 +59,26 @@ export function resolveEnvPlaceholders(value: string): string {
   }
 
   const missing = new Set<string>();
-  const replaced = value.replace(ENV_INTERPOLATION_PATTERN, (placeholder, envName: string) => {
-    const envValue = process.env[envName];
-    if (envValue === undefined) {
-      missing.add(envName);
-      return placeholder;
+  const replaced = value.replace(
+    ENV_INTERPOLATION_PATTERN,
+    (placeholder, envName: string, fallbackOperator: string | undefined, fallback: string | undefined) => {
+      if (placeholder.startsWith('\\')) {
+        return placeholder.slice(1);
+      }
+      const envValue = process.env[envName];
+      if (envValue !== undefined && envValue !== '') {
+        return envValue;
+      }
+      if (fallbackOperator) {
+        return fallback ?? '';
+      }
+      if (envValue === undefined) {
+        missing.add(envName);
+        return placeholder;
+      }
+      return '';
     }
-    return envValue;
-  });
+  );
 
   if (missing.size > 0) {
     const names = [...missing].toSorted().join(', ');

--- a/tests/config-normalize.test.ts
+++ b/tests/config-normalize.test.ts
@@ -165,4 +165,115 @@ describe('config normalization', () => {
     expect(snake?.oauthClientSecret).toBe('secret-inline');
     expect(snake?.oauthTokenEndpointAuthMethod).toBe('client_secret_basic');
   });
+
+  it('resolves environment placeholders across string-valued config fields', async () => {
+    const previousClientId = process.env.MCPORTER_TEST_CLIENT_ID;
+    const previousSecret = process.env.MCPORTER_TEST_SECRET;
+    const previousCwd = process.env.MCPORTER_TEST_CWD;
+    try {
+      process.env.MCPORTER_TEST_CLIENT_ID = 'client-from-env';
+      delete process.env.MCPORTER_TEST_SECRET;
+      process.env.MCPORTER_TEST_CWD = 'workspace';
+
+      await fs.mkdir(TEMP_DIR, { recursive: true });
+      const configPath = path.join(TEMP_DIR, 'mcporter-env-placeholders.json');
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            mcpServers: {
+              http: {
+                baseUrl: 'https://${MCPORTER_TEST_HOST:-example.com}/mcp',
+                auth: 'oauth',
+                oauthClientId: '${MCPORTER_TEST_CLIENT_ID}',
+                oauthClientSecret: '${MCPORTER_TEST_SECRET:-fallback-secret}',
+                oauthCommand: {
+                  args: ['login', '${MCPORTER_TEST_CLIENT_ID}'],
+                },
+              },
+              stdio: {
+                command: 'node',
+                args: ['server.js', '--client=${MCPORTER_TEST_CLIENT_ID}'],
+                cwd: '${MCPORTER_TEST_CWD}',
+                env: {
+                  CLIENT_ID: '${MCPORTER_TEST_CLIENT_ID}',
+                },
+              },
+            },
+          },
+          null,
+          2
+        ),
+        'utf8'
+      );
+
+      const servers = await loadServerDefinitions({ configPath });
+      const http = servers.find((entry) => entry.name === 'http');
+      const stdio = servers.find((entry) => entry.name === 'stdio');
+
+      expect(http?.command.kind).toBe('http');
+      expect(http?.command.kind === 'http' ? http.command.url.href : undefined).toBe('https://example.com/mcp');
+      expect(http?.oauthClientId).toBe('client-from-env');
+      expect(http?.oauthClientSecret).toBe('fallback-secret');
+      expect(http?.oauthCommand?.args).toEqual(['login', 'client-from-env']);
+
+      expect(stdio?.command.kind).toBe('stdio');
+      expect(stdio?.command.kind === 'stdio' ? stdio.command.args : undefined).toEqual([
+        'server.js',
+        '--client=client-from-env',
+      ]);
+      expect(stdio?.command.kind === 'stdio' ? stdio.command.cwd : undefined).toBe(path.resolve(TEMP_DIR, 'workspace'));
+      expect(stdio?.env).toEqual({ CLIENT_ID: 'client-from-env' });
+    } finally {
+      if (previousClientId === undefined) {
+        delete process.env.MCPORTER_TEST_CLIENT_ID;
+      } else {
+        process.env.MCPORTER_TEST_CLIENT_ID = previousClientId;
+      }
+      if (previousSecret === undefined) {
+        delete process.env.MCPORTER_TEST_SECRET;
+      } else {
+        process.env.MCPORTER_TEST_SECRET = previousSecret;
+      }
+      if (previousCwd === undefined) {
+        delete process.env.MCPORTER_TEST_CWD;
+      } else {
+        process.env.MCPORTER_TEST_CWD = previousCwd;
+      }
+    }
+  });
+
+  it('reports the config field when a required placeholder is missing', async () => {
+    const previousClientId = process.env.MCPORTER_TEST_MISSING_CLIENT_ID;
+    try {
+      delete process.env.MCPORTER_TEST_MISSING_CLIENT_ID;
+
+      await fs.mkdir(TEMP_DIR, { recursive: true });
+      const configPath = path.join(TEMP_DIR, 'mcporter-env-missing.json');
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            mcpServers: {
+              oauth: {
+                baseUrl: 'https://example.com/mcp',
+                oauthClientId: '${MCPORTER_TEST_MISSING_CLIENT_ID}',
+              },
+            },
+          },
+          null,
+          2
+        ),
+        'utf8'
+      );
+
+      await expect(loadServerDefinitions({ configPath })).rejects.toThrow(/oauthClientId/);
+    } finally {
+      if (previousClientId === undefined) {
+        delete process.env.MCPORTER_TEST_MISSING_CLIENT_ID;
+      } else {
+        process.env.MCPORTER_TEST_MISSING_CLIENT_ID = previousClientId;
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Resolves `${VAR}` and `${VAR:-fallback}` placeholders uniformly across string-valued `mcporter.json` server fields instead of limiting placeholder support to headers and env overrides.

## Changes

- Reuses the existing environment placeholder resolver during config normalization.
- Supports fallback placeholders inside interpolated strings, e.g. `https://${HOST:-example.com}/mcp`.
- Applies resolution recursively across nested string values such as OAuth fields, command args, cwd, env records, and OAuth command args.
- Adds coverage for successful cross-field substitution and missing required placeholder errors.

Fixes #157.

## Validation

- Not run locally; the repository checkout/download timed out in this environment, so the patch was prepared against the targeted source files via the GitHub API.