### PR TITLE
feat(runtime): re-export RuntimeOptions from package entry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,14 @@ export type { CommandSpec, ServerDefinition } from './config.js';
 export { loadServerDefinitions } from './config.js';
 export type { CallResult, ConnectionIssue, ImageContent } from './result-utils.js';
 export { createCallResult, describeConnectionIssue, wrapCallResult } from './result-utils.js';
-export type { CallOptions, ListToolsOptions, Runtime, RuntimeLogger, ServerToolInfo } from './runtime.js';
+export type {
+  CallOptions,
+  ListToolsOptions,
+  Runtime,
+  RuntimeLogger,
+  RuntimeOptions,
+  ServerToolInfo,
+} from './runtime.js';
 export { callOnce, createRuntime } from './runtime.js';
 export type { GeneratedRuntimeContext } from './generated-daemon-runtime.js';
 export { createGeneratedKeepAliveRuntime } from './generated-daemon-runtime.js';


### PR DESCRIPTION
## Summary

- Re-exports `RuntimeOptions` from `src/index.ts` so consumers wrapping `createRuntime` can name the parameter type directly instead of reaching for `Parameters<typeof createRuntime>[0]`.
- Reformats the existing single-line `from './runtime.js'` type export into a multi-line block so future additions stay reviewable.

Strictly additive. `RuntimeOptions`'s transitive references (`ServerDefinition`, `RuntimeLogger`) are already public from `src/index.ts`, so this is a true one-liner with no cascading exports.

Closes #200.

## Test plan

- `pnpm check` (format + lint + typecheck) — green
- `pnpm test` (706 tests, 3 skipped) — green
- Verified consumers can `import type { RuntimeOptions } from 'mcporter'` (typecheck via tsgo).