### PR TITLE
docs(readme): mention callOnce disableOAuth for headless callers

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ const result = await callOnce({
 console.log(result); // raw MCP envelope
 ```
 
-`callOnce` automatically discovers the selected server (including Cursor/Claude/Codex/Windsurf/OpenCode/VS Code imports), handles OAuth prompts, and closes transports when it finishes. It is ideal for manual runs or wiring MCPorter directly into an agent tool hook.
+`callOnce` automatically discovers the selected server (including Cursor/Claude/Codex/Windsurf/OpenCode/VS Code imports), handles OAuth prompts, and closes transports when it finishes. It is ideal for manual runs or wiring MCPorter directly into an agent tool hook. In headless contexts, pass `disableOAuth: true` to suppress interactive OAuth and rely on cached tokens only — the library equivalent of the CLI's `--no-oauth` flag.
 
 ## Compose Automations with the Runtime
 


### PR DESCRIPTION
## Summary

README follow-up requested in #201: the `callOnce` section (the README's recommended entry point for "agent tool hook" / headless use) still implied interactive OAuth was unavoidable. #198 shipped the `disableOAuth` option on `callOnce` and updated `docs/mcp.md` / `docs/cli-reference.md`, but not the README.

- Documents `disableOAuth: true` on the `callOnce` README section and cross-references the CLI's `--no-oauth` flag, matching the phrasing in `docs/mcp.md`.

## Proof

Rendered README section after the change (GitHub-rendered on the PR branch):
https://github.com/feniix/mcporter/blob/docs/readme-callonce-disable-oauth/README.md#one-shot-calls-from-code

Copied rendered output of the updated paragraph:

> `callOnce` automatically discovers the selected server (including Cursor/Claude/Codex/Windsurf/OpenCode/VS Code imports), handles OAuth prompts, and closes transports when it finishes. It is ideal for manual runs or wiring MCPorter directly into an agent tool hook. In headless contexts, pass `disableOAuth: true` to suppress interactive OAuth and rely on cached tokens only — the library equivalent of the CLI's `--no-oauth` flag.

## Test plan

- [x] Docs-only change; rendered Markdown reviewed (see Proof above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)