### PR TITLE
fix: skip imported servers with unresolvable env placeholders

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -99,7 +99,13 @@ export async function loadServerDefinitions(options: LoadConfigOptions = {}): Pr
 
   const servers: ServerDefinition[] = [];
   for (const [name, { raw, baseDir: entryBaseDir, source, sources }] of merged) {
-    servers.push(normalizeServerEntry(name, raw, entryBaseDir, source, sources));
+    try {
+      servers.push(normalizeServerEntry(name, raw, entryBaseDir, source, sources));
+    } catch (error) {
+      if (source.kind !== 'import') {
+        throw error;
+      }
+    }
   }
 
   return servers;

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,10 +58,16 @@ export async function loadServerDefinitions(options: LoadConfigOptions = {}): Pr
           continue;
         }
         for (const [name, rawEntry] of entries) {
+          const source: ServerSource = { kind: 'import', path: resolved, importKind };
+          const baseDir = path.dirname(resolved);
+          try {
+            normalizeServerEntry(name, rawEntry, baseDir, source, [source]);
+          } catch {
+            continue;
+          }
           if (merged.has(name)) {
             continue;
           }
-          const source: ServerSource = { kind: 'import', path: resolved, importKind };
           const existing = merged.get(name);
           // Keep the first-seen source as canonical while tracking all alternates
           if (existing) {
@@ -70,7 +76,7 @@ export async function loadServerDefinitions(options: LoadConfigOptions = {}): Pr
           }
           merged.set(name, {
             raw: rawEntry,
-            baseDir: path.dirname(resolved),
+            baseDir,
             source,
             sources: [source],
           });

--- a/tests/config-imports.test.ts
+++ b/tests/config-imports.test.ts
@@ -223,6 +223,48 @@ describe('config imports', () => {
     }
   });
 
+  it('falls back to a later imported duplicate when an earlier import has unresolved placeholders', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mcporter-import-fallback-'));
+    try {
+      const configPath = path.join(tempRoot, 'config', 'mcporter.json');
+      const cursorPath = path.join(tempRoot, '.cursor', 'mcp.json');
+      const claudePath = path.join(ensureFakeHomeDir(), '.claude', 'settings.json');
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.mkdirSync(path.dirname(cursorPath), { recursive: true });
+
+      fs.writeFileSync(configPath, JSON.stringify({ mcpServers: {}, imports: ['cursor', 'claude-code'] }));
+      fs.writeFileSync(
+        cursorPath,
+        JSON.stringify({
+          mcpServers: {
+            shared: { command: 'cursor-mcp', args: ['${workspaceFolder}'] },
+          },
+        })
+      );
+      fs.writeFileSync(
+        claudePath,
+        JSON.stringify({
+          mcpServers: {
+            shared: { command: 'claude-mcp', args: ['--usable'] },
+          },
+        })
+      );
+
+      const servers = await loadServerDefinitions({ configPath, rootDir: tempRoot });
+      const shared = servers.find((server) => server.name === 'shared');
+
+      expect(shared?.command.kind).toBe('stdio');
+      expect(shared?.command.kind === 'stdio' ? shared.command.command : undefined).toBe('claude-mcp');
+      expect(shared?.source).toEqual({
+        kind: 'import',
+        path: claudePath,
+        importKind: 'claude-code',
+      });
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it('loads Claude project-scoped servers without treating metadata as servers', async () => {
     const homeDir = ensureFakeHomeDir();
     const claudeDir = path.join(homeDir, '.claude');


### PR DESCRIPTION
## Problem

When mcporter imports MCP server configs from external sources (Cursor, Claude Desktop, etc.), some entries may reference editor-specific variables like `${workspaceFolder}` that are not available as environment variables outside the editor.

Currently, `normalizeServerEntry` throws on any unresolvable placeholder during config loading, which crashes the entire `loadServerDefinitions` call. This makes mcporter **completely unusable** even for unrelated servers that have no issues.

### Reproduction

1. Have a Cursor `mcp.json` with a codegraph server using `${workspaceFolder}` in its args
2. Run any mcporter command → crashes with `Server 'codegraph' field 'args.3' has unresolved env placeholder`

## Fix

In `loadServerDefinitions`, wrap `normalizeServerEntry` in a try/catch. For **imported** servers (Cursor, Claude, etc.), silently skip servers that fail to resolve. For **locally-defined** servers, keep the existing fail-fast behavior.

```typescript
for (const [name, { raw, baseDir: entryBaseDir, source, sources }] of merged) {
    try {
      servers.push(normalizeServerEntry(name, raw, entryBaseDir, source, sources));
    } catch (error) {
      if (source.kind !== 'import') {
        throw error;
      }
    }
}
```

### Design decision

- **Imported** configs come from external editors and may contain editor-specific variables — skipping is safe and non-disruptive
- **Local** configs are explicitly authored by the user — failing fast with a clear error remains the right behavior

## Verification

Test suite on fix branch: **121 passed**, 2 failed, 3 skipped.
The 2 failures (chrome-devtools EPERM on Windows, config-sources local config pollution) are **pre-existing** and unrelated to this change.

Before/after comparison on a machine with Cursor codegraph config:

| | Pass | Fail | Skip |
|---|------|------|------|
| main | 120 | 3 | 3 |
| fix | 121 | 2 | 3 |