### PR TITLE
fix(windows): set windowsHide on execFile spawns to suppress visible console flashes

### DIFF
--- a/src/cli/generate/artifacts.ts
+++ b/src/cli/generate/artifacts.ts
@@ -112,7 +112,7 @@ async function bundleWithBun({
       args.push('--minify');
     }
     await new Promise<void>((resolve, reject) => {
-      execFile(bunBin, args, { cwd: stagingDir, env: process.env }, (error) => {
+      execFile(bunBin, args, { cwd: stagingDir, env: process.env, windowsHide: true }, (error) => {
         if (error) {
           reject(error);
           return;
@@ -133,7 +133,7 @@ export async function compileBundleWithBun(bundlePath: string, outputPath: strin
     execFile(
       bunBin,
       ['build', bundlePath, '--compile', '--outfile', outputPath],
-      { cwd: process.cwd(), env: process.env },
+      { cwd: process.cwd(), env: process.env, windowsHide: true },
       (error) => {
         if (error) {
           reject(error);
@@ -292,7 +292,7 @@ async function installPublishedBundlerDeps(stagingDir: string): Promise<void> {
     execFile(
       'npm',
       ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--min-release-age=0'],
-      { cwd: stagingDir, env: process.env },
+      { cwd: stagingDir, env: process.env, windowsHide: true },
       (error) => {
         if (error) {
           reject(

--- a/src/cli/generate/runtime.ts
+++ b/src/cli/generate/runtime.ts
@@ -17,7 +17,7 @@ export async function resolveRuntimeKind(
 export async function verifyBunAvailable(): Promise<string> {
   const bunBin = process.env.BUN_BIN ?? 'bun';
   await new Promise<void>((resolve, reject) => {
-    execFile(bunBin, ['--version'], { cwd: process.cwd(), env: process.env }, (error) => {
+    execFile(bunBin, ['--version'], { cwd: process.cwd(), env: process.env, windowsHide: true }, (error) => {
       if (error) {
         reject(new Error('Unable to locate Bun runtime. Install Bun or set BUN_BIN to the bun executable.'));
         return;

--- a/src/runtime-process-utils.ts
+++ b/src/runtime-process-utils.ts
@@ -269,7 +269,7 @@ async function listDescendantPidsWindows(rootPid: number): Promise<number[]> {
 
 function execFileAsync(command: string, args: readonly string[]): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    execFile(command, args, { encoding: 'utf8' }, (error, stdout, stderr) => {
+    execFile(command, args, { encoding: 'utf8', windowsHide: true }, (error, stdout, stderr) => {
       if (error) {
         reject(error);
         return;


### PR DESCRIPTION
## Summary

Without windowsHide: true, Node's child_process default STARTUPINFO leaves wShowWindow = SW_SHOW. On Windows 11 22H2+ with the default DelegationTerminal = {00000000-0000-0000-0000-000000000000} ("Let Windows decide"), the OS routes the new console to Windows Terminal — which opens a **visible new tab** for every such spawn, briefly stealing focus.

This PR adds windowsHide: true to the 5 `execFile` call sites in `src/`. The fix is one option per call site; no behavior change on macOS/Linux (the option is a no-op there).

## User-visible impact (the daily-flash source)

The most common offender is `listDescendantPidsWindows` in `src/runtime-process-utils.ts`, which runs:

```typescript
execFile('powershell.exe', ['-NoProfile', '-Command',
  'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId | ConvertTo-Json -Compress']);
```

every time mcporter tears down a stdio MCP server's process tree. The existing CHANGELOG entry under 0.6.2 documents this:

> STDIO transports on Windows tear down entire process trees via `powershell.exe Get-CimInstance Win32_Process` to avoid orphaned child servers.

That's correct functionally, but each invocation creates a new console process. Without `windowsHide`, Windows Terminal hosts it visibly. On a session with frequent MCP server calls this can flash multiple tabs per minute.

## Sites changed

| File | Sites | What spawns |
|---|---|---|
| `src/runtime-process-utils.ts` | 1 (line 272) | `execFileAsync` helper — used by `listDescendantPidsWindows` for `powershell.exe` and by `listDescendantPidsPosix` for `ps` |
| `src/cli/generate/artifacts.ts` | 3 (lines 115, 133, 292) | `bun build`, `bun build --compile`, `npm install` (during standalone binary preparation) |
| `src/cli/generate/runtime.ts` | 1 (line 20) | `bun --version` probe in `verifyBunAvailable` |

The runtime-process-utils fix is the daily-visible bug. The 4 cli/generate sites are bonus hygiene for the same defect — they only fire during `mcporter generate-cli` flows but have no reason to ever paint a console window.

## Verification

Ran a process+window watcher on Windows 11 (build 26100, Windows Terminal as default terminal app):

**Pre-patch (mcporter 0.10.2 unmodified):** 10-min observation caught 3 visible `CASCADIA_HOSTING_WINDOW_CLASS` tabs (titles "Windows PowerShell" / "Terminal") at minute marks; each correlated within the same millisecond bucket with an `mcporter daemon → node.exe → powershell.exe -Command "Get-CimInstance Win32_Process..."` spawn chain.

**Post-patch (this branch built locally over 0.10.2):** Exercised mcporter list → daemon status → daemon stop, plus an active `calendar.ListCalendarView` invocation. Watcher reported 0 visible windows of any class during a 60s window covering the operations.

## Caveats

- This PR does not add a regression test. The behavior is a Node options flag plumbed through to Win32 `CreateProcess` — testing it would require a Windows-only test that snapshots desktop windows around an `execFile` call, which feels out of proportion for a one-line option. Happy to add if you'd like; suggest pointers to the right test style for the repo.
- I marked this **draft** because of the missing test and so you can adjust scope (e.g., if you'd prefer a separate PR for the `cli/generate/` sites).
- No CHANGELOG entry was added — happy to add one under `[Unreleased]` (probably a `### Windows` or `### Runtime` section) if that matches your release flow.

## Why `windowsHide: true` (not other approaches)

- Per [Node.js docs](https://nodejs.org/api/child_process.html#child_processexecfilefile-args-options-callback), `windowsHide: true` sets the `STARTF_USESHOWWINDOW + SW_HIDE` flags at process creation — exactly when `conhost.exe` first attaches.
- Other workarounds (e.g., wrapping in `wscript.exe` + `WScript.Shell.Run(cmd, 0, false)`) suppress the same way but lose the stdin/stdout pipes that `execFile` needs for `stdout` capture. `windowsHide` preserves all pipes.
- Reference fix on a similar bug: NodeJS `child_process` exposes this option specifically for this case. No-op on POSIX.

## Related

This is unreported upstream as of this PR (searched all 82 issues + 86 PRs across both `openclaw/mcporter` and `steipete/mcporter` redirects).
