### PR TITLE
Treat CloudBase MCP as a keep-alive stdio server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Prevent direct daemon starts from rebinding over an already-running healthy daemon, avoiding orphaned keep-alive processes during foreground or launch races. (PR #195, thanks @zm2231)
 - Return a non-zero exit code for explicit `mcporter list <unknown-server>` failures while preserving aggregate list health checks by default. (Issue #203, thanks @theo674)
 - Reconcile keep-alive daemon metadata with the responding process and serialize daemon startup across parallel clients, preventing duplicate orphaned daemons. (Issue #191, thanks @dtmsyi)
+- Keep CloudBase MCP alive by default so device-code authentication can finish polling and persist credentials after returning `AUTH_PENDING`. (PR #193, thanks @sevzq)
 - Keep daemon-managed stdio servers warm across repeated `mcporter list` requests instead of treating non-interactive tool listing as a throwaway process. (Issue #188, thanks @robertoronderosjr)
 
 ### Tooling / Dependencies

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -8,7 +8,7 @@ read_when:
 
 ## Goals
 
-- **Invisible keep-alive:** `mcporter call` should transparently start (and reuse) a per-login daemon whenever a configured server requires persistence (e.g., `chrome-devtools`). No extra flags for agents.
+- **Invisible keep-alive:** `mcporter call` should transparently start (and reuse) a per-login daemon whenever a configured server requires persistence (e.g., `chrome-devtools` or CloudBase device authentication). No extra flags for agents.
 - **Shared state:** Multiple CLI invocations/agents within the same user session must reuse the same warm transport so STDIO servers can hold tabs, cookies, and other stateful context.
 - **Per-config scope:** The daemon lives under the current user account, keyed by config path (`~/.mcporter/daemon/daemon-<config-hash>.sock` on Unix-like systems, or `$XDG_STATE_HOME/mcporter/daemon/...` when set), and never crosses user boundaries.
 - **Resilience:** If the daemon or a keep-alive server crashes, the next CLI call restarts it automatically.
@@ -34,7 +34,7 @@ read_when:
 - **Keep-alive detection:**
   - Extend `ServerDefinition` with `lifecycle?: "ephemeral" | { mode: "keep-alive", idleTimeoutMs?: number }`.
   - Provide a config-level `defaultKeepAlive` array or `MCPORTER_KEEPALIVE` env var for quick overrides.
-  - Ship a hardcoded allowlist (initially `chrome-devtools`, `mobile-mcp`, `playwright`) so existing configs benefit immediately; users can opt out per server.
+  - Ship a hardcoded allowlist (`chrome-devtools`, `mobile-mcp`, `playwright`, `cloudbase`) so existing configs benefit immediately; users can opt out per server.
 
 ## CLI Surface
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ export { extractListFlags } from './cli/list-flags.js';
 export { resolveCallTimeout } from './cli/timeouts.js';
 
 const FORCE_EXIT_GRACE_MS = 50;
-const DAEMON_FAST_PATH_SERVERS = new Set(['chrome-devtools', 'mobile-mcp', 'playwright']);
+const DAEMON_FAST_PATH_SERVERS = new Set(['chrome-devtools', 'mobile-mcp', 'playwright', 'cloudbase']);
 
 export async function handleAuth(
   ...args: Parameters<typeof import('./cli/auth-command.js').handleAuth>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ export { extractListFlags } from './cli/list-flags.js';
 export { resolveCallTimeout } from './cli/timeouts.js';
 
 const FORCE_EXIT_GRACE_MS = 50;
-const DAEMON_FAST_PATH_SERVERS = new Set(['chrome-devtools', 'mobile-mcp', 'playwright', 'cloudbase']);
+const DAEMON_FAST_PATH_SERVERS = new Set(['chrome-devtools', 'mobile-mcp', 'playwright']);
 
 export async function handleAuth(
   ...args: Parameters<typeof import('./cli/auth-command.js').handleAuth>

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,6 +1,6 @@
 import type { CommandSpec, RawLifecycle, ServerDefinition, ServerLifecycle } from './config-schema.js';
 
-const DEFAULT_KEEP_ALIVE = new Set(['chrome-devtools', 'mobile-mcp', 'playwright']);
+const DEFAULT_KEEP_ALIVE = new Set(['chrome-devtools', 'mobile-mcp', 'playwright', 'cloudbase']);
 
 const includeOverride = parseList(process.env.MCPORTER_KEEPALIVE);
 const excludeOverride = parseList(process.env.MCPORTER_DISABLE_KEEPALIVE ?? process.env.MCPORTER_NO_KEEPALIVE);
@@ -19,6 +19,7 @@ const KEEP_ALIVE_COMMANDS: CommandSignature[] = [
   { label: 'chrome-devtools', fragments: ['chrome-devtools-mcp'] },
   { label: 'mobile-mcp', fragments: ['@mobilenext/mobile-mcp', 'mobile-mcp'] },
   { label: 'playwright', fragments: ['@playwright/mcp', 'playwright/mcp'] },
+  { label: 'cloudbase', fragments: ['@cloudbase/cloudbase-mcp', 'cloudbase-mcp'] },
 ];
 
 const CHROME_DEVTOOLS_URL_PLACEHOLDERS = [String.raw`\${CHROME_DEVTOOLS_URL}`, '$env:CHROME_DEVTOOLS_URL'];

--- a/tests/cli-daemon-fast-path.test.ts
+++ b/tests/cli-daemon-fast-path.test.ts
@@ -89,19 +89,14 @@ describe('daemon call fast path', () => {
     );
   });
 
-  it('routes CloudBase auth calls through the daemon fast path', async () => {
+  it('leaves CloudBase calls on the config-aware runtime path', async () => {
+    mocks.createRuntime.mockRejectedValue(new Error('runtime path used'));
     const { runCli } = await import('../src/cli.js');
-    vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await runCli(['call', 'cloudbase.auth', '--output', 'json']);
+    await expect(runCli(['call', 'cloudbase.auth', '--output', 'json'])).rejects.toThrow('runtime path used');
 
-    expect(mocks.createRuntime).not.toHaveBeenCalled();
-    expect(mocks.daemonCallTool).toHaveBeenCalledWith(
-      expect.objectContaining({
-        server: 'cloudbase',
-        tool: 'auth',
-      })
-    );
+    expect(mocks.createRuntime).toHaveBeenCalled();
+    expect(mocks.daemonCallTool).not.toHaveBeenCalled();
   });
 
   it.each(['MCPORTER_RECORD', 'MCPORTER_REPLAY'] as const)(

--- a/tests/cli-daemon-fast-path.test.ts
+++ b/tests/cli-daemon-fast-path.test.ts
@@ -89,6 +89,21 @@ describe('daemon call fast path', () => {
     );
   });
 
+  it('routes CloudBase auth calls through the daemon fast path', async () => {
+    const { runCli } = await import('../src/cli.js');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runCli(['call', 'cloudbase.auth', '--output', 'json']);
+
+    expect(mocks.createRuntime).not.toHaveBeenCalled();
+    expect(mocks.daemonCallTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        server: 'cloudbase',
+        tool: 'auth',
+      })
+    );
+  });
+
   it.each(['MCPORTER_RECORD', 'MCPORTER_REPLAY'] as const)(
     'bypasses the daemon fast path while %s is active',
     async (modeEnv) => {

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -16,6 +16,20 @@ const CHROME_COMMAND_ENV: CommandSpec = {
   cwd: process.cwd(),
 };
 
+const CLOUDBASE_NPX_COMMAND: CommandSpec = {
+  kind: 'stdio',
+  command: 'npx',
+  args: ['-y', '@cloudbase/cloudbase-mcp@latest'],
+  cwd: process.cwd(),
+};
+
+const CLOUDBASE_BIN_COMMAND: CommandSpec = {
+  kind: 'stdio',
+  command: 'cloudbase-mcp',
+  args: [],
+  cwd: process.cwd(),
+};
+
 describe('resolveLifecycle', () => {
   it('forces chrome-devtools placeholder runs to be ephemeral', () => {
     const lifecycle = resolveLifecycle('chrome-devtools', undefined, CHROME_COMMAND);
@@ -24,6 +38,21 @@ describe('resolveLifecycle', () => {
 
   it('forces chrome-devtools $env placeholder runs to be ephemeral', () => {
     const lifecycle = resolveLifecycle('chrome-devtools', undefined, CHROME_COMMAND_ENV);
+    expect(lifecycle?.mode).toBe('ephemeral');
+  });
+
+  it('auto-enables keep-alive for CloudBase MCP package commands', () => {
+    const lifecycle = resolveLifecycle('cloudbase', undefined, CLOUDBASE_NPX_COMMAND);
+    expect(lifecycle?.mode).toBe('keep-alive');
+  });
+
+  it('auto-enables keep-alive for CloudBase MCP binary commands', () => {
+    const lifecycle = resolveLifecycle('tcb', undefined, CLOUDBASE_BIN_COMMAND);
+    expect(lifecycle?.mode).toBe('keep-alive');
+  });
+
+  it('honors explicit ephemeral lifecycle for CloudBase MCP commands', () => {
+    const lifecycle = resolveLifecycle('cloudbase', 'ephemeral', CLOUDBASE_NPX_COMMAND);
     expect(lifecycle?.mode).toBe('ephemeral');
   });
 });


### PR DESCRIPTION
## Summary
- mark CloudBase MCP as a default keep-alive stdio server
- recognize both `@cloudbase/cloudbase-mcp` package invocations and `cloudbase-mcp` binary invocations
- keep explicit `lifecycle: "ephemeral"` overrides respected

## Context
CloudBase MCP device-code auth returns `AUTH_PENDING` after emitting the device challenge, then continues polling in the background so credentials can be persisted after the browser authorization succeeds. When CloudBase MCP is invoked as an ephemeral stdio server, that process exits immediately after returning `AUTH_PENDING`, so the polling loop is cut off before credentials can be written.

Treating CloudBase MCP as keep-alive matches that stateful auth flow and lets the daemon keep the MCP process alive until device-code polling finishes.

## Tests
- `pnpm exec vitest run tests/lifecycle.test.ts`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint:oxlint`
- smoke: `resolveLifecycle(...)` for `@cloudbase/cloudbase-mcp@latest` returns `{ "mode": "keep-alive" }`