### PR TITLE
fix: keep daemon retry logs off JSON stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### CLI
 
-- Keep keep-alive daemon retry diagnostics on stderr so `mcporter call --output json` stdout stays parseable after a daemon recovery.
+- Keep keep-alive daemon retry diagnostics on stderr so `mcporter call --output json` stdout stays parseable after a daemon recovery. (PR #163 / issue #160, thanks @clawSean)
 - Increase the default OAuth browser wait from 60 seconds to 5 minutes so hosted MCP sign-ins have enough time for account and permission review.
 
 ### Config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### CLI
 
+- Keep keep-alive daemon retry diagnostics on stderr so `mcporter call --output json` stdout stays parseable after a daemon recovery.
 - Increase the default OAuth browser wait from 60 seconds to 5 minutes so hosted MCP sign-ins have enough time for account and permission review.
 
 ### Config

--- a/src/daemon/runtime-wrapper.ts
+++ b/src/daemon/runtime-wrapper.ts
@@ -160,5 +160,5 @@ function shouldRestartDaemonServer(error: unknown): boolean {
 
 function logDaemonRetry(server: string, operation: string, error: unknown): void {
   const reason = error instanceof Error ? error.message : String(error);
-  console.log(`[mcporter] Restarting '${server}' before retrying ${operation}: ${reason}`);
+  console.error(`[mcporter] Restarting '${server}' before retrying ${operation}: ${reason}`);
 }

--- a/tests/cli-output-utils.test.ts
+++ b/tests/cli-output-utils.test.ts
@@ -88,6 +88,17 @@ describe('printCallOutput format selection', () => {
       },
     ],
     [
+      'json emits valid JSON for MCP error envelopes instead of inspect output',
+      'json',
+      { content: [{ type: 'text', text: 'MCP error -32602: Tool search not found' }], isError: true },
+      (logged: unknown) => {
+        expect(JSON.parse(String(logged))).toEqual({
+          content: [{ type: 'text', text: 'MCP error -32602: Tool search not found' }],
+          isError: true,
+        });
+      },
+    ],
+    [
       'json emits null for undefined raw fallback',
       'json',
       undefined,

--- a/tests/keep-alive-runtime.test.ts
+++ b/tests/keep-alive-runtime.test.ts
@@ -139,12 +139,15 @@ describe('createKeepAliveRuntime', () => {
       keepAliveServers: new Set(['alpha']),
     });
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     await expect(keepAliveRuntime.callTool('alpha', 'ping', {})).resolves.toBe('daemon-call');
     expect(daemon.callTool).toHaveBeenCalledTimes(2);
     expect(daemon.closeServer).toHaveBeenCalledWith({ server: 'alpha' });
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Restarting 'alpha'"));
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Restarting 'alpha'"));
     logSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it('deduplicates concurrent restarts for the same server', async () => {


### PR DESCRIPTION
## Problem

`mcporter call --output json` should keep stdout parseable whenever it promises JSON output. Issue #160 covers several ways stdout can stop being parseable for MCP servers that return `structuredContent`/`isError` shapes or trigger keep-alive daemon recovery.

Current `main` already handles the structured-content/raw fallback cases. One remaining path is keep-alive daemon retry diagnostics: if a daemon call hits a fatal transport error, mcporter logs the retry notice with `console.log`, which writes to stdout before retrying the operation. That pollutes `--output json` stdout even when the final tool result is valid JSON.

## Root cause

`logDaemonRetry()` used `console.log(...)`, so operational diagnostics shared stdout with machine-readable command output.

## What changed

- Move keep-alive daemon retry diagnostics from stdout to stderr.
- Add regression coverage that daemon restarts do not write to `console.log` and do write the retry notice to `console.error`.
- Add explicit CLI output regression coverage for MCP `isError` envelopes remaining valid JSON under `--output json`.
- Add an Unreleased changelog entry.

## Scope

This does not change retry behavior, daemon lifecycle, or the rendered diagnostic text. It only changes the stream used for the diagnostic line.

Fixes #160.

## Tests

- `./runner pnpm exec vitest run tests/cli-output-utils.test.ts tests/keep-alive-runtime.test.ts tests/result-utils.test.ts`
- `./runner pnpm format:check`
- `./runner pnpm typecheck`
- `./runner pnpm check`
- `PNPM_CONFIG_LOGLEVEL=error npm_config_loglevel=error ./runner pnpm exec vitest run tests/generate-cli.test.ts`
- `PNPM_CONFIG_LOGLEVEL=error npm_config_loglevel=error ./runner pnpm test`

Note: the first full `./runner pnpm test` run on this host failed because the repo declares Node >=24 while the host has Node 22.22.2, and pnpm engine warnings on stdout broke generated-CLI JSON assertions. Re-running with pnpm loglevel set to `error` suppressed the environment warning and the full suite passed.
