### PR TITLE
fix(oauth): degrade to re-auth on corrupt credential cache instead of crashing

### DIFF
--- a/src/oauth-persistence.ts
+++ b/src/oauth-persistence.ts
@@ -152,7 +152,7 @@ class DirectoryPersistence implements OAuthPersistence {
   }
 
   async readTokens(): Promise<OAuthTokens | undefined> {
-    return readJsonFile<OAuthTokens>(this.tokenPath);
+    return this.readJsonOrUndefined<OAuthTokens>(this.tokenPath);
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
@@ -162,7 +162,7 @@ class DirectoryPersistence implements OAuthPersistence {
   }
 
   async readClientInfo(): Promise<OAuthClientInformationMixed | undefined> {
-    return readJsonFile<OAuthClientInformationMixed>(this.clientInfoPath);
+    return this.readJsonOrUndefined<OAuthClientInformationMixed>(this.clientInfoPath);
   }
 
   async saveClientInfo(info: OAuthClientInformationMixed): Promise<void> {
@@ -187,7 +187,23 @@ class DirectoryPersistence implements OAuthPersistence {
   }
 
   async readState(): Promise<string | undefined> {
-    return readJsonFile<string>(this.statePath);
+    return this.readJsonOrUndefined<string>(this.statePath);
+  }
+
+  // A present-but-corrupt cache file (truncated or malformed JSON) means "no
+  // usable credentials": degrade to re-auth instead of crashing the connection,
+  // mirroring VaultPersistence and the daemon/server-proxy readers. Genuine I/O
+  // faults still propagate (readJsonFile re-throws everything except ENOENT).
+  private async readJsonOrUndefined<T>(filePath: string): Promise<T | undefined> {
+    try {
+      return await readJsonFile<T>(filePath);
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) {
+        throw error;
+      }
+      this.logger?.debug?.(`Ignoring corrupt OAuth cache file ${filePath}: ${error.message}`);
+      return undefined;
+    }
   }
 
   async saveState(value: string): Promise<void> {

--- a/src/oauth-persistence.ts
+++ b/src/oauth-persistence.ts
@@ -187,13 +187,19 @@ class DirectoryPersistence implements OAuthPersistence {
   }
 
   async readState(): Promise<string | undefined> {
-    return this.readJsonOrUndefined<string>(this.statePath);
+    // Deliberately NOT corrupt-tolerant: a corrupt OAuth state must fail the
+    // flow closed. Returning undefined here would skip the CSRF state check on
+    // the authorization callback (see oauth.ts), so only the credential caches
+    // (tokens/client) degrade to re-auth.
+    return readJsonFile<string>(this.statePath);
   }
 
-  // A present-but-corrupt cache file (truncated or malformed JSON) means "no
-  // usable credentials": degrade to re-auth instead of crashing the connection,
+  // A present-but-corrupt credential cache (tokens/client) means "no usable
+  // credentials": degrade to re-auth instead of crashing the connection,
   // mirroring VaultPersistence and the daemon/server-proxy readers. Genuine I/O
   // faults still propagate (readJsonFile re-throws everything except ENOENT).
+  // OAuth state is intentionally excluded (see readState) so its CSRF check
+  // still fails closed on a corrupt state file.
   private async readJsonOrUndefined<T>(filePath: string): Promise<T | undefined> {
     try {
       return await readJsonFile<T>(filePath);

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -150,8 +150,8 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
     // previous client registration is cached with a different redirect URI the
     // auth server will reject the request with `invalid_redirect_uri`.  Clear
     // the stale registration so the next flow re-registers with the new URI.
-    // Wrapped in try/catch so persistence errors (malformed JSON, permission
-    // issues) close the already-bound callback server instead of leaking it.
+    // Wrapped in try/catch so non-recoverable persistence errors (for example,
+    // permission issues) close the already-bound callback server instead of leaking it.
     if (usesDynamicPort) {
       try {
         const cachedClient = await persistence.readClientInfo();

--- a/tests/oauth-persistence.test.ts
+++ b/tests/oauth-persistence.test.ts
@@ -44,6 +44,28 @@ describe('oauth persistence', () => {
     await Promise.all(tempRoots.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
   });
 
+  it('degrades to undefined when a cached credential file is corrupt instead of throwing', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-corrupt-'));
+    tempRoots.push(tmp);
+    homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmp);
+    hasSpy = true;
+
+    const cacheDir = path.join(tmp, 'cache');
+    await fs.mkdir(cacheDir, { recursive: true });
+    // Truncated / malformed credential files, e.g. an interrupted write.
+    await fs.writeFile(path.join(cacheDir, 'tokens.json'), '{ "access_token": "part');
+    await fs.writeFile(path.join(cacheDir, 'client.json'), 'not json at all');
+    await fs.writeFile(path.join(cacheDir, 'state.txt'), '"unterminated');
+
+    const persistence = await buildOAuthPersistence(mkDef('service', cacheDir));
+
+    // A corrupt cache must read as "no usable credentials" (degrade to re-auth),
+    // not surface a SyntaxError that crashes the connection.
+    expect(await persistence.readTokens()).toBeUndefined();
+    expect(await persistence.readClientInfo()).toBeUndefined();
+    expect(await persistence.readState()).toBeUndefined();
+  });
+
   it('prefers explicit tokenCacheDir before vault when reading tokens', async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-'));
     tempRoots.push(tmp);

--- a/tests/oauth-persistence.test.ts
+++ b/tests/oauth-persistence.test.ts
@@ -44,7 +44,7 @@ describe('oauth persistence', () => {
     await Promise.all(tempRoots.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
   });
 
-  it('degrades to undefined when a cached credential file is corrupt instead of throwing', async () => {
+  it('degrades corrupt credential caches to undefined but keeps corrupt OAuth state failing closed', async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-corrupt-'));
     tempRoots.push(tmp);
     homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmp);
@@ -59,11 +59,13 @@ describe('oauth persistence', () => {
 
     const persistence = await buildOAuthPersistence(mkDef('service', cacheDir));
 
-    // A corrupt cache must read as "no usable credentials" (degrade to re-auth),
-    // not surface a SyntaxError that crashes the connection.
+    // Corrupt credential caches must read as "no usable credentials" (degrade to
+    // re-auth), not surface a SyntaxError that crashes the connection.
     expect(await persistence.readTokens()).toBeUndefined();
     expect(await persistence.readClientInfo()).toBeUndefined();
-    expect(await persistence.readState()).toBeUndefined();
+    // OAuth state must NOT silently degrade: returning undefined would skip the
+    // CSRF state check on callback (oauth.ts). It must fail closed.
+    await expect(persistence.readState()).rejects.toThrow(SyntaxError);
   });
 
   it('prefers explicit tokenCacheDir before vault when reading tokens', async () => {

--- a/tests/oauth-session.test.ts
+++ b/tests/oauth-session.test.ts
@@ -148,10 +148,9 @@ describe('FileOAuthClientProvider session lifecycle', () => {
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('clearing stale client registration'));
   });
 
-  it('closes the callback server when stale-client reads throw', async () => {
+  it('closes the callback server when stale-client reads have I/O errors', async () => {
     const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
     tempDirs.push(tokenCacheDir);
-    await fs.writeFile(path.join(tokenCacheDir, 'client.json'), '{not-valid-json', 'utf8');
     const definition: ServerDefinition = {
       name: 'test-oauth-read-failure',
       description: 'Test OAuth server',
@@ -165,6 +164,8 @@ describe('FileOAuthClientProvider session lifecycle', () => {
       error: vi.fn(),
     };
 
+    const readError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    const readFileSpy = vi.spyOn(fs, 'readFile').mockRejectedValueOnce(readError);
     const originalCreateServer = http.createServer.bind(http);
     const createdServers: http.Server[] = [];
     const createServerSpy = vi.spyOn(http, 'createServer').mockImplementation((...args) => {
@@ -174,11 +175,12 @@ describe('FileOAuthClientProvider session lifecycle', () => {
     });
 
     try {
-      await expect(createOAuthSession(definition, logger)).rejects.toThrow(SyntaxError);
+      await expect(createOAuthSession(definition, logger)).rejects.toMatchObject({ code: 'EACCES' });
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(createdServers).toHaveLength(1);
       expect(createdServers[0]?.listening).toBe(false);
     } finally {
+      readFileSpy.mockRestore();
       createServerSpy.mockRestore();
     }
   });


### PR DESCRIPTION
## Problem

When a cached OAuth credential file under an explicit `tokenCacheDir` (or a legacy per-server cache during migration) is present but **corrupt** — truncated or malformed JSON, e.g. from an interrupted write — `DirectoryPersistence`'s readers let the `JSON.parse` `SyntaxError` propagate. Through `CompositePersistence` that crashes the MCP connection instead of treating the file as "no usable credentials" and degrading to re-auth.

## Root cause

`DirectoryPersistence.readTokens()` and `readClientInfo()` call `readJsonFile`, which maps only `ENOENT` to `undefined` and re-throws everything else (including `SyntaxError`).

This is asymmetric with the rest of the codebase, which already treats a corrupt credential file as recoverable:

- `VaultPersistence` / `readVaultState` (`oauth-vault.ts`) catches `SyntaxError` and rebuilds (`needsRepair`)
- `daemon/host.ts` and `server-proxy.ts` wrap their reads in catch-all handlers

These `DirectoryPersistence` readers were the lone exceptions.

## Fix

Route the **credential** readers (`readTokens`, `readClientInfo`) through a small private helper (`readJsonOrUndefined`) that maps **only** `SyntaxError` → `undefined`; genuine I/O faults still propagate. Mirrors the existing `VaultPersistence` pattern (`if (!(error instanceof SyntaxError)) throw error`).

**OAuth `state` is deliberately excluded.** A corrupt `state.txt` must fail the flow *closed*: `oauth.ts` only enforces the callback state check when `expectedState` is truthy, so degrading state to `undefined` would skip the CSRF check (thanks @chatgpt-codex-connector for catching this on the first pass). `readState()` therefore keeps throwing on corrupt input. `readJsonFile` itself is also left untouched, since the vault relies on it throwing `SyntaxError` to distinguish corrupt-from-missing for its repair path.

## Verification

Run locally (Node 22, vitest):

- New regression test in `tests/oauth-persistence.test.ts` writes corrupt `tokens.json` / `client.json` / `state.txt` and asserts `readTokens()` / `readClientInfo()` resolve to `undefined` **while `readState()` rejects with `SyntaxError`** (CSRF fail-closed).
  - The credential-degrade assertions fail on `main` (`SyntaxError: Unterminated string in JSON`); they pass with the fix.
- Full `oauth-persistence` suite: **35/35 passing**.
- `tsgo --noEmit`, `oxfmt --check`, `oxlint --type-aware`: clean.

Fixes #207.
