### PR TITLE
feat: add headless OAuth browser suppression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.pnpm-store
 .DS_Store
 dist
 dist-bun

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### OAuth
 
+- Add headless OAuth login support via `--no-browser`, `--browser none`, and `MCPORTER_OAUTH_NO_BROWSER`, emitting parseable authorization URLs for remote auth flows. (PR #171 / issue #169, thanks @feniix)
 - Proactively complete OAuth for configured HTTP servers that allow unauthenticated `initialize`/`listTools` but require credentials for tool calls, and close the local callback server promptly after browser authorization. (PR #159, thanks @Spacefish)
 - Refresh expired cached OAuth access tokens during non-interactive `mcporter list` without opening a browser or clearing cached credentials when refresh fails. (Issue #166, thanks @chrisabad)
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ Helpful flags:
 - `--` (on `mcporter call`) -- stop flag parsing so the remaining tokens stay literal positional values, even when they start with `--`.
 - `--json` (on `mcporter list`) -- emit JSON summaries/counts instead of text. Multi-server runs report per-server statuses, counts, and connection issues; single-server runs include the full tool metadata.
 - `--output json/raw` (on `mcporter call`) -- when a connection fails, MCPorter prints the usual colorized hint and also emits a structured `{ server, tool, issue }` envelope so scripts can handle auth/offline/http errors programmatically.
-- `--json` (on `mcporter auth`) -- emit the same structured connection envelope whenever OAuth/transport setup fails, instead of throwing an error.
+- `--json` (on `mcporter auth`) -- emit the same structured connection envelope whenever OAuth/transport setup fails, instead of throwing an error. With `--no-browser`, it emits auth-start JSON containing `authorizationUrl` and `redirectUrl`.
+- `--no-browser` / `--browser none` (on `mcporter auth` or `mcporter config login`) -- suppress browser launch and print the OAuth authorization URL for headless workflows; `MCPORTER_OAUTH_NO_BROWSER=1` / `true` / `yes` enables the same behavior.
 - `--json` (on `mcporter emit-ts`) -- print a JSON summary describing the emitted files (mode + output paths) instead of text logs—handy when generating artifacts inside scripts.
 - `--all-parameters` -- show every schema field when listing a server (default output shows at least five parameters plus a summary of the rest).
 - `--http-url <https://…>` / `--stdio "command …"` -- describe an ad-hoc MCP server inline. STDIO transports now inherit your current shell environment automatically; add `--env KEY=value` only when you need to inject/override variables alongside `--cwd`, `--name`, or `--persist <config.json>`. These flags now work with `mcporter auth` too, so `mcporter auth https://mcp.example.com/mcp` just works.
@@ -414,6 +415,8 @@ If an HTTP MCP requires browser login (OAuth), persist it with `--auth oauth` (o
 npx mcporter config add notion https://mcp.notion.com/mcp --auth oauth
 npx mcporter auth notion
 ```
+
+On headless hosts, use `npx mcporter auth notion --no-browser` to print the authorization URL instead of launching the platform browser. Treat the printed URL as sensitive operational output. If you open it on another machine, make sure the printed `redirectUrl` callback port is reachable through a loopback-only tunnel or a configured `oauthRedirectUrl`.
 
 Providers that do not support dynamic client registration can use a pre-registered app:
 

--- a/docs/adhoc.md
+++ b/docs/adhoc.md
@@ -53,7 +53,7 @@ This name becomes the cache key for OAuth tokens and log preferences, so repeate
 
 Many hosted MCP servers (Supabase, Vercel, etc.) advertise OAuth capabilities but expect clients to discover this dynamically. When an ad-hoc HTTP server responds with `401/403` during the initial handshake, mcporter now:
 
-1. **Promotes the definition to OAuth** and spins up the default browser flow—no need to edit config or supply `auth: "oauth"` manually.
+1. **Promotes the definition to OAuth** and spins up the default browser flow—no need to edit config or supply `auth: "oauth"` manually. On headless hosts, pass `--no-browser` (or `--browser none`) to print the authorization URL instead of launching the platform browser.
 2. **Persists the change** whenever you pass `--persist`, so future runs remember that the endpoint requires OAuth without repeating the detection step.
 
 The CLI still avoids surprise prompts during `mcporter list`; the upgrade happens the first time you run `mcporter auth <url>` or any other command that allows OAuth (i.e., not in `--autoAuthorize=false` mode).
@@ -62,6 +62,8 @@ The CLI still avoids surprise prompts during `mcporter list`; the upgrade happen
 
 - OAuth flows are allowed; successful tokens store under the inferred name just like regular definitions.
 - `mcporter auth` accepts the same `--http-url/--stdio` flags (and even bare URLs), so you can immediately re-run `mcporter auth https://…` after a 401 without touching a config file.
+- Use `mcporter auth <url> --no-browser` for human-in-the-loop headless OAuth. Text mode writes only the authorization URL to stdout; `--json --no-browser` writes `authorizationUrl` plus `redirectUrl` as JSON. Keep that URL out of durable CI logs and support bundles.
+- When opening the URL on a different machine, remember that loopback redirect URLs point at the browser machine unless an SSH tunnel forwards the callback port back to the mcporter process. Use `oauthRedirectUrl` when you need a predictable callback port.
 - Nothing is written to disk unless you pass `--persist /path/to/config.json`. When set, we merge the generated definition into that file (creating it if necessary) so future runs can rely on the standard config pipeline. Ad-hoc HTTP headers are persisted with the entry, so placeholders such as `--header 'Authorization=$env:MY_TOKEN'` keep working through the normal config header resolver.
 
 ## Safety Nets

--- a/docs/config.md
+++ b/docs/config.md
@@ -148,7 +148,8 @@ Use `--scope home|project` with `mcporter config add` to pick the write target e
 ### `mcporter config login <name|url>` / `logout`
 
 - Mirrors `mcporter auth`. `login` completes OAuth (or token provisioning) for either a named server or an ad-hoc URL. When a hosted MCP returns 401/403, mcporter automatically promotes that target to OAuth and re-runs the flow, matching the behavior documented in `docs/adhoc.md`.
-- `--browser none` suppresses automatic browser launch (useful for copying the URL into a remote browser).
+- `--no-browser` suppresses automatic browser launch and prints the authorization URL to stdout so it can be copied from a headless host. `--browser none` is accepted as a compatibility alias, and `MCPORTER_OAUTH_NO_BROWSER=1` / `true` / `yes` enables the same behavior by environment.
+- In `--json --no-browser` mode, stdout contains a JSON object with `authorizationUrl` and `redirectUrl`; diagnostics stay off stdout so scripts can parse the result. Treat emitted authorization URLs as sensitive operational output.
 - `logout` wipes the shared vault entry, legacy `~/.mcporter/<name>/` caches, and the custom `tokenCacheDir` when present. Pass `--all` to clear everything.
 
 ### `mcporter config doctor`

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -74,6 +74,13 @@ Expectations:
 - If a token cache exists, log should mention the cleared directory.
 - Failed auths emit the unified message (`Failed to authorize 'SERVER': ...`).
 
+For headless OAuth URL capture, run the same auth command with `--no-browser`:
+
+- Text mode stdout should contain exactly one authorization URL line and no logger prefix.
+- `--json --no-browser` stdout should parse as JSON with `authorizationUrl` and `redirectUrl`.
+- If completing the flow from another machine over SSH, forward the printed callback port with a loopback-only tunnel; avoid exposing the callback listener publicly.
+- Treat copied authorization URLs as sensitive and avoid storing them in long-lived logs.
+
 ## Tips
 
 - To exercise error paths, point at a placeholder endpoint and use `--timeout 1000` (e.g., `https://example.com/mcp.listStuff`).

--- a/src/cli/auth-command.ts
+++ b/src/cli/auth-command.ts
@@ -10,7 +10,7 @@ import { extractEphemeralServerFlags } from './ephemeral-flags.js';
 import { persistPreparedEphemeralServer, prepareEphemeralServerTarget } from './ephemeral-target.js';
 import { looksLikeHttpUrl } from './http-utils.js';
 import { buildConnectionIssueEnvelope } from './json-output.js';
-import { logInfo, logWarn } from './logger-context.js';
+import { getActiveLogger, logInfo, logWarn } from './logger-context.js';
 import { consumeOutputFormat } from './output-format.js';
 
 type Runtime = Awaited<ReturnType<typeof createRuntime>>;
@@ -61,7 +61,9 @@ export async function handleAuth(runtime: Runtime, args: string[]): Promise<void
   const definition = runtime.getDefinition(target);
   if (shouldReset) {
     await clearOAuthCaches(definition);
-    logInfo(`Cleared cached credentials for '${target}'.`);
+    if (!noBrowser) {
+      logInfo(`Cleared cached credentials for '${target}'.`);
+    }
   }
 
   if (definition.command.kind === 'stdio' && definition.oauthCommand) {
@@ -80,16 +82,20 @@ export async function handleAuth(runtime: Runtime, args: string[]): Promise<void
       if (!noBrowser) {
         logInfo(`Initiating OAuth flow for '${target}'...`);
       }
-      const tools = await runtime.listTools(target, {
-        autoAuthorize: true,
-        ...(noBrowser
-          ? {
-              oauthSessionOptions: buildNoBrowserOAuthOptions(format, markAuthorizationOutputEmitted),
-            }
-          : {}),
-      });
+      const tools = await withInfoLogsSuppressed(noBrowser, () =>
+        runtime.listTools(target, {
+          autoAuthorize: true,
+          ...(noBrowser
+            ? {
+                oauthSessionOptions: buildNoBrowserOAuthOptions(format, markAuthorizationOutputEmitted),
+              }
+            : {}),
+        })
+      );
       await persistPreparedEphemeralServer(runtime, prepared);
-      logInfo(`Authorization complete. ${tools.length} tool${tools.length === 1 ? '' : 's'} available.`);
+      if (!noBrowser) {
+        logInfo(`Authorization complete. ${tools.length} tool${tools.length === 1 ? '' : 's'} available.`);
+      }
       return;
     } catch (error) {
       await persistPreparedEphemeralServer(runtime, prepared);
@@ -114,6 +120,20 @@ export async function handleAuth(runtime: Runtime, args: string[]): Promise<void
       }
       throw new Error(`Failed to authorize '${target}': ${message}`, { cause: error });
     }
+  }
+}
+
+async function withInfoLogsSuppressed<T>(enabled: boolean, task: () => Promise<T>): Promise<T> {
+  if (!enabled) {
+    return task();
+  }
+  const logger = getActiveLogger();
+  const originalInfo = logger.info.bind(logger);
+  logger.info = () => {};
+  try {
+    return await task();
+  } finally {
+    logger.info = originalInfo;
   }
 }
 

--- a/src/cli/auth-command.ts
+++ b/src/cli/auth-command.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import type { ServerDefinition } from '../config-schema.js';
+import type { OAuthAuthorizationRequest, OAuthSessionOptions } from '../oauth.js';
 import { analyzeConnectionError } from '../error-classifier.js';
 import { clearOAuthCaches } from '../oauth-persistence.js';
 import type { createRuntime } from '../runtime.js';
@@ -14,7 +15,18 @@ import { consumeOutputFormat } from './output-format.js';
 
 type Runtime = Awaited<ReturnType<typeof createRuntime>>;
 
+type BrowserSuppression = 'default' | 'no-browser';
+
+const TRUE_VALUES = new Set(['1', 'true', 'yes']);
+const FALSE_VALUES = new Set(['0', 'false', 'no']);
+
 export async function handleAuth(runtime: Runtime, args: string[]): Promise<void> {
+  const browserSuppression = consumeBrowserSuppression(args, process.env);
+  const noBrowser = browserSuppression === 'no-browser';
+  let authorizationOutputEmitted = false;
+  const markAuthorizationOutputEmitted = () => {
+    authorizationOutputEmitted = true;
+  };
   const resetIndex = args.indexOf('--reset');
   const shouldReset = resetIndex !== -1;
   if (shouldReset) {
@@ -55,7 +67,7 @@ export async function handleAuth(runtime: Runtime, args: string[]): Promise<void
   if (definition.command.kind === 'stdio' && definition.oauthCommand) {
     logInfo(`Starting auth helper for '${target}' (stdio). Leave this running until the browser flow completes.`);
     try {
-      await runStdioAuth(definition);
+      await runStdioAuth(definition, { noBrowser });
       logInfo(`Auth helper for '${target}' finished. You can now call tools.`);
     } finally {
       await persistPreparedEphemeralServer(runtime, prepared);
@@ -65,8 +77,17 @@ export async function handleAuth(runtime: Runtime, args: string[]): Promise<void
 
   for (let attempt = 0; attempt < 2; attempt += 1) {
     try {
-      logInfo(`Initiating OAuth flow for '${target}'...`);
-      const tools = await runtime.listTools(target, { autoAuthorize: true });
+      if (!noBrowser) {
+        logInfo(`Initiating OAuth flow for '${target}'...`);
+      }
+      const tools = await runtime.listTools(target, {
+        autoAuthorize: true,
+        ...(noBrowser
+          ? {
+              oauthSessionOptions: buildNoBrowserOAuthOptions(format, markAuthorizationOutputEmitted),
+            }
+          : {}),
+      });
       await persistPreparedEphemeralServer(runtime, prepared);
       logInfo(`Authorization complete. ${tools.length} tool${tools.length === 1 ? '' : 's'} available.`);
       return;
@@ -78,12 +99,16 @@ export async function handleAuth(runtime: Runtime, args: string[]): Promise<void
       }
       const message = error instanceof Error ? error.message : String(error);
       if (format === 'json') {
-        const payload = buildConnectionIssueEnvelope({
-          server: target,
-          error,
-          issue: analyzeConnectionError(error),
-        });
-        console.log(JSON.stringify(payload, null, 2));
+        if (authorizationOutputEmitted) {
+          console.error(`Failed to authorize '${target}': ${message}`);
+        } else {
+          const payload = buildConnectionIssueEnvelope({
+            server: target,
+            error,
+            issue: analyzeConnectionError(error),
+          });
+          console.log(JSON.stringify(payload, null, 2));
+        }
         process.exitCode = 1;
         return;
       }
@@ -92,16 +117,17 @@ export async function handleAuth(runtime: Runtime, args: string[]): Promise<void
   }
 }
 
-async function runStdioAuth(definition: ServerDefinition): Promise<void> {
+async function runStdioAuth(definition: ServerDefinition, options: { noBrowser?: boolean } = {}): Promise<void> {
   const authArgs = [...(definition.command.kind === 'stdio' ? (definition.command.args ?? []) : [])];
   if (definition.oauthCommand) {
     authArgs.push(...definition.oauthCommand.args);
   }
+  const env = options.noBrowser ? { ...process.env, MCPORTER_OAUTH_NO_BROWSER: '1' } : process.env;
   return new Promise((resolve, reject) => {
     const child = spawn(definition.command.kind === 'stdio' ? definition.command.command : '', authArgs, {
       stdio: 'inherit',
       cwd: definition.command.kind === 'stdio' ? definition.command.cwd : process.cwd(),
-      env: process.env,
+      env,
     });
     child.on('error', reject);
     child.on('exit', (code) => {
@@ -112,6 +138,68 @@ async function runStdioAuth(definition: ServerDefinition): Promise<void> {
       }
     });
   });
+}
+
+function buildNoBrowserOAuthOptions(
+  format: 'text' | 'json',
+  markAuthorizationOutputEmitted: () => void
+): OAuthSessionOptions {
+  return {
+    suppressBrowserLaunch: true,
+    onAuthorizationUrl(request: OAuthAuthorizationRequest) {
+      markAuthorizationOutputEmitted();
+      if (format === 'json') {
+        console.log(
+          JSON.stringify(
+            {
+              authorizationUrl: request.authorizationUrl,
+              redirectUrl: request.redirectUrl,
+            },
+            null,
+            2
+          )
+        );
+        return;
+      }
+      console.log(request.authorizationUrl);
+    },
+  };
+}
+
+function consumeBrowserSuppression(args: string[], env: NodeJS.ProcessEnv): BrowserSuppression {
+  let mode = resolveBrowserSuppressionFromEnv(env.MCPORTER_OAUTH_NO_BROWSER);
+  const noBrowserIndex = args.indexOf('--no-browser');
+  if (noBrowserIndex !== -1) {
+    args.splice(noBrowserIndex, 1);
+    mode = 'no-browser';
+  }
+  const browserIndex = args.indexOf('--browser');
+  if (browserIndex !== -1) {
+    const value = args[browserIndex + 1];
+    if (!value) {
+      throw new Error("Flag '--browser' requires a value.");
+    }
+    if (value !== 'none') {
+      throw new Error("--browser must be 'none' when provided to mcporter auth.");
+    }
+    args.splice(browserIndex, 2);
+    mode = 'no-browser';
+  }
+  return mode;
+}
+
+function resolveBrowserSuppressionFromEnv(raw: string | undefined): BrowserSuppression {
+  if (raw === undefined) {
+    return 'default';
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (!normalized || FALSE_VALUES.has(normalized)) {
+    return 'default';
+  }
+  if (TRUE_VALUES.has(normalized)) {
+    return 'no-browser';
+  }
+  return 'default';
 }
 
 function shouldRetryAuthError(error: unknown): boolean {
@@ -130,7 +218,10 @@ export function printAuthHelp(): void {
     '',
     'Common flags:',
     '  --reset                 Clear cached credentials before re-authorizing.',
-    '  --json                  Emit a JSON envelope on failure.',
+    '  --json                  Emit a JSON envelope on failure (and auth-start JSON with --no-browser).',
+    '  --no-browser            Print the OAuth authorization URL without launching a browser.',
+    '  --browser none          Alias for --no-browser (also supported by config login).',
+    '  MCPORTER_OAUTH_NO_BROWSER=1|true|yes also enables --no-browser behavior.',
     '',
     'Ad-hoc targets:',
     '  --http-url <url>        Register an HTTP server for this run.',
@@ -147,6 +238,7 @@ export function printAuthHelp(): void {
     '',
     'Examples:',
     '  mcporter auth linear',
+    '  mcporter auth linear --no-browser',
     '  mcporter auth https://mcp.example.com/mcp',
     '  mcporter auth --stdio "npx -y chrome-devtools-mcp@latest"',
     '  mcporter auth --http-url http://localhost:3000/mcp --allow-http',

--- a/src/cli/config/help.ts
+++ b/src/cli/config/help.ts
@@ -98,8 +98,21 @@ export const CONFIG_HELP_ENTRIES: Record<ConfigSubcommand, ConfigHelpEntry> = {
     name: 'login <name|url> [options]',
     summary: 'Run the OAuth/auth flow',
     usage: 'mcporter config login <name|url> [options]',
-    description: 'Delegates to `mcporter auth`, so you can pass ephemeral flags like --http-url/--stdio/--reset.',
-    examples: ['pnpm mcporter config login linear', 'pnpm mcporter config login https://example.com/mcp --reset'],
+    description:
+      'Delegates to `mcporter auth`, so you can pass ephemeral flags like --http-url/--stdio/--reset and browser-suppression flags for headless OAuth.',
+    flags: [
+      { flag: '--no-browser', description: 'Print the OAuth authorization URL without launching a browser.' },
+      { flag: '--browser none', description: 'Alias for --no-browser.' },
+      {
+        flag: 'MCPORTER_OAUTH_NO_BROWSER=1|true|yes',
+        description: 'Environment default for browser-suppressed OAuth.',
+      },
+    ],
+    examples: [
+      'pnpm mcporter config login linear',
+      'pnpm mcporter config login linear --no-browser',
+      'pnpm mcporter config login https://example.com/mcp --reset',
+    ],
   },
   logout: {
     name: 'logout <name>',

--- a/src/daemon/runtime-wrapper.ts
+++ b/src/daemon/runtime-wrapper.ts
@@ -52,6 +52,9 @@ class KeepAliveRuntime implements Runtime {
   }
 
   async listTools(server: string, options?: ListToolsOptions): Promise<Awaited<ReturnType<Runtime['listTools']>>> {
+    if (options?.oauthSessionOptions) {
+      return this.base.listTools(server, options);
+    }
     if (this.shouldUseDaemon(server)) {
       return (await this.invokeWithRestart(server, 'listTools', () =>
         this.daemon.listTools({

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -16,6 +16,16 @@ import { buildOAuthPersistence } from './oauth-persistence.js';
 const CALLBACK_HOST = '127.0.0.1';
 const CALLBACK_PATH = '/callback';
 
+export interface OAuthAuthorizationRequest {
+  authorizationUrl: string;
+  redirectUrl: string;
+}
+
+export interface OAuthSessionOptions {
+  suppressBrowserLaunch?: boolean;
+  onAuthorizationUrl?: (request: OAuthAuthorizationRequest) => void | Promise<void>;
+}
+
 interface Deferred<T> {
   promise: Promise<T>;
   resolve: (value: T) => void;
@@ -75,7 +85,8 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
     private readonly definition: ServerDefinition,
     persistence: OAuthPersistence,
     redirectUrl: URL,
-    logger: OAuthLogger
+    logger: OAuthLogger,
+    private readonly options: OAuthSessionOptions = {}
   ) {
     this.redirectUrlValue = redirectUrl;
     this.logger = logger;
@@ -97,7 +108,8 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
 
   static async create(
     definition: ServerDefinition,
-    logger: OAuthLogger
+    logger: OAuthLogger,
+    options: OAuthSessionOptions = {}
   ): Promise<{
     provider: PersistentOAuthClientProvider;
     close: () => Promise<void>;
@@ -158,7 +170,7 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
       }
     }
 
-    const provider = new PersistentOAuthClientProvider(definition, persistence, redirectUrl, logger);
+    const provider = new PersistentOAuthClientProvider(definition, persistence, redirectUrl, logger, options);
     provider.attachServer(server);
     return {
       provider,
@@ -185,7 +197,7 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
         const error = parsed.searchParams.get('error');
         const receivedState = parsed.searchParams.get('state');
         const expectedState = await this.persistence.readState();
-        if (expectedState && receivedState && receivedState !== expectedState) {
+        if (expectedState && receivedState !== expectedState) {
           res.statusCode = 400;
           res.setHeader('Content-Type', 'text/html');
           res.end('<html><body><h1>Authorization failed</h1><p>Invalid OAuth state</p></body></html>');
@@ -259,11 +271,19 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
   }
 
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
-    this.logger.info(`Authorization required for ${this.definition.name}. Opening browser...`);
     this.authorizationRedirectStarted = true;
     this.ensureAuthorizationDeferred();
-    __oauthInternals.openExternal(authorizationUrl.toString());
-    this.logger.warn(`If the browser did not open, visit ${authorizationUrl.toString()} manually.`);
+    const request = {
+      authorizationUrl: authorizationUrl.toString(),
+      redirectUrl: this.redirectUrlValue.toString(),
+    } satisfies OAuthAuthorizationRequest;
+    if (this.options.suppressBrowserLaunch) {
+      await this.options.onAuthorizationUrl?.(request);
+      return;
+    }
+    this.logger.info(`Authorization required for ${this.definition.name}. Opening browser...`);
+    __oauthInternals.openExternal(request.authorizationUrl);
+    this.logger.warn(`If the browser did not open, visit ${request.authorizationUrl} manually.`);
   }
 
   hasAuthorizationRedirectStarted(): boolean {
@@ -330,8 +350,12 @@ export interface OAuthSession {
 }
 
 // createOAuthSession spins up a file-backed OAuth provider and callback server for the target definition.
-export async function createOAuthSession(definition: ServerDefinition, logger: OAuthLogger): Promise<OAuthSession> {
-  const { provider, close } = await PersistentOAuthClientProvider.create(definition, logger);
+export async function createOAuthSession(
+  definition: ServerDefinition,
+  logger: OAuthLogger,
+  options: OAuthSessionOptions = {}
+): Promise<OAuthSession> {
+  const { provider, close } = await PersistentOAuthClientProvider.create(definition, logger, options);
   const waitForAuthorizationCode = () => provider.waitForAuthorizationCode();
   const hasAuthorizationRedirectStarted = () => provider.hasAuthorizationRedirectStarted();
   return {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,6 +1,7 @@
 import type { CallToolRequest, ListResourcesRequest, ReadResourceRequest } from '@modelcontextprotocol/sdk/types.js';
 import { loadServerDefinitions, type ServerDefinition } from './config.js';
 import { createPrefixedConsoleLogger, type Logger, type LogLevel, resolveLogLevelFromEnv } from './logging.js';
+import type { OAuthSessionOptions } from './oauth.js';
 import { closeTransportAndWait } from './runtime-process-utils.js';
 import './sdk-patches.js';
 import { shouldResetConnection } from './runtime/errors.js';
@@ -38,12 +39,14 @@ export interface ListToolsOptions {
   readonly includeSchema?: boolean;
   readonly autoAuthorize?: boolean;
   readonly allowCachedAuth?: boolean;
+  readonly oauthSessionOptions?: OAuthSessionOptions;
 }
 
 interface ConnectOptions {
   readonly maxOAuthAttempts?: number;
   readonly skipCache?: boolean;
   readonly allowCachedAuth?: boolean;
+  readonly oauthSessionOptions?: OAuthSessionOptions;
 }
 
 export interface Runtime {
@@ -173,6 +176,7 @@ class McpRuntime implements Runtime {
       maxOAuthAttempts: autoAuthorize ? undefined : 0,
       skipCache: !autoAuthorize,
       allowCachedAuth: options.allowCachedAuth,
+      oauthSessionOptions: options.oauthSessionOptions,
     });
     try {
       const tools: ServerToolInfo[] = [];
@@ -286,6 +290,7 @@ class McpRuntime implements Runtime {
       oauthTimeoutMs: this.oauthTimeoutMs ?? OAUTH_CODE_TIMEOUT_MS,
       onDefinitionPromoted: (promoted) => this.definitions.set(promoted.name, promoted),
       allowCachedAuth: options.allowCachedAuth,
+      oauthSessionOptions: options.oauthSessionOptions,
     });
 
     if (useCache) {

--- a/src/runtime/transport.ts
+++ b/src/runtime/transport.ts
@@ -7,7 +7,7 @@ import type { ServerDefinition } from '../config.js';
 import { resolveEnvValue, withEnvOverrides } from '../env.js';
 import { analyzeConnectionError } from '../error-classifier.js';
 import type { Logger } from '../logging.js';
-import { createOAuthSession, type OAuthSession } from '../oauth.js';
+import { createOAuthSession, type OAuthSession, type OAuthSessionOptions } from '../oauth.js';
 import { readCachedAccessToken } from '../oauth-persistence.js';
 import { materializeHeaders } from '../runtime-header-utils.js';
 import { isUnauthorizedError, maybeEnableOAuth } from '../runtime-oauth-support.js';
@@ -80,6 +80,7 @@ export interface CreateClientContextOptions {
   readonly oauthTimeoutMs?: number;
   readonly onDefinitionPromoted?: (definition: ServerDefinition) => void;
   readonly allowCachedAuth?: boolean;
+  readonly oauthSessionOptions?: OAuthSessionOptions;
 }
 
 function removeAuthorizationHeader(headers: Record<string, string> | undefined): Record<string, string> | undefined {
@@ -251,7 +252,7 @@ async function attemptHttpClientContext(
   let oauthSession: OAuthSession | undefined;
   const shouldEstablishOAuth = activeDefinition.auth === 'oauth' && options.maxOAuthAttempts !== 0;
   if (shouldEstablishOAuth) {
-    oauthSession = await createOAuthSession(activeDefinition, logger);
+    oauthSession = await createOAuthSession(activeDefinition, logger, options.oauthSessionOptions);
   }
   const transportOptions = createHttpTransportOptions(activeDefinition, oauthSession, shouldEstablishOAuth);
 

--- a/tests/cli-auth-help.test.ts
+++ b/tests/cli-auth-help.test.ts
@@ -27,7 +27,11 @@ describe('mcporter auth help shortcut', () => {
 
     await runCli(['auth', '--help']);
 
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Usage: mcporter auth'));
+    const output = errorSpy.mock.calls.map(([message]) => String(message)).join('\n');
+    expect(output).toContain('Usage: mcporter auth');
+    expect(output).toContain('--no-browser');
+    expect(output).toContain('--browser none');
+    expect(output).toContain('MCPORTER_OAUTH_NO_BROWSER');
     expect(process.exitCode).toBe(0);
   });
 
@@ -37,7 +41,11 @@ describe('mcporter auth help shortcut', () => {
 
     await runCli(['auth', 'help']);
 
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Usage: mcporter auth'));
+    const output = errorSpy.mock.calls.map(([message]) => String(message)).join('\n');
+    expect(output).toContain('Usage: mcporter auth');
+    expect(output).toContain('--no-browser');
+    expect(output).toContain('--browser none');
+    expect(output).toContain('MCPORTER_OAUTH_NO_BROWSER');
     expect(process.exitCode).toBe(0);
   });
 });

--- a/tests/cli-auth.test.ts
+++ b/tests/cli-auth.test.ts
@@ -68,6 +68,181 @@ describe('mcporter auth ad-hoc support', () => {
     expect(registerDefinition).not.toHaveBeenCalled();
   });
 
+  it('passes no-browser OAuth session options when --no-browser is provided', async () => {
+    const { handleAuth } = await cliModulePromise;
+    const definition = {
+      name: 'linear',
+      command: { kind: 'http', url: new URL('https://mcp.linear.app/mcp') },
+      auth: 'oauth',
+    } as ServerDefinition;
+    const listTools = vi.fn().mockResolvedValue([{ name: 'ok' }]);
+    const runtime = {
+      getDefinitions: () => [definition],
+      registerDefinition: vi.fn(),
+      listTools,
+      getDefinition: () => definition,
+    } as unknown as Awaited<ReturnType<(typeof import('../src/runtime.js'))['createRuntime']>>;
+
+    await handleAuth(runtime, ['linear', '--no-browser']);
+
+    expect(listTools).toHaveBeenCalledWith(
+      'linear',
+      expect.objectContaining({
+        autoAuthorize: true,
+        oauthSessionOptions: expect.objectContaining({ suppressBrowserLaunch: true }),
+      })
+    );
+  });
+
+  it('supports documented --browser none as a no-browser alias', async () => {
+    const { handleAuth } = await cliModulePromise;
+    const definition = {
+      name: 'linear',
+      command: { kind: 'http', url: new URL('https://mcp.linear.app/mcp') },
+      auth: 'oauth',
+    } as ServerDefinition;
+    const listTools = vi.fn().mockResolvedValue([{ name: 'ok' }]);
+    const runtime = {
+      getDefinitions: () => [definition],
+      registerDefinition: vi.fn(),
+      listTools,
+      getDefinition: () => definition,
+    } as unknown as Awaited<ReturnType<(typeof import('../src/runtime.js'))['createRuntime']>>;
+
+    await handleAuth(runtime, ['linear', '--browser', 'none']);
+
+    expect(listTools).toHaveBeenCalledWith(
+      'linear',
+      expect.objectContaining({
+        autoAuthorize: true,
+        oauthSessionOptions: expect.objectContaining({ suppressBrowserLaunch: true }),
+      })
+    );
+  });
+
+  it('rejects unsupported --browser values', async () => {
+    const { handleAuth } = await cliModulePromise;
+    const definition = {
+      name: 'linear',
+      command: { kind: 'http', url: new URL('https://m.linear.app/mcp') },
+      auth: 'oauth',
+    } as ServerDefinition;
+    const runtime = {
+      getDefinitions: () => [definition],
+      registerDefinition: vi.fn(),
+      listTools: vi.fn().mockResolvedValue([{ name: 'ok' }]),
+      getDefinition: () => definition,
+    } as unknown as Awaited<ReturnType<(typeof import('../src/runtime.js'))['createRuntime']>>;
+
+    await expect(handleAuth(runtime, ['linear', '--browser', 'auto'])).rejects.toThrow(/--browser must be 'none'/);
+  });
+
+  it('prints only the authorization URL to stdout in no-browser text mode', async () => {
+    const { handleAuth } = await cliModulePromise;
+    const definition = {
+      name: 'linear',
+      command: { kind: 'http', url: new URL('https://mcp.linear.app/mcp') },
+      auth: 'oauth',
+    } as ServerDefinition;
+    const listTools = vi.fn(async (_target, options?: Record<string, unknown>) => {
+      const oauthSessionOptions = options?.oauthSessionOptions as
+        | { onAuthorizationUrl?: (request: { authorizationUrl: string; redirectUrl: string }) => void | Promise<void> }
+        | undefined;
+      await oauthSessionOptions?.onAuthorizationUrl?.({
+        authorizationUrl: 'https://auth.example.com/authorize?state=abc',
+        redirectUrl: 'http://127.0.0.1:54321/callback',
+      });
+      return [{ name: 'ok' }];
+    });
+    const runtime = {
+      getDefinitions: () => [definition],
+      registerDefinition: vi.fn(),
+      listTools,
+      getDefinition: () => definition,
+    } as unknown as Awaited<ReturnType<(typeof import('../src/runtime.js'))['createRuntime']>>;
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handleAuth(runtime, ['linear', '--no-browser']);
+
+    expect(logSpy.mock.calls.map(([message]) => message)).toEqual(['https://auth.example.com/authorize?state=abc']);
+    logSpy.mockRestore();
+  });
+
+  it('prints auth-start JSON once and keeps later failures off stdout', async () => {
+    const { handleAuth } = await cliModulePromise;
+    const definition = {
+      name: 'linear',
+      command: { kind: 'http', url: new URL('https://mcp.linear.app/mcp') },
+      auth: 'oauth',
+    } as ServerDefinition;
+    const listTools = vi.fn(async (_target, options?: Record<string, unknown>) => {
+      const oauthSessionOptions = options?.oauthSessionOptions as
+        | { onAuthorizationUrl?: (request: { authorizationUrl: string; redirectUrl: string }) => void | Promise<void> }
+        | undefined;
+      await oauthSessionOptions?.onAuthorizationUrl?.({
+        authorizationUrl: 'https://auth.example.com/authorize?state=abc',
+        redirectUrl: 'http://127.0.0.1:54321/callback',
+      });
+      throw new Error('OAuth authorization timed out');
+    });
+    const runtime = {
+      getDefinitions: () => [definition],
+      registerDefinition: vi.fn(),
+      listTools,
+      getDefinition: () => definition,
+    } as unknown as Awaited<ReturnType<(typeof import('../src/runtime.js'))['createRuntime']>>;
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await handleAuth(runtime, ['linear', '--json', '--no-browser']);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(logSpy.mock.calls[0]?.[0] ?? '{}')).toEqual({
+      authorizationUrl: 'https://auth.example.com/authorize?state=abc',
+      redirectUrl: 'http://127.0.0.1:54321/callback',
+    });
+    expect(errorSpy).toHaveBeenCalledWith("Failed to authorize 'linear': OAuth authorization timed out");
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    process.exitCode = undefined;
+  });
+
+  it('honors MCPORTER_OAUTH_NO_BROWSER truthy values', async () => {
+    const previous = process.env.MCPORTER_OAUTH_NO_BROWSER;
+    process.env.MCPORTER_OAUTH_NO_BROWSER = 'yes';
+    try {
+      const { handleAuth } = await cliModulePromise;
+      const definition = {
+        name: 'linear',
+        command: { kind: 'http', url: new URL('https://mcp.linear.app/mcp') },
+        auth: 'oauth',
+      } as ServerDefinition;
+      const listTools = vi.fn().mockResolvedValue([{ name: 'ok' }]);
+      const runtime = {
+        getDefinitions: () => [definition],
+        registerDefinition: vi.fn(),
+        listTools,
+        getDefinition: () => definition,
+      } as unknown as Awaited<ReturnType<(typeof import('../src/runtime.js'))['createRuntime']>>;
+
+      await handleAuth(runtime, ['linear']);
+
+      expect(listTools).toHaveBeenCalledWith(
+        'linear',
+        expect.objectContaining({
+          autoAuthorize: true,
+          oauthSessionOptions: expect.objectContaining({ suppressBrowserLaunch: true }),
+        })
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.MCPORTER_OAUTH_NO_BROWSER;
+      } else {
+        process.env.MCPORTER_OAUTH_NO_BROWSER = previous;
+      }
+    }
+  });
+
   it('emits JSON envelopes when auth fails and --json is provided', async () => {
     const { handleAuth } = await cliModulePromise;
     const definition = {

--- a/tests/cli-auth.test.ts
+++ b/tests/cli-auth.test.ts
@@ -168,6 +168,45 @@ describe('mcporter auth ad-hoc support', () => {
     logSpy.mockRestore();
   });
 
+  it('keeps no-browser stdout parseable when info logging is enabled', async () => {
+    const [{ handleAuth }, { getActiveLogger, setLogLevel }] = await Promise.all([
+      cliModulePromise,
+      import('../src/cli/logger-context.js'),
+    ]);
+    const definition = {
+      name: 'linear',
+      command: { kind: 'http', url: new URL('https://mcp.linear.app/mcp') },
+      auth: 'oauth',
+    } as ServerDefinition;
+    const listTools = vi.fn(async (_target, options?: Record<string, unknown>) => {
+      const oauthSessionOptions = options?.oauthSessionOptions as
+        | { onAuthorizationUrl?: (request: { authorizationUrl: string; redirectUrl: string }) => void | Promise<void> }
+        | undefined;
+      await oauthSessionOptions?.onAuthorizationUrl?.({
+        authorizationUrl: 'https://auth.example.com/authorize?state=abc',
+        redirectUrl: 'http://127.0.0.1:54321/callback',
+      });
+      getActiveLogger().info('runtime OAuth status');
+      return [{ name: 'ok' }];
+    });
+    const runtime = {
+      getDefinitions: () => [definition],
+      registerDefinition: vi.fn(),
+      listTools,
+      getDefinition: () => definition,
+    } as unknown as Awaited<ReturnType<(typeof import('../src/runtime.js'))['createRuntime']>>;
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      setLogLevel('info');
+      await handleAuth(runtime, ['linear', '--no-browser']);
+      expect(logSpy.mock.calls.map(([message]) => message)).toEqual(['https://auth.example.com/authorize?state=abc']);
+    } finally {
+      setLogLevel('warn');
+      logSpy.mockRestore();
+    }
+  });
+
   it('prints auth-start JSON once and keeps later failures off stdout', async () => {
     const { handleAuth } = await cliModulePromise;
     const definition = {

--- a/tests/cli-config-command.test.ts
+++ b/tests/cli-config-command.test.ts
@@ -148,6 +148,12 @@ describe('mcporter config CLI', () => {
     expect(invokeAuth).toHaveBeenCalledWith(['linear']);
   });
 
+  it('delegates login browser-suppression flags to the auth handler', async () => {
+    const invokeAuth = vi.fn().mockResolvedValue(undefined);
+    await handleConfigCli(buildOptions({ configPath }, { invokeAuth }), ['login', 'linear', '--no-browser']);
+    expect(invokeAuth).toHaveBeenCalledWith(['linear', '--no-browser']);
+  });
+
   it('clears cached credentials on logout', async () => {
     const tokenDir = path.join(tempDir, 'token-cache');
     await fs.mkdir(path.dirname(configPath), { recursive: true });
@@ -217,6 +223,18 @@ describe('mcporter config CLI', () => {
     const output = logs.join('\n');
     expect(output).toContain('mcporter config list');
     expect(output).toContain('--source <local|import>');
+  });
+
+  it('prints browser-suppression flags in config login help', async () => {
+    const logs: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation(captureLog(logs));
+    await handleConfigCli(buildOptions({ configPath }), ['help', 'login']);
+    spy.mockRestore();
+    const output = logs.join('\n');
+    expect(output).toContain('mcporter config login');
+    expect(output).toContain('--no-browser');
+    expect(output).toContain('--browser none');
+    expect(output).toContain('MCPORTER_OAUTH_NO_BROWSER');
   });
 
   it('warns when requesting help for unknown subcommands', async () => {

--- a/tests/oauth-callback.test.ts
+++ b/tests/oauth-callback.test.ts
@@ -89,7 +89,7 @@ describe('oauth callback handling', () => {
     await expect(wait).resolves.toBe('xyz');
   });
 
-  it('accepts callbacks that omit state (compat servers)', async () => {
+  it('rejects callbacks that omit state when expected state exists', async () => {
     const session = await createOAuthSession(makeDefinition(), logger);
     cleanup = () => session.close();
     const provider = session.provider as StatefulProvider;
@@ -97,6 +97,24 @@ describe('oauth callback handling', () => {
     redirect.hostname = '127.0.0.1';
 
     await provider.state();
+    const wait = session.waitForAuthorizationCode();
+    wait.catch(() => {});
+
+    const badUrl = new URL(redirect);
+    badUrl.searchParams.set('code', 'nostate');
+    const status = await requestStatus(badUrl);
+    expect(status).toBeGreaterThanOrEqual(400);
+    await expect(wait).rejects.toThrow(/state/i);
+    await wait.catch(() => {});
+  });
+
+  it('accepts callbacks that omit state when no expected state exists', async () => {
+    const session = await createOAuthSession(makeDefinition({ name: `nostate-${randomUUID()}` }), logger);
+    cleanup = () => session.close();
+    const provider = session.provider as StatefulProvider;
+    const redirect = new URL(String(provider.redirectUrl));
+    redirect.hostname = '127.0.0.1';
+
     const wait = session.waitForAuthorizationCode();
 
     const okUrl = new URL(redirect);

--- a/tests/oauth-session.test.ts
+++ b/tests/oauth-session.test.ts
@@ -10,6 +10,7 @@ type StatefulProvider = {
   redirectUrl: string | URL;
   state: () => Promise<string>;
   redirectToAuthorization: (authorizationUrl: URL) => Promise<void>;
+  hasAuthorizationRedirectStarted: () => boolean;
 };
 
 const requestStatus = (target: URL): Promise<number> =>
@@ -243,6 +244,48 @@ describe('FileOAuthClientProvider session lifecycle', () => {
     expect(status).toBe(200);
     await expect(waitPromise).resolves.toBe('stable-deferred-code');
     await session.close();
+  });
+
+  it('suppresses browser launch and reports authorization URL when configured', async () => {
+    const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
+    tempDirs.push(tokenCacheDir);
+    const definition: ServerDefinition = {
+      name: 'test-oauth-no-browser-url',
+      description: 'Test OAuth server',
+      command: { kind: 'http', url: new URL('https://example.com/mcp') },
+      auth: 'oauth',
+      tokenCacheDir,
+    };
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const onAuthorizationUrl = vi.fn();
+
+    const session = await createOAuthSession(definition, logger, {
+      suppressBrowserLaunch: true,
+      onAuthorizationUrl,
+    });
+    const provider = session.provider as StatefulProvider;
+    const openSpy = vi.spyOn(__oauthInternals, 'openExternal').mockImplementation(() => {});
+    const authorizationUrl = new URL('https://example.com/auth?code=xyz');
+    const waitPromise = session.waitForAuthorizationCode().catch(() => undefined);
+
+    await provider.redirectToAuthorization(authorizationUrl);
+
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(onAuthorizationUrl).toHaveBeenCalledWith({
+      authorizationUrl: authorizationUrl.toString(),
+      redirectUrl: String(provider.redirectUrl),
+    });
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining(`visit ${authorizationUrl.toString()} manually`)
+    );
+    expect(provider.hasAuthorizationRedirectStarted()).toBe(true);
+
+    await session.close();
+    await waitPromise;
   });
 
   it('logs the manual OAuth URL at warn level for headless terminals (#139)', async () => {


### PR DESCRIPTION
## Summary
- Add `--no-browser`, documented `--browser none` alias, and `MCPORTER_OAUTH_NO_BROWSER` support for headless OAuth auth flows.
- Emit stable auth-start URL output in text/JSON modes while suppressing browser launch and preserving callback completion.
- Harden OAuth callback state handling and document headless/SSH forwarding behavior.

## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [x] Documentation
- [ ] Refactor

## Test plan
- `pnpm run check`
- `pnpm test`

Related to #169