### PR TITLE
Add non-interactive OAuth vault seeding CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Docs
+
+- Document the planned `mcporter vault` CLI surface for unattended OAuth credential seeding in CI, containers, and multitenant deployments. (Issue #156)
+
 ### Config
 
 - Resolve `${VAR}` and `${VAR:-fallback}` placeholders across string-valued server config fields such as `baseUrl`, `command`/`args`, `tokenCacheDir`, and pre-registered OAuth fields while keeping headers/env/bearer-token placeholders lazy until runtime. (PR #161 / issue #157, thanks @zxyasfas)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [Unreleased]
 
-### Docs
+### CLI
 
-- Document the planned `mcporter vault` CLI surface for unattended OAuth credential seeding in CI, containers, and multitenant deployments. (Issue #156)
+- Add `mcporter vault set/clear` for unattended OAuth credential seeding in CI, containers, and multitenant deployments. (Issue #156)
 
 ### Config
 

--- a/README.md
+++ b/README.md
@@ -423,6 +423,8 @@ cat ./notion-oauth.json | npx mcporter vault set notion --stdin
 npx mcporter vault clear notion
 ```
 
+`--config` selects the server definition; it does not isolate the credential vault. Use a tenant-specific `XDG_DATA_HOME` or `tokenCacheDir` when different deployments share the same server name and URL.
+
 Providers that do not support dynamic client registration can use a pre-registered app:
 
 ```jsonc

--- a/README.md
+++ b/README.md
@@ -415,6 +415,14 @@ npx mcporter config add notion https://mcp.notion.com/mcp --auth oauth
 npx mcporter auth notion
 ```
 
+For unattended deployments where another provisioner already holds valid OAuth credentials, seed the same persistence layer without a browser:
+
+```bash
+npx mcporter vault set notion --tokens-file ./notion-oauth.json
+cat ./notion-oauth.json | npx mcporter vault set notion --stdin
+npx mcporter vault clear notion
+```
+
 Providers that do not support dynamic client registration can use a pre-registered app:
 
 ```jsonc

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -56,6 +56,22 @@ A quick reference for the primary `mcporter` subcommands. Each command inherits
   - `--json` – shortcut for `--output json`.
   - `--raw` – shortcut for `--output raw`.
 
+## `mcporter vault` (planned)
+
+- Planned scriptable surface for unattended OAuth credential provisioning in CI,
+  containers, and multitenant deployments.
+- Planned as a top-level command because config and vault data are separate
+  mcporter entities with separate storage classes.
+- Intended commands:
+  - `mcporter vault set <server> --tokens-file <path>`
+  - `mcporter vault set <server> --stdin`
+  - `mcporter vault clear <server>`
+- The implementation should resolve `<server>` through the same config/import
+  stack as other commands and write through the existing OAuth persistence layer,
+  not by editing `credentials.json` directly.
+- See [Unattended OAuth Vault Seeding](vault.md) for the implementation
+  specification and payload contract.
+
 ## `mcporter generate-cli`
 
 - Produces a standalone CLI for a single MCP server (optionally bundling or

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -56,19 +56,19 @@ A quick reference for the primary `mcporter` subcommands. Each command inherits
   - `--json` – shortcut for `--output json`.
   - `--raw` – shortcut for `--output raw`.
 
-## `mcporter vault` (planned)
+## `mcporter vault`
 
-- Planned scriptable surface for unattended OAuth credential provisioning in CI,
+- Scriptable surface for unattended OAuth credential provisioning in CI,
   containers, and multitenant deployments.
-- Planned as a top-level command because config and vault data are separate
-  mcporter entities with separate storage classes.
-- Intended commands:
+- Top-level command because config and vault data are separate mcporter entities
+  with separate storage classes.
+- Commands:
   - `mcporter vault set <server> --tokens-file <path>`
   - `mcporter vault set <server> --stdin`
   - `mcporter vault clear <server>`
-- The implementation should resolve `<server>` through the same config/import
-  stack as other commands and write through the existing OAuth persistence layer,
-  not by editing `credentials.json` directly.
+- Resolves `<server>` through the same config/import stack as other commands and
+  writes through the existing OAuth persistence layer, not by editing
+  `credentials.json` directly.
 - See [Unattended OAuth Vault Seeding](vault.md) for the implementation
   specification and payload contract.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -151,11 +151,11 @@ Use `--scope home|project` with `mcporter config add` to pick the write target e
 - `--browser none` suppresses automatic browser launch (useful for copying the URL into a remote browser).
 - `logout` wipes the shared vault entry, legacy `~/.mcporter/<name>/` caches, and the custom `tokenCacheDir` when present. Pass `--all` to clear everything.
 
-### Planned: `mcporter vault`
+### `mcporter vault`
 
-Issue #156 tracks a scriptable `mcporter vault` command for unattended OAuth credential provisioning. The intended use case is CI, containers, and multitenant deployment systems where an external provisioner already has valid OAuth credentials and needs to seed mcporter without launching a browser.
+`mcporter vault` provides scriptable unattended OAuth credential provisioning. The intended use case is CI, containers, and multitenant deployment systems where an external provisioner already has valid OAuth credentials and needs to seed mcporter without launching a browser.
 
-`vault` is planned as a top-level command, not a `config` subcommand, because config and vault data are different mcporter entities with different storage classes. The command should act as a thin CLI surface over existing config resolution and OAuth persistence:
+`vault` is a top-level command, not a `config` subcommand, because config and vault data are different mcporter entities with different storage classes. The command acts as a thin CLI surface over existing config resolution and OAuth persistence:
 
 ```bash
 mcporter vault set <server> --tokens-file <path>

--- a/docs/config.md
+++ b/docs/config.md
@@ -151,6 +151,29 @@ Use `--scope home|project` with `mcporter config add` to pick the write target e
 - `--browser none` suppresses automatic browser launch (useful for copying the URL into a remote browser).
 - `logout` wipes the shared vault entry, legacy `~/.mcporter/<name>/` caches, and the custom `tokenCacheDir` when present. Pass `--all` to clear everything.
 
+### Planned: `mcporter vault`
+
+Issue #156 tracks a scriptable `mcporter vault` command for unattended OAuth credential provisioning. The intended use case is CI, containers, and multitenant deployment systems where an external provisioner already has valid OAuth credentials and needs to seed mcporter without launching a browser.
+
+`vault` is planned as a top-level command, not a `config` subcommand, because config and vault data are different mcporter entities with different storage classes. The command should act as a thin CLI surface over existing config resolution and OAuth persistence:
+
+```bash
+mcporter vault set <server> --tokens-file <path>
+mcporter vault set <server> --stdin
+mcporter vault clear <server>
+```
+
+The payload is a single vault-entry-compatible credential object, not the full `credentials.json` file with internal map keys:
+
+```json
+{
+  "tokens": { "access_token": "...", "refresh_token": "...", "token_type": "Bearer" },
+  "clientInfo": { "client_id": "..." }
+}
+```
+
+See [Unattended OAuth Vault Seeding](./vault.md) for the implementation requirements, validation contract, and upstream PR checklist.
+
 ### `mcporter config doctor`
 
 - Early validator that checks for simple issues (e.g., OAuth entries missing cache paths). Future iterations will add fixes for Accept headers, duplicate imports, and more.

--- a/docs/config.md
+++ b/docs/config.md
@@ -163,6 +163,8 @@ mcporter vault set <server> --stdin
 mcporter vault clear <server>
 ```
 
+`--config` and `--root` select which server definition is resolved; they do not isolate credential storage. For tenant-specific credentials, isolate `$XDG_DATA_HOME` or configure a distinct `tokenCacheDir`.
+
 The payload is a single vault-entry-compatible credential object, not the full `credentials.json` file with internal map keys:
 
 ```json

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,7 @@ A _porter_ carries luggage between trains. mcporter does the same for MCP server
 - [Install](install.md) — npm, npx, Homebrew, or the standalone Bun-compiled binary.
 - [Quickstart](quickstart.md) — your first list/call/resource in five minutes.
 - [Configuration](config.md) — `mcporter.json`, imports, env interpolation, OAuth.
+- [Unattended vault seeding](vault.md) — planned CLI surface for provisioning OAuth credentials in headless deployments.
 - [CLI reference](cli-reference.md) — every subcommand and flag.
 - [Ad-hoc connections](adhoc.md) — point at any MCP endpoint without editing config.
 - [Agent skills](agent-skills.md) — exposing servers to agents the right way.

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ A _porter_ carries luggage between trains. mcporter does the same for MCP server
 - [Install](install.md) — npm, npx, Homebrew, or the standalone Bun-compiled binary.
 - [Quickstart](quickstart.md) — your first list/call/resource in five minutes.
 - [Configuration](config.md) — `mcporter.json`, imports, env interpolation, OAuth.
-- [Unattended vault seeding](vault.md) — planned CLI surface for provisioning OAuth credentials in headless deployments.
+- [Unattended vault seeding](vault.md) — CLI surface for provisioning OAuth credentials in headless deployments.
 - [CLI reference](cli-reference.md) — every subcommand and flag.
 - [Ad-hoc connections](adhoc.md) — point at any MCP endpoint without editing config.
 - [Agent skills](agent-skills.md) — exposing servers to agents the right way.

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -18,7 +18,7 @@ The command exposes existing mcporter credential persistence through a scriptabl
 - Let CI, containers, deployment controllers, and fleet provisioners seed OAuth credentials without a browser flow.
 - Keep server identity resolution inside mcporter so callers never reproduce the vault key format.
 - Preserve the same credential read/write behavior used by runtime OAuth flows.
-- Support tenant/deployment isolation through the existing `--config <path>` and `--root <dir>` global flags.
+- Let automation select tenant/deployment-specific server definitions through the existing `--config <path>` and `--root <dir>` global flags.
 - Keep stdout/stderr script-safe: never print token material, return non-zero on invalid input, and keep validation messages concise.
 
 ## CLI
@@ -29,7 +29,9 @@ mcporter vault set <server> --stdin
 mcporter vault clear <server>
 ```
 
-`<server>` resolves through the same config/import discovery stack as `mcporter list`, `mcporter call`, `mcporter auth`, and `mcporter config logout`. The command honors explicit `--config <path>` and `--root <dir>` overrides so automated deployments can target an isolated config file and project root.
+`<server>` resolves through the same config/import discovery stack as `mcporter list`, `mcporter call`, `mcporter auth`, and `mcporter config logout`. The command honors explicit `--config <path>` and `--root <dir>` overrides so automated deployments can target a specific config file and project root.
+
+`--config` and `--root` only control server-definition resolution; they do not isolate the credential vault. Deployments that use the same resolved server name and transport descriptor share the same vault key unless they also isolate credential storage with `XDG_DATA_HOME` or a per-server `tokenCacheDir`.
 
 `--tokens-file` and `--stdin` are mutually exclusive. Missing input, duplicate input sources, malformed JSON, missing `tokens`, or unknown servers fail before writing anything.
 

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -7,11 +7,11 @@ read_when:
 
 # Unattended OAuth Vault Seeding
 
-This document specifies the planned `mcporter vault` CLI surface for issue #156. The goal is complete unattended use of `mcporter` in multitenant and multideployment automation where an external provisioner already holds valid OAuth credentials.
+`mcporter vault` seeds or clears OAuth credentials without launching a browser flow. It exists for multitenant and multideployment automation where an external provisioner already holds valid OAuth credentials.
 
-The command should expose existing mcporter credential persistence through a scriptable CLI. It must not create a second vault format, duplicate key computation, or require callers to know internal storage details.
+The command exposes existing mcporter credential persistence through a scriptable CLI. It does not create a second vault format, duplicate key computation, or require callers to know internal storage details.
 
-`vault` should remain a top-level command. Config and vault data are different mcporter entities with different storage classes: config describes server definitions, while the vault stores OAuth credential material derived from those definitions.
+`vault` is a top-level command. Config and vault data are different mcporter entities with different storage classes: config describes server definitions, while the vault stores OAuth credential material derived from those definitions.
 
 ## Objectives
 
@@ -21,7 +21,7 @@ The command should expose existing mcporter credential persistence through a scr
 - Support tenant/deployment isolation through the existing `--config <path>` and `--root <dir>` global flags.
 - Keep stdout/stderr script-safe: never print token material, return non-zero on invalid input, and keep validation messages concise.
 
-## Planned CLI
+## CLI
 
 ```bash
 mcporter vault set <server> --tokens-file <path>
@@ -29,15 +29,15 @@ mcporter vault set <server> --stdin
 mcporter vault clear <server>
 ```
 
-`<server>` must resolve through the same config/import discovery stack as `mcporter list`, `mcporter call`, `mcporter auth`, and `mcporter config logout`. The command should honor explicit `--config <path>` and `--root <dir>` overrides so automated deployments can target an isolated config file and project root.
+`<server>` resolves through the same config/import discovery stack as `mcporter list`, `mcporter call`, `mcporter auth`, and `mcporter config logout`. The command honors explicit `--config <path>` and `--root <dir>` overrides so automated deployments can target an isolated config file and project root.
 
-`--tokens-file` and `--stdin` are mutually exclusive. Missing input, duplicate input sources, malformed JSON, missing `tokens`, or unknown servers should fail before writing anything.
+`--tokens-file` and `--stdin` are mutually exclusive. Missing input, duplicate input sources, malformed JSON, missing `tokens`, or unknown servers fail before writing anything.
 
-`vault set` should not require the server definition to declare `auth: "oauth"`. Older configs and some imported definitions may still rely on cached OAuth credentials without that marker, and unattended provisioning should not force unrelated config rewrites.
+`vault set` does not require the server definition to declare `auth: "oauth"`. Older configs and some imported definitions may still rely on cached OAuth credentials without that marker, and unattended provisioning should not force unrelated config rewrites.
 
 ## Payload Contract
 
-The input payload should mirror mcporter's own single-entry vault storage schema when possible. It should not be the full `credentials.json` file. The full vault file contains internal map keys derived from the resolved server definition; that key format remains private.
+The input payload mirrors mcporter's own single-entry vault storage schema when possible. It is not the full `credentials.json` file. The full vault file contains internal map keys derived from the resolved server definition; that key format remains private.
 
 Required shape:
 
@@ -68,15 +68,15 @@ For portability with exported vault-entry-shaped data, the CLI may accept these 
 }
 ```
 
-When present, `serverName`, `serverUrl`, and `updatedAt` are compatibility metadata only. mcporter should compute authoritative storage metadata from the resolved server definition and current write time.
+When present, `serverName`, `serverUrl`, and `updatedAt` are compatibility metadata only. mcporter computes authoritative storage metadata from the resolved server definition and current write time.
 
-`state` and `codeVerifier` exist in mcporter's internal `VaultEntry` type, but they should not be part of the public seed contract unless maintainers explicitly decide to support full OAuth-flow artifact import. They are transient browser-flow artifacts, not deployment credentials.
+`state` and `codeVerifier` exist in mcporter's internal `VaultEntry` type, but they are not part of the public seed contract. They are transient browser-flow artifacts, not deployment credentials.
 
 A future `mcporter vault export <server>` can reuse this same single-entry payload shape. That command is out of scope for issue #156, but the import contract should avoid blocking a later export/import workflow.
 
 ## Implementation Requirements
 
-The command should be a thin CLI adapter over existing primitives:
+The command is a thin CLI adapter over existing primitives:
 
 - Use `loadServerDefinitions(...)` for config/import discovery.
 - Use `resolveServerDefinition(...)` for server lookup, fuzzy matching, and error behavior.
@@ -94,20 +94,20 @@ The CLI must not:
 
 Writing through `buildOAuthPersistence(definition)` is important because runtime OAuth reads from the same abstraction. If a server defines `tokenCacheDir`, persistence writes must stay compatible with that override instead of seeding only the shared vault and leaving an older cache to shadow the new credentials.
 
-`vault clear` should use the same clearing semantics as `mcporter config logout`: remove the shared vault entry, legacy `~/.mcporter/<server>/` cache, provider-specific legacy files, and explicit `tokenCacheDir` when present.
+`vault clear` uses the same clearing semantics as `mcporter config logout`: it removes the shared vault entry, legacy `~/.mcporter/<server>/` cache, provider-specific legacy files, and explicit `tokenCacheDir` when present.
 
 ## Validation
 
-Initial validation should be strict enough for automation but avoid replacing the MCP SDK's OAuth token typing:
+Validation is strict enough for automation but avoids replacing the MCP SDK's OAuth token typing:
 
 - The payload must be a JSON object.
 - `tokens` must be a JSON object.
-- Token field validation should mirror mcporter's stored `OAuthTokens` shape as closely as practical instead of inventing a stricter CLI-only schema.
+- Token field validation mirrors mcporter's stored `OAuthTokens` shape instead of inventing a stricter CLI-only schema.
 - If known token fields such as `access_token`, `refresh_token`, or `token_type` are present, they must have the same primitive types mcporter would persist in the vault.
 - `clientInfo`, when present, must be a JSON object.
 - Secret values must not be echoed in errors, logs, or success messages.
 
-Unknown extra fields should be ignored unless they conflict with the public contract. Ignoring unknown fields keeps exported credential payloads portable across minor mcporter versions.
+Unknown extra fields are ignored unless they conflict with the public contract. Ignoring unknown fields keeps exported credential payloads portable across minor mcporter versions.
 
 ## Test Plan
 

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -1,0 +1,135 @@
+---
+summary: 'Implementation specification for unattended OAuth credential seeding through a thin mcporter vault CLI surface.'
+read_when:
+  - 'Planning or implementing non-interactive OAuth credential provisioning'
+  - 'Working on the OAuth vault, persistence layer, or headless deployment flows'
+---
+
+# Unattended OAuth Vault Seeding
+
+This document specifies the planned `mcporter vault` CLI surface for issue #156. The goal is complete unattended use of `mcporter` in multitenant and multideployment automation where an external provisioner already holds valid OAuth credentials.
+
+The command should expose existing mcporter credential persistence through a scriptable CLI. It must not create a second vault format, duplicate key computation, or require callers to know internal storage details.
+
+`vault` should remain a top-level command. Config and vault data are different mcporter entities with different storage classes: config describes server definitions, while the vault stores OAuth credential material derived from those definitions.
+
+## Objectives
+
+- Let CI, containers, deployment controllers, and fleet provisioners seed OAuth credentials without a browser flow.
+- Keep server identity resolution inside mcporter so callers never reproduce the vault key format.
+- Preserve the same credential read/write behavior used by runtime OAuth flows.
+- Support tenant/deployment isolation through the existing `--config <path>` and `--root <dir>` global flags.
+- Keep stdout/stderr script-safe: never print token material, return non-zero on invalid input, and keep validation messages concise.
+
+## Planned CLI
+
+```bash
+mcporter vault set <server> --tokens-file <path>
+mcporter vault set <server> --stdin
+mcporter vault clear <server>
+```
+
+`<server>` must resolve through the same config/import discovery stack as `mcporter list`, `mcporter call`, `mcporter auth`, and `mcporter config logout`. The command should honor explicit `--config <path>` and `--root <dir>` overrides so automated deployments can target an isolated config file and project root.
+
+`--tokens-file` and `--stdin` are mutually exclusive. Missing input, duplicate input sources, malformed JSON, missing `tokens`, or unknown servers should fail before writing anything.
+
+`vault set` should not require the server definition to declare `auth: "oauth"`. Older configs and some imported definitions may still rely on cached OAuth credentials without that marker, and unattended provisioning should not force unrelated config rewrites.
+
+## Payload Contract
+
+The input payload should mirror mcporter's own single-entry vault storage schema when possible. It should not be the full `credentials.json` file. The full vault file contains internal map keys derived from the resolved server definition; that key format remains private.
+
+Required shape:
+
+```json
+{
+  "tokens": {
+    "access_token": "...",
+    "refresh_token": "...",
+    "token_type": "Bearer"
+  },
+  "clientInfo": {
+    "client_id": "..."
+  }
+}
+```
+
+`tokens` is required. `clientInfo` is optional because some deployments use pre-registered OAuth clients from config and only need to seed tokens. Use mcporter vault terminology (`tokens`, `clientInfo`) in the public contract so the CLI, docs, and on-disk entry shape stay unambiguous.
+
+For portability with exported vault-entry-shaped data, the CLI may accept these metadata fields:
+
+```json
+{
+  "serverName": "linear",
+  "serverUrl": "https://mcp.linear.app/mcp",
+  "updatedAt": "2026-05-09T00:00:00.000Z",
+  "tokens": { "access_token": "...", "token_type": "Bearer" },
+  "clientInfo": { "client_id": "..." }
+}
+```
+
+When present, `serverName`, `serverUrl`, and `updatedAt` are compatibility metadata only. mcporter should compute authoritative storage metadata from the resolved server definition and current write time.
+
+`state` and `codeVerifier` exist in mcporter's internal `VaultEntry` type, but they should not be part of the public seed contract unless maintainers explicitly decide to support full OAuth-flow artifact import. They are transient browser-flow artifacts, not deployment credentials.
+
+A future `mcporter vault export <server>` can reuse this same single-entry payload shape. That command is out of scope for issue #156, but the import contract should avoid blocking a later export/import workflow.
+
+## Implementation Requirements
+
+The command should be a thin CLI adapter over existing primitives:
+
+- Use `loadServerDefinitions(...)` for config/import discovery.
+- Use `resolveServerDefinition(...)` for server lookup, fuzzy matching, and error behavior.
+- Use `buildOAuthPersistence(definition)` to save `tokens` and optional `clientInfo`.
+- Use `clearOAuthCaches(definition)` for `vault clear`.
+- Reuse existing JSON file/stdin parsing patterns where practical.
+
+The CLI must not:
+
+- call `vaultKeyForDefinition(...)` directly,
+- hand-edit `credentials.json`,
+- duplicate `saveVaultEntry(...)` behavior,
+- introduce a second credential persistence path,
+- add dependencies for payload validation or parsing.
+
+Writing through `buildOAuthPersistence(definition)` is important because runtime OAuth reads from the same abstraction. If a server defines `tokenCacheDir`, persistence writes must stay compatible with that override instead of seeding only the shared vault and leaving an older cache to shadow the new credentials.
+
+`vault clear` should use the same clearing semantics as `mcporter config logout`: remove the shared vault entry, legacy `~/.mcporter/<server>/` cache, provider-specific legacy files, and explicit `tokenCacheDir` when present.
+
+## Validation
+
+Initial validation should be strict enough for automation but avoid replacing the MCP SDK's OAuth token typing:
+
+- The payload must be a JSON object.
+- `tokens` must be a JSON object.
+- Token field validation should mirror mcporter's stored `OAuthTokens` shape as closely as practical instead of inventing a stricter CLI-only schema.
+- If known token fields such as `access_token`, `refresh_token`, or `token_type` are present, they must have the same primitive types mcporter would persist in the vault.
+- `clientInfo`, when present, must be a JSON object.
+- Secret values must not be echoed in errors, logs, or success messages.
+
+Unknown extra fields should be ignored unless they conflict with the public contract. Ignoring unknown fields keeps exported credential payloads portable across minor mcporter versions.
+
+## Test Plan
+
+Add focused tests for:
+
+- `vault set <server> --tokens-file <path>` writes credentials that runtime persistence can read.
+- `vault set <server> --stdin` reads the same payload shape.
+- `vault set` rejects missing input, both input sources at once, invalid JSON, missing `tokens`, and unknown servers.
+- `vault clear <server>` clears via the same semantics as `config logout`.
+- `--config <path>` and `--root <dir>` select the intended server definition.
+- Token material never appears in success output or validation errors.
+
+Before opening the upstream PR, run the repository green gate through the local wrapper:
+
+```bash
+./runner pnpm run docs:list
+./runner pnpm run check
+./runner pnpm test
+```
+
+## Upstream PR Notes
+
+The upstream PR should describe this as unattended OAuth credential provisioning for multitenant and multideployment systems. It should emphasize that the implementation exposes existing mcporter behavior instead of creating a new credential subsystem.
+
+Keep the patch focused: CLI handler, help text, tests, docs, and a changelog entry for the new user-facing command.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -151,6 +151,17 @@ export async function runCli(argv: string[]): Promise<void> {
     return;
   }
 
+  if (command === 'vault') {
+    const { handleVaultCommand, printVaultHelp } = await import('./cli/vault-command.js');
+    if (consumeHelpTokens(args)) {
+      printVaultHelp();
+      process.exitCode = 0;
+      return;
+    }
+    await handleVaultCommand({ loadOptions: { configPath, rootDir: rootOverride } }, args);
+    return;
+  }
+
   if (command === 'emit-ts') {
     if (consumeHelpTokens(args)) {
       const { printEmitTsHelp } = await import('./cli/emit-ts-command.js');
@@ -427,6 +438,7 @@ function isExplicitNonCallCommand(command: string): boolean {
     command === 'resources' ||
     command === 'daemon' ||
     command === 'config' ||
+    command === 'vault' ||
     command === 'emit-ts' ||
     command === 'generate-cli' ||
     command === 'inspect-cli' ||

--- a/src/cli/help-output.ts
+++ b/src/cli/help-output.ts
@@ -67,6 +67,11 @@ function buildCommandSections(colorize: boolean): string[] {
           summary: 'Complete OAuth for a server without listing tools',
           usage: 'mcporter auth <server | url> [--reset]',
         },
+        {
+          name: 'vault',
+          summary: 'Seed or clear OAuth credentials for unattended deployments',
+          usage: 'mcporter vault set <server> --tokens-file <path>',
+        },
       ],
     },
     {

--- a/src/cli/vault-command.ts
+++ b/src/cli/vault-command.ts
@@ -1,0 +1,189 @@
+import fsSync from 'node:fs';
+import fs from 'node:fs/promises';
+import {
+  OAuthClientInformationFullSchema,
+  OAuthClientInformationSchema,
+  OAuthTokensSchema,
+  type OAuthClientInformationMixed,
+  type OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import { loadServerDefinitions, type LoadConfigOptions } from '../config.js';
+import { buildOAuthPersistence, clearOAuthCaches } from '../oauth-persistence.js';
+import { CliUsageError } from './errors.js';
+import { resolveServerDefinition } from './config/shared.js';
+
+type VaultSubcommand = 'set' | 'clear';
+
+export interface VaultCliOptions {
+  readonly loadOptions: LoadConfigOptions;
+}
+
+interface ParsedSetArgs {
+  readonly server: string;
+  readonly input: { kind: 'file'; path: string } | { kind: 'stdin' };
+}
+
+interface VaultSeedPayload {
+  readonly tokens: OAuthTokens;
+  readonly clientInfo?: OAuthClientInformationMixed;
+}
+
+export async function handleVaultCommand(options: VaultCliOptions, args: string[]): Promise<void> {
+  const subcommand = args.shift() as VaultSubcommand | undefined;
+  switch (subcommand) {
+    case 'set':
+      await handleVaultSet(options, args);
+      return;
+    case 'clear':
+      await handleVaultClear(options, args);
+      return;
+    default:
+      throw new CliUsageError("Usage: mcporter vault <set|clear>. Run 'mcporter vault --help'.");
+  }
+}
+
+async function handleVaultSet(options: VaultCliOptions, args: string[]): Promise<void> {
+  const parsed = parseSetArgs(args);
+  const servers = await loadServerDefinitions(options.loadOptions);
+  const target = resolveServerDefinition(parsed.server, servers);
+  const payload = parseSeedPayload(await readPayload(parsed.input));
+  const persistence = await buildOAuthPersistence(target);
+  await persistence.saveTokens(payload.tokens);
+  if (payload.clientInfo) {
+    await persistence.saveClientInfo(payload.clientInfo);
+  }
+  console.log(`Seeded OAuth credentials for '${target.name}'.`);
+}
+
+async function handleVaultClear(options: VaultCliOptions, args: string[]): Promise<void> {
+  const server = args.shift();
+  if (!server || args.length > 0) {
+    throw new CliUsageError('Usage: mcporter vault clear <server>');
+  }
+  const servers = await loadServerDefinitions(options.loadOptions);
+  const target = resolveServerDefinition(server, servers);
+  await clearOAuthCaches(target);
+  console.log(`Cleared cached credentials for '${target.name}'.`);
+}
+
+function parseSetArgs(args: string[]): ParsedSetArgs {
+  const server = args.shift();
+  if (!server) {
+    throw new CliUsageError('Usage: mcporter vault set <server> --tokens-file <path> | --stdin');
+  }
+
+  let input: ParsedSetArgs['input'] | undefined;
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--tokens-file') {
+      if (input) {
+        throw new CliUsageError("Specify exactly one of '--tokens-file <path>' or '--stdin'.");
+      }
+      const filePath = args[index + 1];
+      if (!filePath) {
+        throw new CliUsageError("Flag '--tokens-file' requires a path.");
+      }
+      input = { kind: 'file', path: filePath };
+      index += 1;
+      continue;
+    }
+    if (token === '--stdin') {
+      if (input) {
+        throw new CliUsageError("Specify exactly one of '--tokens-file <path>' or '--stdin'.");
+      }
+      input = { kind: 'stdin' };
+      continue;
+    }
+    if (token?.startsWith('--tokens-file=')) {
+      if (input) {
+        throw new CliUsageError("Specify exactly one of '--tokens-file <path>' or '--stdin'.");
+      }
+      const filePath = token.slice('--tokens-file='.length);
+      if (!filePath) {
+        throw new CliUsageError("Flag '--tokens-file' requires a path.");
+      }
+      input = { kind: 'file', path: filePath };
+      continue;
+    }
+    throw new CliUsageError(`Unknown vault set flag '${token}'.`);
+  }
+
+  if (!input) {
+    throw new CliUsageError('Usage: mcporter vault set <server> --tokens-file <path> | --stdin');
+  }
+  return { server, input };
+}
+
+async function readPayload(input: ParsedSetArgs['input']): Promise<string> {
+  if (input.kind === 'stdin') {
+    return fsSync.readFileSync(0, 'utf8');
+  }
+  return await fs.readFile(input.path, 'utf8');
+}
+
+function parseSeedPayload(raw: string): VaultSeedPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new CliUsageError('Invalid vault payload: expected JSON object.');
+  }
+  if (!isRecord(parsed)) {
+    throw new CliUsageError('Invalid vault payload: expected JSON object.');
+  }
+  if (!('tokens' in parsed)) {
+    throw new CliUsageError("Invalid vault payload: missing required 'tokens' object.");
+  }
+
+  const tokensResult = OAuthTokensSchema.safeParse(parsed.tokens);
+  if (!tokensResult.success) {
+    throw new CliUsageError("Invalid vault payload: 'tokens' must match mcporter OAuth token storage shape.");
+  }
+
+  const clientInfo = parsed.clientInfo;
+  if (clientInfo === undefined) {
+    return { tokens: tokensResult.data };
+  }
+
+  const fullClientResult = OAuthClientInformationFullSchema.safeParse(clientInfo);
+  if (fullClientResult.success) {
+    return { tokens: tokensResult.data, clientInfo: fullClientResult.data };
+  }
+  const clientResult = OAuthClientInformationSchema.safeParse(clientInfo);
+  if (clientResult.success) {
+    return { tokens: tokensResult.data, clientInfo: clientResult.data };
+  }
+  throw new CliUsageError("Invalid vault payload: 'clientInfo' must match mcporter OAuth client storage shape.");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+export function printVaultHelp(): void {
+  const lines = [
+    'Usage: mcporter vault <command>',
+    '',
+    'Purpose:',
+    '  Seed or clear OAuth credentials without launching a browser flow.',
+    '',
+    'Commands:',
+    '  set <server> --tokens-file <path>  Seed credentials from a JSON file.',
+    '  set <server> --stdin               Seed credentials from stdin.',
+    '  clear <server>                     Clear cached credentials for a server.',
+    '',
+    'Payload:',
+    '  { "tokens": { "access_token": "...", "token_type": "Bearer" }, "clientInfo": { "client_id": "..." } }',
+    '',
+    'Examples:',
+    '  mcporter vault set linear --tokens-file ./linear-oauth.json',
+    '  cat ./linear-oauth.json | mcporter vault set linear --stdin',
+    '  mcporter vault clear linear',
+  ];
+  console.error(lines.join('\n'));
+}
+
+export const __vaultCommandInternals = {
+  parseSetArgs,
+  parseSeedPayload,
+};

--- a/tests/cli-config-routing.test.ts
+++ b/tests/cli-config-routing.test.ts
@@ -10,11 +10,29 @@ vi.mock('../src/cli/config-command.js', async () => {
   };
 });
 
+vi.mock('../src/cli/vault-command.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/cli/vault-command.js')>('../src/cli/vault-command.js');
+  return {
+    ...actual,
+    handleVaultCommand: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
 describe('mcporter config entrypoint', () => {
   it('routes to the config handler before runtime inference', async () => {
     const { runCli } = await import('../src/cli.js');
     const { handleConfigCli } = await import('../src/cli/config-command.js');
     await runCli(['config']);
     expect(handleConfigCli).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes to the vault handler before runtime inference', async () => {
+    const { runCli } = await import('../src/cli.js');
+    const { handleVaultCommand } = await import('../src/cli/vault-command.js');
+    await runCli(['--config', '/tmp/mcporter.json', 'vault', 'clear', 'linear']);
+    expect(handleVaultCommand).toHaveBeenCalledWith(
+      { loadOptions: { configPath: '/tmp/mcporter.json', rootDir: undefined } },
+      ['clear', 'linear']
+    );
   });
 });

--- a/tests/cli-vault-command.test.ts
+++ b/tests/cli-vault-command.test.ts
@@ -1,0 +1,156 @@
+import fsSync from 'node:fs';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleVaultCommand, __vaultCommandInternals } from '../src/cli/vault-command.js';
+import { loadServerDefinitions } from '../src/config.js';
+import { buildOAuthPersistence } from '../src/oauth-persistence.js';
+import { loadVaultEntry } from '../src/oauth-vault.js';
+
+describe('mcporter vault CLI', () => {
+  const originalEnv = { ...process.env };
+  let tempDir: string;
+  let configPath: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-vault-'));
+    configPath = path.join(tempDir, 'config', 'mcporter.json');
+    process.env = { ...originalEnv, XDG_DATA_HOME: path.join(tempDir, 'data') };
+    vi.spyOn(os, 'homedir').mockReturnValue(path.join(tempDir, 'home'));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('seeds tokens and clientInfo from a JSON file through OAuth persistence', async () => {
+    await writeConfig({
+      linear: { baseUrl: 'https://mcp.linear.app/mcp', auth: 'oauth' },
+    });
+    const payloadPath = path.join(tempDir, 'linear-oauth.json');
+    await fs.writeFile(
+      payloadPath,
+      JSON.stringify({
+        tokens: { access_token: 'file-token', refresh_token: 'refresh-token', token_type: 'Bearer' },
+        clientInfo: { client_id: 'client-123' },
+      }),
+      'utf8'
+    );
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handleVaultCommand({ loadOptions: { configPath } }, ['set', 'linear', '--tokens-file', payloadPath]);
+
+    const [definition] = await loadServerDefinitions({ configPath });
+    expect(definition).toBeDefined();
+    const persistence = await buildOAuthPersistence(definition!);
+    expect(await persistence.readTokens()).toEqual({
+      access_token: 'file-token',
+      refresh_token: 'refresh-token',
+      token_type: 'Bearer',
+    });
+    expect(await persistence.readClientInfo()).toEqual({ client_id: 'client-123' });
+    expect(logSpy).toHaveBeenCalledWith("Seeded OAuth credentials for 'linear'.");
+    expect(logSpy.mock.calls.flat().join('\n')).not.toContain('file-token');
+  });
+
+  it('seeds tokens from stdin and honors explicit tokenCacheDir stores', async () => {
+    const tokenCacheDir = path.join(tempDir, 'token-cache');
+    await writeConfig({
+      linear: {
+        baseUrl: 'https://mcp.linear.app/mcp',
+        tokenCacheDir,
+      },
+    });
+    vi.spyOn(fsSync, 'readFileSync').mockReturnValueOnce(
+      JSON.stringify({ tokens: { access_token: 'stdin-token', token_type: 'Bearer' } })
+    );
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handleVaultCommand({ loadOptions: { configPath } }, ['set', 'linear', '--stdin']);
+
+    const [definition] = await loadServerDefinitions({ configPath });
+    const persistence = await buildOAuthPersistence(definition!);
+    expect(await persistence.readTokens()).toEqual({ access_token: 'stdin-token', token_type: 'Bearer' });
+    const cacheTokens = JSON.parse(await fs.readFile(path.join(tokenCacheDir, 'tokens.json'), 'utf8')) as {
+      access_token?: string;
+    };
+    expect(cacheTokens.access_token).toBe('stdin-token');
+  });
+
+  it('clears credentials using the same broad cache semantics as config logout', async () => {
+    const tokenCacheDir = path.join(tempDir, 'token-cache');
+    await writeConfig({
+      linear: {
+        baseUrl: 'https://mcp.linear.app/mcp',
+        auth: 'oauth',
+        tokenCacheDir,
+      },
+    });
+    const payloadPath = path.join(tempDir, 'linear-oauth.json');
+    await fs.writeFile(
+      payloadPath,
+      JSON.stringify({ tokens: { access_token: 'clear-token', token_type: 'Bearer' } }),
+      'utf8'
+    );
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handleVaultCommand({ loadOptions: { configPath } }, ['set', 'linear', '--tokens-file', payloadPath]);
+    const [definition] = await loadServerDefinitions({ configPath });
+    expect(await loadVaultEntry(definition!)).toBeDefined();
+    await handleVaultCommand({ loadOptions: { configPath } }, ['clear', 'linear']);
+
+    await expect(fs.access(tokenCacheDir)).rejects.toThrow();
+    expect(await loadVaultEntry(definition!)).toBeUndefined();
+  });
+
+  it('uses rootDir config resolution when no explicit config path is supplied', async () => {
+    await writeConfig({
+      project: { baseUrl: 'https://project.example/mcp' },
+    });
+    const payloadPath = path.join(tempDir, 'project-oauth.json');
+    await fs.writeFile(
+      payloadPath,
+      JSON.stringify({ tokens: { access_token: 'root-token', token_type: 'Bearer' } }),
+      'utf8'
+    );
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handleVaultCommand({ loadOptions: { rootDir: tempDir } }, ['set', 'project', '--tokens-file', payloadPath]);
+
+    const [definition] = await loadServerDefinitions({ rootDir: tempDir });
+    const persistence = await buildOAuthPersistence(definition!);
+    expect(await persistence.readTokens()).toEqual({ access_token: 'root-token', token_type: 'Bearer' });
+  });
+
+  it('rejects malformed payloads without leaking token material', () => {
+    try {
+      __vaultCommandInternals.parseSeedPayload(
+        JSON.stringify({
+          tokens: { access_token: 'secret-token', token_type: 123 },
+        })
+      );
+      throw new Error('Expected payload parsing to fail');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).toContain("Invalid vault payload: 'tokens' must match mcporter OAuth token storage shape.");
+      expect(message).not.toContain('secret-token');
+    }
+  });
+
+  it('rejects ambiguous or missing input sources', () => {
+    expect(() => __vaultCommandInternals.parseSetArgs(['linear'])).toThrow(
+      'Usage: mcporter vault set <server> --tokens-file <path> | --stdin'
+    );
+    expect(() => __vaultCommandInternals.parseSetArgs(['linear', '--stdin', '--tokens-file', 'tokens.json'])).toThrow(
+      "Specify exactly one of '--tokens-file <path>' or '--stdin'."
+    );
+  });
+
+  async function writeConfig(mcpServers: Record<string, unknown>): Promise<void> {
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(configPath, JSON.stringify({ mcpServers }), 'utf8');
+  }
+});


### PR DESCRIPTION
## Summary

Closes #156.

Adds a top-level `mcporter vault` CLI for unattended OAuth credential provisioning:

- `mcporter vault set <server> --tokens-file <path>`
- `mcporter vault set <server> --stdin`
- `mcporter vault clear <server>`

This lets CI, headless containers, fleets, and multitenant deployments seed credentials without reproducing mcporter’s internal vault key format or hand-editing `credentials.json`.

## Implementation

- Resolves `<server>` through the existing config/import discovery path.
- Writes credentials through `buildOAuthPersistence(definition)`, so shared vault and `tokenCacheDir` behavior stay aligned with runtime OAuth.
- Clears credentials through `clearOAuthCaches(definition)`, matching `config logout` semantics.
- Validates payloads with the MCP SDK OAuth token/client schemas.
- Keeps `vault` separate from `config` because config definitions and credential vault data are separate storage classes.
- Adds docs, README examples, changelog entry, and regression tests.

## Payload

```json
{
  "tokens": {
    "access_token": "...",
    "refresh_token": "...",
    "token_type": "Bearer"
  },
  "clientInfo": {
    "client_id": "..."
  }
}
```

## Verification

```bash
./runner pnpm exec vitest run tests/cli-vault-command.test.ts tests/cli-config-routing.test.ts
./runner pnpm run check
./runner pnpm run docs:list
./runner pnpm test
./runner pnpm exec tsx src/cli.ts vault --help
```