### PR TITLE
fix: stop non-client daemon starts from orphaning a running daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### CLI
 
 - Add `mcporter record` and `mcporter replay` helpers for capturing and replaying MCP JSON-RPC traffic, with server filters and daemon-safe manual env setup. (PR #192, thanks @LDMB123)
+- Prevent direct daemon starts from rebinding over an already-running healthy daemon, avoiding orphaned keep-alive processes during foreground or launch races. (PR #195, thanks @zm2231)
 - Reconcile keep-alive daemon metadata with the responding process and serialize daemon startup across parallel clients, preventing duplicate orphaned daemons. (Issue #191, thanks @dtmsyi)
 - Keep daemon-managed stdio servers warm across repeated `mcporter list` requests instead of treating non-interactive tool listing as a throwaway process. (Issue #188, thanks @robertoronderosjr)
 

--- a/src/daemon/config-layers.ts
+++ b/src/daemon/config-layers.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import path from 'node:path';
 import type { LoadConfigOptions } from '../config.js';
 import { listConfigLayerPaths } from '../config.js';
 
@@ -18,6 +19,9 @@ export async function collectConfigLayers(
   const entries: Array<{ path: string; mtimeMs: number | null }> = [];
   for (const layerPath of layerPaths) {
     entries.push({ path: layerPath, mtimeMs: await statConfigMtime(layerPath) });
+  }
+  if (entries.length === 0 && options.configPath) {
+    entries.push({ path: path.resolve(options.configPath), mtimeMs: await statConfigMtime(options.configPath) });
   }
   return entries;
 }

--- a/src/daemon/definition-hash.ts
+++ b/src/daemon/definition-hash.ts
@@ -1,0 +1,40 @@
+import { createHash } from 'node:crypto';
+import type { ServerDefinition } from '../config.js';
+
+export function hashDaemonDefinitions(definitions: readonly ServerDefinition[]): string {
+  const sorted = definitions.toSorted((a, b) => a.name.localeCompare(b.name));
+  return createHash('sha256').update(stableJsonStringify(sorted)).digest('hex').slice(0, 16);
+}
+
+function stableJsonStringify(value: unknown): string {
+  const json = JSON.stringify(sortJsonValue(value));
+  if (json === undefined) {
+    throw new TypeError('Cannot serialize unsupported JSON root value.');
+  }
+  return json;
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sortJsonValue(entry));
+  }
+  if (!isPlainObject(value)) {
+    return value;
+  }
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(value).toSorted()) {
+    const entry = (value as Record<string, unknown>)[key];
+    if (entry !== undefined) {
+      result[key] = sortJsonValue(entry);
+    }
+  }
+  return result;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}

--- a/src/daemon/host.ts
+++ b/src/daemon/host.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import net from 'node:net';
 import path from 'node:path';
 import { loadDaemonConfig, type ServerDefinition } from '../config.js';
-import { withFileLock, writeJsonFile } from '../fs-json.js';
+import { readJsonFile, withFileLock, writeJsonFile } from '../fs-json.js';
 import { isKeepAliveServer } from '../lifecycle.js';
 import { createRuntime, type Runtime } from '../runtime.js';
 import { collectConfigLayers, statConfigMtime } from './config-layers.js';
@@ -188,10 +188,10 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
     });
   });
 
-  // Separate lock from the client's metadata lock so a client awaiting readiness can't deadlock the bind.
   let claimed = false;
   await withFileLock(`${options.metadataPath}.bind`, async () => {
-    if (await isDaemonResponding(options.socketPath)) {
+    const live = await probeLiveDaemon(options.socketPath);
+    if (live && (await metadataMatches(options.metadataPath, live))) {
       return;
     }
     await prepareSocket(options.socketPath);
@@ -229,15 +229,28 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
 
 const DAEMON_PROBE_TIMEOUT_MS = 2_000;
 
-// Connect-only is not enough: a hung daemon still has its socket in listen(2), so the kernel accepts the
-// connection. Require a status response that reports this socket and a live pid, matching the client's liveness
-// contract, so a hung/dead/foreign listener falls through to rebind instead of stranding the caller.
 export async function isDaemonResponding(socketPath: string): Promise<boolean> {
+  return (await probeLiveDaemon(socketPath)) !== null;
+}
+
+async function probeLiveDaemon(socketPath: string): Promise<StatusResult | null> {
   const status = await probeDaemonStatus(socketPath);
-  if (!status || status.socketPath !== socketPath) {
+  if (!status || status.socketPath !== socketPath || !isProcessAlive(status.pid)) {
+    return null;
+  }
+  return status;
+}
+
+export async function metadataMatches(
+  metadataPath: string,
+  live: Pick<StatusResult, 'pid' | 'socketPath'>
+): Promise<boolean> {
+  try {
+    const existing = await readJsonFile<{ pid?: number; socketPath?: string }>(metadataPath);
+    return existing?.pid === live.pid && existing?.socketPath === live.socketPath;
+  } catch {
     return false;
   }
-  return isProcessAlive(status.pid);
 }
 
 function isProcessAlive(pid: number): boolean {

--- a/src/daemon/host.ts
+++ b/src/daemon/host.ts
@@ -1,8 +1,9 @@
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import net from 'node:net';
 import path from 'node:path';
 import { loadDaemonConfig, type ServerDefinition } from '../config.js';
-import { writeJsonFile } from '../fs-json.js';
+import { withFileLock, writeJsonFile } from '../fs-json.js';
 import { isKeepAliveServer } from '../lifecycle.js';
 import { createRuntime, type Runtime } from '../runtime.js';
 import { collectConfigLayers, statConfigMtime } from './config-layers.js';
@@ -83,7 +84,6 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
     logPath: options.logPath,
   });
 
-  await prepareSocket(options.socketPath);
   await fs.mkdir(path.dirname(options.metadataPath), { recursive: true });
   const configMtimeMs = await statConfigMtime(options.configPath);
 
@@ -188,27 +188,106 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
     });
   });
 
