### PR TITLE
[codex] isolate config tests and remove legacy release archive

### DIFF
--- a/dist-bun/mcporter-macos-arm64-v0.6.2.tar.gz.sha256
+++ b/dist-bun/mcporter-macos-arm64-v0.6.2.tar.gz.sha256
@@ -1,1 +1,0 @@
-f10d87f12794933b1f0d9b793e955342905a19fdc79a89df2e18d9654f7ba9f2  mcporter-macos-arm64-v0.6.2.tar.gz

--- a/tests/cli-config-command.test.ts
+++ b/tests/cli-config-command.test.ts
@@ -344,6 +344,8 @@ describe('mcporter config CLI', () => {
   });
 
   it('suggests close matches when get cannot auto-correct', async () => {
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(configPath, JSON.stringify({ mcpServers: {}, imports: [] }), 'utf8');
     await handleConfigCli(buildOptions({ configPath }), ['add', 'shadcn', 'https://shadcn.io/api/mcp']);
     const logs: string[] = [];
     const spy = vi.spyOn(console, 'log').mockImplementation(captureLog(logs));


### PR DESCRIPTION
## Summary

Isolates config CLI tests from the operator home data directory and removes the checked-in legacy `v0.6.2` macOS release archive now that the same archive and checksum exist on the GitHub release.

The branch was rebased onto current `origin/main` (`37391ce`, `mcporter@0.12.0`) before landing validation.

## Goal (Cherny pattern)
SUCCESS_CRITERION: MCPorter config CLI tests pass with isolated config/data homes, the redundant checked-in release archive is removed without losing release evidence, and the local `mcporter` CLI reports the npm latest version.
VERIFY_COMMAND:    pnpm exec vitest run tests/cli-config-command.test.ts && pnpm run check && mcporter --version
ROLLBACK_COMMAND:  git revert HEAD --no-edit
TIMEBOX:           PT2H

## Validation

- GitHub release readback for `v0.6.2` confirmed `mcporter-macos-arm64-v0.6.2.tar.gz` and `mcporter-macos-arm64-v0.6.2.tar.gz.sha256` are both uploaded release assets.
- Release asset digest for `mcporter-macos-arm64-v0.6.2.tar.gz`: `sha256:f10d87f12794933b1f0d9b793e955342905a19fdc79a89df2e18d9654f7ba9f2`.
- `npm view mcporter version` returned `0.12.0`.
- `/opt/homebrew/bin/mcporter --version` and `mcporter --version` both returned `0.12.0` after `npm install -g --prefix /opt/homebrew mcporter@latest`.
- `pnpm exec vitest run tests/cli-config-command.test.ts` passed on rebased PR head `1373c7e`.
- `pnpm run check` passed on rebased PR head `1373c7e`.
- `~/.agents/skills/codex-prepush/codex-prepush.sh origin/main` passed with no HIGH/CRITICAL findings.

## Proof

```text
$ pnpm exec vitest run tests/cli-config-command.test.ts
RUN v4.1.8 /Users/louisherman/Projects/mcporter
PASS tests/cli-config-command.test.ts (22 tests) 59ms

Test Files  1 passed (1)
Tests       22 passed (22)
Duration    344ms
exit: 0
```

```text
$ pnpm run check
> mcporter@0.12.0 check /Users/louisherman/Projects/mcporter
> pnpm format:check && pnpm lint:oxlint && pnpm typecheck

All matched files use the correct format.
Found 0 warnings and 0 errors.
tsgo --project tsconfig.json --noEmit
exit: 0
```

```text
$ npm view mcporter version
0.12.0
$ /opt/homebrew/bin/mcporter --version
0.12.0
$ mcporter --version
0.12.0
```

```text
$ ~/.agents/skills/codex-prepush/codex-prepush.sh origin/main
codex-prepush: no HIGH/CRITICAL findings - push allowed
exit: 0
```

## Notes

Submitted from the `LDMB123/mcporter` fork because direct push to `openclaw/mcporter` is not permitted for this token.