-  await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(options.socketPath, () => {
-      server.off('error', reject);
-      resolve();
+  // Separate lock from the client's metadata lock so a client awaiting readiness can't deadlock the bind.
+  let claimed = false;
+  await withFileLock(`${options.metadataPath}.bind`, async () => {
+    if (await isDaemonResponding(options.socketPath)) {
+      return;
+    }
+    await prepareSocket(options.socketPath);
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(options.socketPath, () => {
+        server.off('error', reject);
+        resolve();
+      });
     });
+    await writeJsonFile(options.metadataPath, {
+      pid: process.pid,
+      socketPath: options.socketPath,
+      configPath: options.configPath,
+      configLayers,
+      startedAt: Date.now(),
+      logPath: options.logPath ?? null,
+      configMtimeMs,
+    });
+    claimed = true;
   });
 
-  await writeJsonFile(options.metadataPath, {
-    pid: process.pid,
-    socketPath: options.socketPath,
-    configPath: options.configPath,
-    configLayers,
-    startedAt: Date.now(),
-    logPath: options.logPath ?? null,
-    configMtimeMs,
-  });
+  if (!claimed) {
+    logEvent(logContext, 'Daemon already running for this config; exiting without rebinding.');
+    server.close();
+    await runtime.close().catch(() => {});
+    await disposeLogContext(logContext).catch(() => {});
+    process.exit(0);
+  }
 
   process.once('SIGINT', shutdown);
   process.once('SIGTERM', shutdown);
   process.once('SIGQUIT', shutdown);
+}
+
+const DAEMON_PROBE_TIMEOUT_MS = 2_000;
+
+// Connect-only is not enough: a hung daemon still has its socket in listen(2), so the kernel accepts the
+// connection. Require a status response that reports this socket and a live pid, matching the client's liveness
+// contract, so a hung/dead/foreign listener falls through to rebind instead of stranding the caller.
+export async function isDaemonResponding(socketPath: string): Promise<boolean> {
+  const status = await probeDaemonStatus(socketPath);
+  if (!status || status.socketPath !== socketPath) {
+    return false;
+  }
+  return isProcessAlive(status.pid);
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+async function probeDaemonStatus(socketPath: string): Promise<StatusResult | null> {
+  return await new Promise<StatusResult | null>((resolve) => {
+    const probe = net.createConnection(socketPath);
+    let buffer = '';
+    let settled = false;
+    const finish = (status: StatusResult | null): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      probe.removeAllListeners();
+      probe.destroy();
+      resolve(status);
+    };
+    const parse = (): StatusResult | null => {
+      try {
+        const response = JSON.parse(buffer.trim()) as DaemonResponse<StatusResult>;
+        return response.ok && response.result ? response.result : null;
+      } catch {
+        return null;
+      }
+    };
+    probe.setTimeout(DAEMON_PROBE_TIMEOUT_MS, () => finish(null));
+    probe.once('connect', () => {
+      probe.write(JSON.stringify({ id: randomUUID(), method: 'status', params: {} } satisfies DaemonRequest));
+    });
+    probe.on('data', (chunk) => {
+      buffer += chunk.toString();
+      const status = parse();
+      if (status) {
+        finish(status);
+      }
+    });
+    probe.once('end', () => finish(parse()));
+    probe.once('error', () => finish(null));
+  });
 }
 
 async function prepareSocket(socketPath: string): Promise<void> {

--- a/src/daemon/host.ts
+++ b/src/daemon/host.ts
@@ -198,7 +198,7 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
         }
         return;
       }
-      await stopLiveDaemon(options.socketPath);
+      await stopLiveDaemon(options.socketPath, live.pid);
     }
     await prepareSocket(options.socketPath);
     await new Promise<void>((resolve, reject) => {
@@ -318,14 +318,14 @@ function normalizeLayers(
   return normalized.toSorted((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
 }
 
-async function stopLiveDaemon(socketPath: string): Promise<void> {
+async function stopLiveDaemon(socketPath: string, livePid: number): Promise<void> {
   const stopped = await sendDaemonStop(socketPath);
   if (!stopped) {
     throw new Error('Live daemon did not accept stop before rebinding.');
   }
   const deadline = Date.now() + 5_000;
   while (Date.now() < deadline) {
-    if (!(await probeLiveDaemon(socketPath))) {
+    if (!isProcessAlive(livePid)) {
       return;
     }
     await delay(100);

--- a/src/daemon/host.ts
+++ b/src/daemon/host.ts
@@ -191,8 +191,14 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
   let claimed = false;
   await withFileLock(`${options.metadataPath}.bind`, async () => {
     const live = await probeLiveDaemon(options.socketPath);
-    if (live && (await metadataMatches(options.metadataPath, live))) {
-      return;
+    if (live) {
+      if (daemonConfigMatches(live, configLayers, options.configPath, configMtimeMs)) {
+        if (!(await metadataMatches(options.metadataPath, live))) {
+          await writeJsonFile(options.metadataPath, metadataFromStatus(live, configLayers));
+        }
+        return;
+      }
+      await stopLiveDaemon(options.socketPath);
     }
     await prepareSocket(options.socketPath);
     await new Promise<void>((resolve, reject) => {
@@ -251,6 +257,124 @@ export async function metadataMatches(
   } catch {
     return false;
   }
+}
+
+function metadataFromStatus(
+  status: StatusResult,
+  fallbackConfigLayers: Array<{ path: string; mtimeMs: number | null }>
+): {
+  pid: number;
+  socketPath: string;
+  configPath: string;
+  configLayers?: StatusResult['configLayers'];
+  startedAt: number;
+  logPath: string | null;
+  configMtimeMs: number | null;
+} {
+  return {
+    pid: status.pid,
+    socketPath: status.socketPath,
+    configPath: status.configPath,
+    configLayers: status.configLayers && status.configLayers.length > 0 ? status.configLayers : fallbackConfigLayers,
+    startedAt: status.startedAt,
+    logPath: status.logPath ?? null,
+    configMtimeMs: status.configMtimeMs ?? null,
+  };
+}
+
+function daemonConfigMatches(
+  live: StatusResult,
+  currentLayers: Array<{ path: string; mtimeMs: number | null }>,
+  currentConfigPath: string,
+  currentConfigMtimeMs: number | null
+): boolean {
+  const liveLayers = normalizeLayers(
+    live.configLayers && live.configLayers.length > 0
+      ? live.configLayers
+      : [{ path: live.configPath, mtimeMs: live.configMtimeMs ?? null }]
+  );
+  const expectedLayers = normalizeLayers(
+    currentLayers.length > 0 ? currentLayers : [{ path: currentConfigPath, mtimeMs: currentConfigMtimeMs }]
+  );
+  if (liveLayers.length !== expectedLayers.length) {
+    return false;
+  }
+  return liveLayers.every((entry, index) => {
+    const expected = expectedLayers[index];
+    return Boolean(expected && entry.path === expected.path && entry.mtimeMs === expected.mtimeMs);
+  });
+}
+
+function normalizeLayers(
+  layers: Array<{ path: string; mtimeMs: number | null }>
+): Array<{ path: string; mtimeMs: number | null }> {
+  const normalized = layers.map((entry) => ({
+    path: path.isAbsolute(entry.path) ? entry.path : path.resolve(entry.path),
+    mtimeMs: entry.mtimeMs ?? null,
+  }));
+  if (normalized.length < 2) {
+    return normalized;
+  }
+  return normalized.toSorted((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+}
+
+async function stopLiveDaemon(socketPath: string): Promise<void> {
+  const stopped = await sendDaemonStop(socketPath);
+  if (!stopped) {
+    throw new Error('Live daemon did not accept stop before rebinding.');
+  }
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (!(await probeLiveDaemon(socketPath))) {
+      return;
+    }
+    await delay(100);
+  }
+  throw new Error('Live daemon did not stop before rebinding.');
+}
+
+async function sendDaemonStop(socketPath: string): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const request: DaemonRequest<'stop', Record<string, never>> = {
+      id: randomUUID(),
+      method: 'stop',
+      params: {},
+    };
+    const socket = net.createConnection(socketPath);
+    let buffer = '';
+    let settled = false;
+    const finish = (result: boolean): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(result);
+    };
+    socket.setTimeout(DAEMON_PROBE_TIMEOUT_MS, () => finish(false));
+    socket.once('connect', () => {
+      socket.write(JSON.stringify(request));
+    });
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString();
+    });
+    socket.once('end', () => {
+      try {
+        const response = JSON.parse(buffer.trim()) as DaemonResponse<boolean>;
+        finish(response.ok);
+      } catch {
+        finish(false);
+      }
+    });
+    socket.once('error', () => finish(false));
+  });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 function isProcessAlive(pid: number): boolean {

--- a/src/daemon/host.ts
+++ b/src/daemon/host.ts
@@ -7,6 +7,7 @@ import { readJsonFile, withFileLock, writeJsonFile } from '../fs-json.js';
 import { isKeepAliveServer } from '../lifecycle.js';
 import { createRuntime, type Runtime } from '../runtime.js';
 import { collectConfigLayers, statConfigMtime } from './config-layers.js';
+import { hashDaemonDefinitions } from './definition-hash.js';
 import {
   createLogContext,
   disposeLogContext,
@@ -60,6 +61,7 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
     rootDir: options.rootDir,
   });
   const keepAliveDefinitions = runtime.getDefinitions().filter(isKeepAliveServer);
+  const definitionHash = hashDaemonDefinitions(keepAliveDefinitions);
   if (keepAliveDefinitions.length === 0) {
     throw new Error('No MCP servers require keep-alive; daemon will not start.');
   }
@@ -164,6 +166,7 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
           startedAt,
           logPath: options.logPath ?? null,
           configMtimeMs,
+          definitionHash,
         },
         logContext,
         shutdown,
@@ -192,7 +195,7 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
   await withFileLock(`${options.metadataPath}.bind`, async () => {
     const live = await probeLiveDaemon(options.socketPath);
     if (live) {
-      if (daemonConfigMatches(live, configLayers, options.configPath, configMtimeMs)) {
+      if (daemonConfigMatches(live, configLayers, options.configPath, configMtimeMs, definitionHash)) {
         if (!(await metadataMatches(options.metadataPath, live))) {
           await writeJsonFile(options.metadataPath, metadataFromStatus(live, configLayers));
         }
@@ -216,6 +219,7 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
       startedAt: Date.now(),
       logPath: options.logPath ?? null,
       configMtimeMs,
+      definitionHash,
     });
     claimed = true;
   });
@@ -270,6 +274,7 @@ function metadataFromStatus(
   startedAt: number;
   logPath: string | null;
   configMtimeMs: number | null;
+  definitionHash?: string;
 } {
   return {
     pid: status.pid,
@@ -279,6 +284,7 @@ function metadataFromStatus(
     startedAt: status.startedAt,
     logPath: status.logPath ?? null,
     configMtimeMs: status.configMtimeMs ?? null,
+    definitionHash: status.definitionHash,
   };
 }
 
@@ -286,8 +292,12 @@ function daemonConfigMatches(
   live: StatusResult,
   currentLayers: Array<{ path: string; mtimeMs: number | null }>,
   currentConfigPath: string,
-  currentConfigMtimeMs: number | null
+  currentConfigMtimeMs: number | null,
+  currentDefinitionHash: string
 ): boolean {
+  if (live.definitionHash !== currentDefinitionHash) {
+    return false;
+  }
   const liveLayers = normalizeLayers(
     live.configLayers && live.configLayers.length > 0
       ? live.configLayers
@@ -469,6 +479,7 @@ async function handleSocketRequest(
     socketPath: string;
     startedAt: number;
     logPath: string | null;
+    definitionHash?: string;
   },
   logContext: LogContext,
   shutdown: () => Promise<void>,
@@ -504,6 +515,7 @@ async function processRequest(
     socketPath: string;
     startedAt: number;
     logPath: string | null;
+    definitionHash?: string;
   },
   logContext: LogContext,
   preParsedRequest?: DaemonRequest
@@ -659,6 +671,7 @@ async function processRequest(
           configPath: metadata.configPath,
           configLayers: metadata.configLayers,
           configMtimeMs: metadata.configMtimeMs,
+          definitionHash: metadata.definitionHash,
           socketPath: metadata.socketPath,
           logPath: metadata.logPath ?? undefined,
           servers: Array.from(managedServers.values()).map((def) => {
@@ -715,6 +728,7 @@ export async function __testProcessRequest(
     socketPath: string;
     startedAt: number;
     logPath: string | null;
+    definitionHash?: string;
   },
   logContext: LogContext,
   preParsedRequest?: DaemonRequest

--- a/src/daemon/protocol.ts
+++ b/src/daemon/protocol.ts
@@ -60,6 +60,7 @@ export interface StatusResult {
     readonly path: string;
     readonly mtimeMs: number | null;
   }>;
+  readonly definitionHash?: string;
   readonly socketPath: string;
   readonly logPath?: string;
   readonly servers: Array<{

--- a/tests/daemon-host.test.ts
+++ b/tests/daemon-host.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ServerDefinition } from '../src/config.js';
-import { __testProcessRequest } from '../src/daemon/host.js';
+import { __testProcessRequest, isDaemonResponding } from '../src/daemon/host.js';
 import type { DaemonRequest } from '../src/daemon/protocol.js';
 import type { Runtime } from '../src/runtime.js';
 
@@ -108,6 +113,78 @@ describe('daemon host request handling', () => {
       autoAuthorize: undefined,
       allowCachedAuth: false,
     });
+  });
+});
+
+// Unix-domain socket servers can't bind a filesystem path on Windows; the daemon uses named pipes there.
+const describeUnixSocket = process.platform === 'win32' ? describe.skip : describe;
+
+describeUnixSocket('isDaemonResponding', () => {
+  const servers: net.Server[] = [];
+  const connections: net.Socket[] = [];
+  const socketPaths: string[] = [];
+
+  function socketPath(): string {
+    const p = path.join(os.tmpdir(), `mcporter-probe-${randomUUID().slice(0, 8)}.sock`);
+    socketPaths.push(p);
+    return p;
+  }
+
+  function listen(server: net.Server, p: string): Promise<void> {
+    servers.push(server);
+    server.on('connection', (socket) => connections.push(socket));
+    return new Promise((resolve) => server.listen(p, () => resolve()));
+  }
+
+  afterEach(async () => {
+    for (const socket of connections.splice(0)) {
+      socket.destroy();
+    }
+    for (const server of servers.splice(0)) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+    for (const p of socketPaths.splice(0)) {
+      await fs.rm(p, { force: true }).catch(() => {});
+    }
+  });
+
+  function statusServer(result: Record<string, unknown>): net.Server {
+    return net.createServer((socket) => {
+      socket.on('data', () => socket.end(JSON.stringify({ id: '1', ok: true, result })));
+    });
+  }
+
+  it('returns true when the socket answers status with a matching socket and live pid', async () => {
+    const p = socketPath();
+    await listen(statusServer({ pid: process.pid, socketPath: p }), p);
+    expect(await isDaemonResponding(p)).toBe(true);
+  });
+
+  it('returns false when the socket accepts but never responds (hung daemon)', async () => {
+    const p = socketPath();
+    await listen(
+      net.createServer(() => {
+        // Accept the connection but never reply, mimicking a daemon whose event loop is blocked.
+      }),
+      p
+    );
+    expect(await isDaemonResponding(p)).toBe(false);
+  }, 5_000);
+
+  it('returns false when status reports a different socket (foreign listener)', async () => {
+    const p = socketPath();
+    await listen(statusServer({ pid: process.pid, socketPath: '/some/other/daemon.sock' }), p);
+    expect(await isDaemonResponding(p)).toBe(false);
+  });
+
+  it('returns false when status reports a dead pid', async () => {
+    const p = socketPath();
+    await listen(statusServer({ pid: 2_147_483_646, socketPath: p }), p);
+    expect(await isDaemonResponding(p)).toBe(false);
+  });
+
+  it('returns false when nothing is listening', async () => {
+    expect(await isDaemonResponding(socketPath())).toBe(false);
   });
 });
 

--- a/tests/daemon-host.test.ts
+++ b/tests/daemon-host.test.ts
@@ -3,9 +3,9 @@ import fs from 'node:fs/promises';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ServerDefinition } from '../src/config.js';
-import { __testProcessRequest, isDaemonResponding } from '../src/daemon/host.js';
+import { __testProcessRequest, isDaemonResponding, metadataMatches } from '../src/daemon/host.js';
 import type { DaemonRequest } from '../src/daemon/protocol.js';
 import type { Runtime } from '../src/runtime.js';
 
@@ -116,7 +116,6 @@ describe('daemon host request handling', () => {
   });
 });
 
-// Unix-domain socket servers can't bind a filesystem path on Windows; the daemon uses named pipes there.
 const describeUnixSocket = process.platform === 'win32' ? describe.skip : describe;
 
 describeUnixSocket('isDaemonResponding', () => {
@@ -163,9 +162,7 @@ describeUnixSocket('isDaemonResponding', () => {
   it('returns false when the socket accepts but never responds (hung daemon)', async () => {
     const p = socketPath();
     await listen(
-      net.createServer(() => {
-        // Accept the connection but never reply, mimicking a daemon whose event loop is blocked.
-      }),
+      net.createServer((socket) => socket.pause()),
       p
     );
     expect(await isDaemonResponding(p)).toBe(false);
@@ -185,6 +182,38 @@ describeUnixSocket('isDaemonResponding', () => {
 
   it('returns false when nothing is listening', async () => {
     expect(await isDaemonResponding(socketPath())).toBe(false);
+  });
+});
+
+describe('metadataMatches', () => {
+  let metadataPath: string;
+  const live = { pid: 4321, socketPath: '/tmp/daemon.sock' };
+
+  beforeEach(async () => {
+    metadataPath = path.join(os.tmpdir(), `mcporter-meta-${randomUUID().slice(0, 8)}.json`);
+  });
+
+  afterEach(async () => {
+    await fs.rm(metadataPath, { force: true }).catch(() => {});
+  });
+
+  it('matches when pid and socket agree', async () => {
+    await fs.writeFile(metadataPath, JSON.stringify({ pid: 4321, socketPath: '/tmp/daemon.sock' }), 'utf8');
+    expect(await metadataMatches(metadataPath, live)).toBe(true);
+  });
+
+  it('does not match a different pid', async () => {
+    await fs.writeFile(metadataPath, JSON.stringify({ pid: 9999, socketPath: '/tmp/daemon.sock' }), 'utf8');
+    expect(await metadataMatches(metadataPath, live)).toBe(false);
+  });
+
+  it('does not match when metadata is missing', async () => {
+    expect(await metadataMatches(metadataPath, live)).toBe(false);
+  });
+
+  it('does not match when metadata is corrupt', async () => {
+    await fs.writeFile(metadataPath, '{ not json', 'utf8');
+    expect(await metadataMatches(metadataPath, live)).toBe(false);
   });
 });
 

--- a/tests/daemon.integration.test.ts
+++ b/tests/daemon.integration.test.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process';
+import { type ChildProcess, execFile, spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import os from 'node:os';
@@ -170,6 +170,55 @@ await new Promise((resolve) => {
       expect(logContents).toContain('callTool success server=daemon-e2e tool=next_value');
     } finally {
       await cli(['daemon', 'stop']).catch(() => {});
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 40_000);
+
+  it('refuses duplicate binds when foreground starts race outside the client lock', async () => {
+    await ensureDistBuilt();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-bind-'));
+    const scriptPath = path.join(tempDir, 'bind-server.mjs');
+    const configPath = path.join(tempDir, 'mcporter.bind.json');
+
+    const serverSource = `import { McpServer } from '${MCP_SERVER_MODULE}';
+import { StdioServerTransport } from '${STDIO_SERVER_MODULE}';
+const server = new McpServer({ name: 'bind-e2e', version: '1.0.0' });
+server.registerTool('ping', { title: 'ping', description: 'ping', inputSchema: {} }, async () => ({
+  content: [{ type: 'text', text: 'pong' }],
+}));
+await server.connect(new StdioServerTransport());
+await new Promise(() => {});
+`;
+    await fs.writeFile(scriptPath, serverSource, 'utf8');
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        mcpServers: {
+          'bind-e2e': { description: 'bind race server', command: 'node', args: [scriptPath], lifecycle: 'keep-alive' },
+        },
+      }),
+      'utf8'
+    );
+
+    const children: ChildProcess[] = [];
+    try {
+      await runCli(['daemon', 'stop'], configPath).catch(() => {});
+      for (let i = 0; i < 4; i++) {
+        children.push(
+          spawn(process.execPath, [CLI_ENTRY, '--config', configPath, 'daemon', 'start', '--foreground'], {
+            env: { ...process.env, MCPORTER_NO_FORCE_EXIT: '1' },
+            stdio: 'ignore',
+          })
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, 4_000));
+      const alive = children.filter((child) => child.exitCode === null && child.signalCode === null);
+      expect(alive).toHaveLength(1);
+    } finally {
+      for (const child of children) {
+        child.kill('SIGKILL');
+      }
+      await runCli(['daemon', 'stop'], configPath).catch(() => {});
       await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 40_000);

--- a/tests/daemon.integration.test.ts
+++ b/tests/daemon.integration.test.ts
@@ -29,6 +29,20 @@ async function readFileWithRetries(filePath: string, retries = 20, delayMs = 100
   throw lastError ?? new Error(`Failed to read ${filePath}`);
 }
 
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForExit(child: ChildProcess, retries = 50, delayMs = 100): Promise<void> {
+  for (let attempt = 0; attempt < retries; attempt++) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      return;
+    }
+    await delay(delayMs);
+  }
+  throw new Error(`Process ${child.pid ?? '<unknown>'} did not exit.`);
+}
+
 async function ensureDistBuilt(): Promise<void> {
   try {
     await fs.access(CLI_ENTRY);
@@ -223,7 +237,7 @@ await new Promise(() => {});
     }
   }, 40_000);
 
-  it('rebinds when a live daemon owns the socket but metadata is missing', async () => {
+  it('repairs metadata when a live daemon owns the socket and metadata is missing', async () => {
     await ensureDistBuilt();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-meta-'));
     const scriptPath = path.join(tempDir, 'meta-server.mjs');
@@ -270,7 +284,73 @@ await new Promise(() => {});
       await fs.rm(metadataPath, { force: true });
 
       const replacement = startForeground();
-      await new Promise((resolve) => setTimeout(resolve, 5_000));
+      await waitForExit(replacement);
+
+      const ownerPid = JSON.parse(await readFileWithRetries(metadataPath, 50)).pid as number;
+      expect(ownerPid).toBe(first.pid);
+      expect(first.exitCode).toBeNull();
+    } finally {
+      for (const child of children) {
+        child.kill('SIGKILL');
+      }
+      await runCli(['daemon', 'stop'], configPath, { MCPORTER_DAEMON_METADATA: metadataPath }).catch(() => {});
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 40_000);
+
+  it('stops a live daemon with stale config before rebinding', async () => {
+    await ensureDistBuilt();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-stale-'));
+    const scriptPath = path.join(tempDir, 'stale-server.mjs');
+    const configPath = path.join(tempDir, 'mcporter.stale.json');
+    const metadataPath = path.join(tempDir, 'daemon.json');
+
+    const serverSource = `import { McpServer } from '${MCP_SERVER_MODULE}';
+import { StdioServerTransport } from '${STDIO_SERVER_MODULE}';
+const server = new McpServer({ name: 'stale-e2e', version: '1.0.0' });
+server.registerTool('ping', { title: 'ping', description: 'ping', inputSchema: {} }, async () => ({
+  content: [{ type: 'text', text: 'pong' }],
+}));
+await server.connect(new StdioServerTransport());
+await new Promise(() => {});
+`;
+    await fs.writeFile(scriptPath, serverSource, 'utf8');
+    const writeConfig = async (description: string): Promise<void> => {
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            'stale-e2e': { description, command: 'node', args: [scriptPath], lifecycle: 'keep-alive' },
+          },
+        }),
+        'utf8'
+      );
+    };
+    await writeConfig('stale server v1');
+
+    const env = { ...process.env, MCPORTER_NO_FORCE_EXIT: '1', MCPORTER_DAEMON_METADATA: metadataPath };
+    const children: ChildProcess[] = [];
+    const startForeground = (): ChildProcess => {
+      const child = spawn(process.execPath, [CLI_ENTRY, '--config', configPath, 'daemon', 'start', '--foreground'], {
+        env,
+        stdio: 'ignore',
+      });
+      children.push(child);
+      return child;
+    };
+
+    try {
+      const first = startForeground();
+      const firstPid = JSON.parse(await readFileWithRetries(metadataPath, 50)).pid as number;
+      expect(firstPid).toBe(first.pid);
+
+      await delay(20);
+      await writeConfig('stale server v2');
+      const staleConfigTime = new Date(Date.now() + 5_000);
+      await fs.utimes(configPath, staleConfigTime, staleConfigTime);
+
+      const replacement = startForeground();
+      await waitForExit(first);
 
       const ownerPid = JSON.parse(await readFileWithRetries(metadataPath, 50)).pid as number;
       expect(ownerPid).toBe(replacement.pid);

--- a/tests/daemon.integration.test.ts
+++ b/tests/daemon.integration.test.ts
@@ -363,4 +363,107 @@ await new Promise(() => {});
       await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 40_000);
+
+  it('stops a live daemon when imported root definitions change', async () => {
+    await ensureDistBuilt();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-root-'));
+    const scriptPath = path.join(tempDir, 'root-server.mjs');
+    const configPath = path.join(tempDir, 'mcporter.root.json');
+    const metadataPath = path.join(tempDir, 'daemon.json');
+    const socketPath = path.join(tempDir, 'daemon.sock');
+    const rootA = path.join(tempDir, 'root-a');
+    const rootB = path.join(tempDir, 'root-b');
+    const fakeHome = path.join(tempDir, 'home');
+
+    const serverSource = `import { McpServer } from '${MCP_SERVER_MODULE}';
+import { StdioServerTransport } from '${STDIO_SERVER_MODULE}';
+const server = new McpServer({ name: 'root-e2e', version: '1.0.0' });
+server.registerTool('ping', { title: 'ping', description: 'ping', inputSchema: {} }, async () => ({
+  content: [{ type: 'text', text: 'pong' }],
+}));
+await server.connect(new StdioServerTransport());
+await new Promise(() => {});
+`;
+    await fs.writeFile(scriptPath, serverSource, 'utf8');
+    await fs.writeFile(configPath, JSON.stringify({ imports: ['cursor'], mcpServers: {} }), 'utf8');
+
+    const writeCursorImport = async (rootDir: string, name: string): Promise<void> => {
+      const importPath = path.join(rootDir, '.cursor', 'mcp.json');
+      await fs.mkdir(path.dirname(importPath), { recursive: true });
+      await fs.writeFile(
+        importPath,
+        JSON.stringify({
+          mcpServers: {
+            [name]: {
+              description: name,
+              command: 'node',
+              args: [scriptPath],
+              lifecycle: 'keep-alive',
+            },
+          },
+        }),
+        'utf8'
+      );
+    };
+    await writeCursorImport(rootA, 'root-a-e2e');
+    await writeCursorImport(rootB, 'root-b-e2e');
+
+    const env = {
+      ...process.env,
+      MCPORTER_NO_FORCE_EXIT: '1',
+      MCPORTER_DAEMON_METADATA: metadataPath,
+      MCPORTER_DAEMON_SOCKET: socketPath,
+      MCPORTER_KEEPALIVE: '*',
+      HOME: fakeHome,
+      XDG_CONFIG_HOME: path.join(tempDir, 'xdg'),
+      APPDATA: path.join(tempDir, 'appdata'),
+    };
+    const children: ChildProcess[] = [];
+    const startForeground = (rootDir: string): ChildProcess => {
+      const child = spawn(
+        process.execPath,
+        [CLI_ENTRY, '--config', configPath, '--root', rootDir, 'daemon', 'start', '--foreground'],
+        {
+          env,
+          stdio: 'ignore',
+        }
+      );
+      children.push(child);
+      return child;
+    };
+
+    try {
+      const first = startForeground(rootA);
+      const firstMetadata = JSON.parse(await readFileWithRetries(metadataPath, 50)) as {
+        pid: number;
+        definitionHash?: string;
+      };
+      expect(firstMetadata.pid).toBe(first.pid);
+      expect(typeof firstMetadata.definitionHash).toBe('string');
+
+      const replacement = startForeground(rootB);
+      await waitForExit(first);
+
+      const replacementMetadata = JSON.parse(await readFileWithRetries(metadataPath, 50)) as {
+        pid: number;
+        definitionHash?: string;
+      };
+      expect(replacementMetadata.pid).toBe(replacement.pid);
+      expect(replacementMetadata.definitionHash).not.toBe(firstMetadata.definitionHash);
+      expect(replacement.exitCode).toBeNull();
+    } finally {
+      for (const child of children) {
+        child.kill('SIGKILL');
+      }
+      await runCli(['daemon', 'stop'], configPath, {
+        MCPORTER_DAEMON_METADATA: metadataPath,
+        MCPORTER_DAEMON_SOCKET: socketPath,
+        MCPORTER_KEEPALIVE: '*',
+        HOME: fakeHome,
+        XDG_CONFIG_HOME: path.join(tempDir, 'xdg'),
+        APPDATA: path.join(tempDir, 'appdata'),
+      }).catch(() => {});
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 40_000);
 });

--- a/tests/daemon.integration.test.ts
+++ b/tests/daemon.integration.test.ts
@@ -222,4 +222,65 @@ await new Promise(() => {});
       await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 40_000);
+
+  it('rebinds when a live daemon owns the socket but metadata is missing', async () => {
+    await ensureDistBuilt();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-meta-'));
+    const scriptPath = path.join(tempDir, 'meta-server.mjs');
+    const configPath = path.join(tempDir, 'mcporter.meta.json');
+    const metadataPath = path.join(tempDir, 'daemon.json');
+
+    const serverSource = `import { McpServer } from '${MCP_SERVER_MODULE}';
+import { StdioServerTransport } from '${STDIO_SERVER_MODULE}';
+const server = new McpServer({ name: 'meta-e2e', version: '1.0.0' });
+server.registerTool('ping', { title: 'ping', description: 'ping', inputSchema: {} }, async () => ({
+  content: [{ type: 'text', text: 'pong' }],
+}));
+await server.connect(new StdioServerTransport());
+await new Promise(() => {});
+`;
+    await fs.writeFile(scriptPath, serverSource, 'utf8');
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        mcpServers: {
+          'meta-e2e': { description: 'meta server', command: 'node', args: [scriptPath], lifecycle: 'keep-alive' },
+        },
+      }),
+      'utf8'
+    );
+
+    // Pin only the metadata path (not the socket, to stay under the unix socket length limit).
+    const env = { ...process.env, MCPORTER_NO_FORCE_EXIT: '1', MCPORTER_DAEMON_METADATA: metadataPath };
+    const children: ChildProcess[] = [];
+    const startForeground = (): ChildProcess => {
+      const child = spawn(process.execPath, [CLI_ENTRY, '--config', configPath, 'daemon', 'start', '--foreground'], {
+        env,
+        stdio: 'ignore',
+      });
+      children.push(child);
+      return child;
+    };
+
+    try {
+      const first = startForeground();
+      const firstPid = JSON.parse(await readFileWithRetries(metadataPath, 50)).pid as number;
+      expect(firstPid).toBe(first.pid);
+
+      await fs.rm(metadataPath, { force: true });
+
+      const replacement = startForeground();
+      await new Promise((resolve) => setTimeout(resolve, 5_000));
+
+      const ownerPid = JSON.parse(await readFileWithRetries(metadataPath, 50)).pid as number;
+      expect(ownerPid).toBe(replacement.pid);
+      expect(replacement.exitCode).toBeNull();
+    } finally {
+      for (const child of children) {
+        child.kill('SIGKILL');
+      }
+      await runCli(['daemon', 'stop'], configPath, { MCPORTER_DAEMON_METADATA: metadataPath }).catch(() => {});
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 40_000);
 });


### PR DESCRIPTION
## Summary

Completes the fix for #191. Its client-side pieces (PID reconciliation and a
spawn mutex in `DaemonClient`) landed, but the proposed host-side guard ("on
daemon start, if a live daemon already owns the socket, do not start a second
one") did not. Explicit and launchd-driven starts (`mcporter daemon start`,
`daemon start --foreground`, detached children) bypass `DaemonClient` entirely
and call `runDaemonHost` directly, so each one unlinks and rebinds the socket,
leaving the previous daemon alive but unreachable. #191's own headline repro
(racing `daemon start --foreground`) still reproduces on current `main`.

This adds the host-side guard.

## What's Included

- `src/daemon/host.ts`
  - Before binding, probe whether a live daemon already owns the socket: it must
    answer a `status` request, report this socket path, and have a live pid. A
    bare connect is not enough, since a hung daemon still has its socket in
    `listen(2)` and the kernel accepts the connection.
  - Skip binding only when on-disk metadata already matches that live daemon's
    pid and socket, which is the same readiness contract `DaemonClient` enforces,
    so a skip can never strand a client. Otherwise rebind (replacing a hung,
    dead, foreign, or metadata-orphaned owner and writing correct metadata),
    which is what `main` does today. Corrupt or missing metadata is treated as
    non-matching.
  - Bind under a dedicated `${metadataPath}.bind` lock, separate from the
    client's metadata lock, so a client awaiting readiness while holding that
    lock cannot deadlock the bind.

## Repro and results

Minimal manual repro (any keep-alive config at ./mcporter.json):

    mcporter --config ./mcporter.json daemon stop
    mcporter --config ./mcporter.json daemon start --foreground &
    mcporter --config ./mcporter.json daemon start --foreground &
    sleep 3
    ps -ax | grep -c "[d]aemon start --foreground"   # main: 2, this branch: 1

Reproduced on a second macOS machine against current `main`. Counts are surviving
daemon processes after the race settles.

| Scenario | `main` | This branch |
| --- | --- | --- |
| #191 repro recipe (race 2x `daemon start --foreground`) | 2 | 1 |
| `daemon start --foreground` x5, 5 trials | 2 every trial | 1 every trial |
| detached `daemon start` x5, 3 trials | up to 3 | 1 every trial |
| implicit cold-start (`mcporter list` x10), 3 trials | 1 | 1 |

A frozen daemon (SIGSTOP, socket still listening) is reclaimed by a replacement
in ~2s, and a live daemon whose metadata is missing is also rebound rather than
stranding the caller, so the guard does not break stale or hung-socket recovery.

## Tests

- `tests/daemon-host.test.ts`: probe (live / hung / foreign-socket / dead-pid /
  no-listener) and `metadataMatches` (match / mismatch / missing / corrupt).
- `tests/daemon.integration.test.ts`: a 4-way `daemon start --foreground` race
  asserting one survivor (fails on `main`), and a missing-metadata case asserting
  the replacement rebinds and the client recovers.

Full suite: 717 passed, 3 skipped (124 files). `pnpm check` clean.

## Relation to #191

#191 prevents redundant launch decisions from `DaemonClient` callers. This
prevents redundant binds from any start path, including the direct `daemon start
--foreground` in #191's own repro. `client.ts` is unchanged.
