### PR TITLE
fix: flush stdout before forced exit to avoid 64KB pipe truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [0.12.2] - Unreleased
 
-- Nothing yet.
+### CLI
+
+- Prevent large piped CLI output from being truncated during forced shutdown, while keeping stalled readers bounded and treating broken pipes as normal shell behavior. (Issue #214, thanks @badmoo)
 
 ## [0.12.1] - 2026-06-26
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,11 @@ function handleStdioError(error: Error): void {
   throw error;
 }
 
+function installStdioErrorHandlers(): void {
+  process.stdout.on('error', handleStdioError);
+  process.stderr.on('error', handleStdioError);
+}
+
 function flushWriteStreamForExit(stream: NodeJS.WriteStream): Promise<void> {
   return new Promise((resolve) => {
     if (!stream.writable || stream.destroyed || stream.writableEnded) {
@@ -390,8 +395,6 @@ async function closeRuntimeAfterCommand(
     const shouldForceExit = !disableForceExit || process.env.MCPORTER_FORCE_EXIT === '1';
     const scheduleForcedExit = () => {
       if (shouldForceExit) {
-        process.stdout.on('error', handleStdioError);
-        process.stderr.on('error', handleStdioError);
         setTimeout(flushStdioThenForceExit, FORCE_EXIT_GRACE_MS);
       }
     };
@@ -418,6 +421,7 @@ async function main(): Promise<void> {
 }
 
 if (process.env.MCPORTER_DISABLE_AUTORUN !== '1') {
+  installStdioErrorHandlers();
   main().catch((error) => {
     if (error instanceof CliUsageError) {
       logError(error.message);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,39 @@ const FORCE_EXIT_GRACE_MS = 50;
 const STDOUT_FLUSH_TIMEOUT_MS = 2000;
 const DAEMON_FAST_PATH_SERVERS = new Set(['chrome-devtools', 'mobile-mcp', 'playwright']);
 
+function ignoreStreamError(): void {}
+
+function flushWriteStreamForExit(stream: NodeJS.WriteStream): Promise<void> {
+  return new Promise((resolve) => {
+    if (!stream.writable || stream.destroyed || stream.writableEnded) {
+      resolve();
+      return;
+    }
+    stream.write('', () => {
+      resolve();
+    });
+  });
+}
+
+function flushStdioThenForceExit(): void {
+  let exited = false;
+  const exit = () => {
+    if (exited) {
+      return;
+    }
+    exited = true;
+    process.exit(process.exitCode ?? 0);
+  };
+  const fallback = setTimeout(exit, STDOUT_FLUSH_TIMEOUT_MS);
+  fallback.unref?.();
+  void Promise.allSettled([flushWriteStreamForExit(process.stdout), flushWriteStreamForExit(process.stderr)]).then(
+    () => {
+      clearTimeout(fallback);
+      exit();
+    }
+  );
+}
+
 export async function handleAuth(
   ...args: Parameters<typeof import('./cli/auth-command.js').handleAuth>
 ): ReturnType<typeof import('./cli/auth-command.js').handleAuth> {
@@ -352,24 +385,9 @@ async function closeRuntimeAfterCommand(
     const shouldForceExit = !disableForceExit || process.env.MCPORTER_FORCE_EXIT === '1';
     const scheduleForcedExit = () => {
       if (shouldForceExit) {
-        setTimeout(() => {
-          let exited = false;
-          const exit = () => {
-            if (exited) {
-              return;
-            }
-            exited = true;
-            process.exit(process.exitCode ?? 0);
-          };
-          // Fallback deadline so a consumer that keeps stdout open but stops
-          // reading cannot block the forced exit indefinitely.
-          const fallback = setTimeout(exit, STDOUT_FLUSH_TIMEOUT_MS);
-          fallback.unref?.();
-          process.stdout.write('', () => {
-            clearTimeout(fallback);
-            exit();
-          });
-        }, FORCE_EXIT_GRACE_MS);
+        process.stdout.on('error', ignoreStreamError);
+        process.stderr.on('error', ignoreStreamError);
+        setTimeout(flushStdioThenForceExit, FORCE_EXIT_GRACE_MS);
       }
     };
     if (DEBUG_HANG) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -352,7 +352,9 @@ async function closeRuntimeAfterCommand(
     const scheduleForcedExit = () => {
       if (shouldForceExit) {
         setTimeout(() => {
-          process.exit(process.exitCode ?? 0);
+          process.stdout.write('', () => {
+            process.exit(process.exitCode ?? 0);
+          });
         }, FORCE_EXIT_GRACE_MS);
       }
     };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,12 @@ const FORCE_EXIT_GRACE_MS = 50;
 const STDOUT_FLUSH_TIMEOUT_MS = 2000;
 const DAEMON_FAST_PATH_SERVERS = new Set(['chrome-devtools', 'mobile-mcp', 'playwright']);
 
-function ignoreStreamError(): void {}
+function handleStdioError(error: Error): void {
+  if ((error as NodeJS.ErrnoException).code === 'EPIPE') {
+    return;
+  }
+  throw error;
+}
 
 function flushWriteStreamForExit(stream: NodeJS.WriteStream): Promise<void> {
   return new Promise((resolve) => {
@@ -385,8 +390,8 @@ async function closeRuntimeAfterCommand(
     const shouldForceExit = !disableForceExit || process.env.MCPORTER_FORCE_EXIT === '1';
     const scheduleForcedExit = () => {
       if (shouldForceExit) {
-        process.stdout.on('error', ignoreStreamError);
-        process.stderr.on('error', ignoreStreamError);
+        process.stdout.on('error', handleStdioError);
+        process.stderr.on('error', handleStdioError);
         setTimeout(flushStdioThenForceExit, FORCE_EXIT_GRACE_MS);
       }
     };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ export { extractListFlags } from './cli/list-flags.js';
 export { resolveCallTimeout } from './cli/timeouts.js';
 
 const FORCE_EXIT_GRACE_MS = 50;
+const STDOUT_FLUSH_TIMEOUT_MS = 2000;
 const DAEMON_FAST_PATH_SERVERS = new Set(['chrome-devtools', 'mobile-mcp', 'playwright']);
 
 export async function handleAuth(
@@ -352,8 +353,21 @@ async function closeRuntimeAfterCommand(
     const scheduleForcedExit = () => {
       if (shouldForceExit) {
         setTimeout(() => {
-          process.stdout.write('', () => {
+          let exited = false;
+          const exit = () => {
+            if (exited) {
+              return;
+            }
+            exited = true;
             process.exit(process.exitCode ?? 0);
+          };
+          // Fallback deadline so a consumer that keeps stdout open but stops
+          // reading cannot block the forced exit indefinitely.
+          const fallback = setTimeout(exit, STDOUT_FLUSH_TIMEOUT_MS);
+          fallback.unref?.();
+          process.stdout.write('', () => {
+            clearTimeout(fallback);
+            exit();
           });
         }, FORCE_EXIT_GRACE_MS);
       }

--- a/tests/cli-stdout-pipe-truncation.integration.test.ts
+++ b/tests/cli-stdout-pipe-truncation.integration.test.ts
@@ -47,8 +47,10 @@ function runCliThroughPipe(args: string[], configPath: string, outFile: string):
     '>',
     shellQuote(outFile),
   ].join(' ');
+  // Use bash with `pipefail` so a non-zero exit from the CLI (the first pipeline
+  // stage) propagates, instead of being masked by the trailing `cat`.
   return new Promise((resolve) => {
-    execFile('sh', ['-c', command], { cwd: process.cwd(), env: process.env }, (error) => {
+    execFile('bash', ['-c', `set -o pipefail; ${command}`], { cwd: process.cwd(), env: process.env }, (error) => {
       resolve(typeof error?.code === 'number' ? error.code : 0);
     });
   });

--- a/tests/cli-stdout-pipe-truncation.integration.test.ts
+++ b/tests/cli-stdout-pipe-truncation.integration.test.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import os from 'node:os';
@@ -140,4 +140,27 @@ await server.connect(transport);
     // The piped output must match the complete file output byte-for-byte.
     expect(pipeBytes).toBe(fileBytes);
   }, 30000);
+
+  it('still force-exits when stdout is piped to a consumer that never reads', async () => {
+    // A consumer that keeps stdout open but never reads fills the pipe buffer
+    // and blocks the drain callback. The fallback deadline must still terminate
+    // the process instead of hanging indefinitely.
+    const start = Date.now();
+    const child = spawn(
+      process.execPath,
+      [CLI_ENTRY, '--config', configPath, 'call', 'large-output.big', '--output', 'json'],
+      { cwd: process.cwd(), env: process.env, stdio: ['ignore', 'pipe', 'ignore'] }
+    );
+    // Intentionally never consume stdout so the OS pipe buffer stays full.
+    child.stdout.pause();
+
+    const code = await new Promise<number>((resolve) => {
+      child.on('exit', (exitCode) => resolve(exitCode ?? -1));
+    });
+    const elapsed = Date.now() - start;
+
+    expect(code).toBe(0);
+    // Terminates via the fallback deadline (~2s) rather than hanging.
+    expect(elapsed).toBeLessThan(8000);
+  }, 20000);
 });

--- a/tests/cli-stdout-pipe-truncation.integration.test.ts
+++ b/tests/cli-stdout-pipe-truncation.integration.test.ts
@@ -165,4 +165,34 @@ await server.connect(transport);
     // Terminates via the fallback deadline (~2s) rather than hanging.
     expect(elapsed).toBeLessThan(8000);
   }, 20000);
+
+  it('does not crash when a piped consumer closes stdout early (EPIPE)', async () => {
+    const command = [
+      shellQuote(process.execPath),
+      shellQuote(CLI_ENTRY),
+      '--config',
+      shellQuote(configPath),
+      'call',
+      'large-output.big',
+      '--output',
+      'json',
+      '|',
+      'head -c 100',
+      '>',
+      '/dev/null',
+    ].join(' ');
+    const result = await new Promise<{ code: number; stderr: string }>((resolve) => {
+      execFile(
+        'bash',
+        ['-c', `set -o pipefail; ${command}`],
+        { cwd: process.cwd(), env: process.env },
+        (error, _stdout, stderr) => {
+          resolve({ code: typeof error?.code === 'number' ? error.code : 0, stderr });
+        }
+      );
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).not.toMatch(/EPIPE|Unhandled 'error'/);
+  }, 20000);
 });

--- a/tests/cli-stdout-pipe-truncation.integration.test.ts
+++ b/tests/cli-stdout-pipe-truncation.integration.test.ts
@@ -75,6 +75,46 @@ function runCliToFile(args: string[], configPath: string, outFile: string): Prom
   });
 }
 
+describe('mcporter broken pipe handling', () => {
+  it('handles asynchronous EPIPE before runtime cleanup begins', async () => {
+    await ensureDistBuilt();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-early-epipe-'));
+    const preloadPath = path.join(tempDir, 'inject-epipe.cjs');
+    await fs.writeFile(
+      preloadPath,
+      `const originalWrite = process.stdout.write.bind(process.stdout);
+let injected = false;
+process.stdout.write = (...args) => {
+  const result = originalWrite(...args);
+  if (!injected) {
+    injected = true;
+    process.nextTick(() => {
+      process.stdout.emit(
+        'error',
+        Object.assign(new Error('simulated asynchronous broken pipe'), { code: 'EPIPE' })
+      );
+    });
+  }
+  return result;
+};
+`,
+      'utf8'
+    );
+
+    try {
+      const result = await new Promise<{ code: number; stderr: string }>((resolve) => {
+        execFile(process.execPath, ['--require', preloadPath, CLI_ENTRY, '--version'], (error, _stdout, stderr) => {
+          resolve({ code: typeof error?.code === 'number' ? error.code : 0, stderr });
+        });
+      });
+      expect(result.code).toBe(0);
+      expect(result.stderr).toBe('');
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+});
+
 // POSIX-only: relies on `sh`, `sleep`, `cat` and POSIX async pipe semantics.
 describe.skipIf(process.platform === 'win32')('mcporter stdout pipe truncation on forced exit', () => {
   let tempDir: string;

--- a/tests/cli-stdout-pipe-truncation.integration.test.ts
+++ b/tests/cli-stdout-pipe-truncation.integration.test.ts
@@ -1,0 +1,143 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const CLI_ENTRY = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
+const testRequire = createRequire(import.meta.url);
+const MCP_SERVER_MODULE = pathToFileURL(testRequire.resolve('@modelcontextprotocol/sdk/server/mcp.js')).href;
+const STDIO_SERVER_MODULE = pathToFileURL(testRequire.resolve('@modelcontextprotocol/sdk/server/stdio.js')).href;
+
+// Payload comfortably larger than the OS pipe buffer (~64KB) so that a forced
+// exit which does not wait for stdout to drain would truncate the output.
+const LARGE_TEXT_BYTES = 200_000;
+
+async function ensureDistBuilt(): Promise<void> {
+  try {
+    await fs.access(CLI_ENTRY);
+  } catch {
+    throw new Error('dist/cli.js is missing; run `pnpm build` before invoking this integration test directly.');
+  }
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+// Run the CLI with stdout connected to a real pipe whose reader is briefly
+// delayed before it starts draining. This is the faithful reproduction of the
+// truncation bug: on POSIX, pipe writes are async, so while the reader sleeps
+// the kernel pipe buffer fills and the remaining bytes stay queued in libuv. A
+// forced `process.exit()` that does not wait for stdout to drain then drops
+// them. The delay (500ms) stays under any reasonable flush window, so the fixed
+// binary still completes once the reader resumes.
+function runCliThroughPipe(args: string[], configPath: string, outFile: string): Promise<number> {
+  const command = [
+    shellQuote(process.execPath),
+    shellQuote(CLI_ENTRY),
+    '--config',
+    shellQuote(configPath),
+    ...args.map(shellQuote),
+    '|',
+    '(sleep 0.5; cat)',
+    '>',
+    shellQuote(outFile),
+  ].join(' ');
+  return new Promise((resolve) => {
+    execFile('sh', ['-c', command], { cwd: process.cwd(), env: process.env }, (error) => {
+      resolve(typeof error?.code === 'number' ? error.code : 0);
+    });
+  });
+}
+
+// Run the CLI with stdout redirected straight to a file (synchronous writes on
+// POSIX) to obtain the complete, untruncated reference output.
+function runCliToFile(args: string[], configPath: string, outFile: string): Promise<number> {
+  const command = [
+    shellQuote(process.execPath),
+    shellQuote(CLI_ENTRY),
+    '--config',
+    shellQuote(configPath),
+    ...args.map(shellQuote),
+    '>',
+    shellQuote(outFile),
+  ].join(' ');
+  return new Promise((resolve) => {
+    execFile('sh', ['-c', command], { cwd: process.cwd(), env: process.env }, (error) => {
+      resolve(typeof error?.code === 'number' ? error.code : 0);
+    });
+  });
+}
+
+// POSIX-only: relies on `sh`, `sleep`, `cat` and POSIX async pipe semantics.
+describe.skipIf(process.platform === 'win32')('mcporter stdout pipe truncation on forced exit', () => {
+  let tempDir: string;
+  let configPath: string;
+
+  beforeAll(async () => {
+    await ensureDistBuilt();
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-pipe-truncation-'));
+    const serverScriptPath = path.join(tempDir, 'large-output-server.mjs');
+    configPath = path.join(tempDir, 'config.json');
+
+    await fs.writeFile(
+      serverScriptPath,
+      `import { McpServer } from ${JSON.stringify(MCP_SERVER_MODULE)};
+import { StdioServerTransport } from ${JSON.stringify(STDIO_SERVER_MODULE)};
+
+const server = new McpServer({ name: 'large-output', version: '1.0.0' });
+
+server.registerTool(
+  'big',
+  { title: 'Big', description: 'Return a large text payload', inputSchema: {} },
+  async () => ({ content: [{ type: 'text', text: 'x'.repeat(${LARGE_TEXT_BYTES}) }] })
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+`,
+      'utf8'
+    );
+
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        { mcpServers: { 'large-output': { command: process.execPath, args: [serverScriptPath] } } },
+        null,
+        2
+      ),
+      'utf8'
+    );
+  });
+
+  afterAll(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('does not truncate large output when stdout is a pipe', async () => {
+    const args = ['call', 'large-output.big', '--output', 'json'];
+    const fileOut = path.join(tempDir, 'file-output.json');
+    const pipeOut = path.join(tempDir, 'pipe-output.json');
+
+    const fileCode = await runCliToFile(args, configPath, fileOut);
+    const pipeCode = await runCliThroughPipe(args, configPath, pipeOut);
+    expect(fileCode).toBe(0);
+    expect(pipeCode).toBe(0);
+
+    const fileBytes = (await fs.readFile(fileOut)).byteLength;
+    const pipeBytes = (await fs.readFile(pipeOut)).byteLength;
+
+    // Sanity: the reference output must exceed the kernel pipe buffer, otherwise
+    // the test cannot exercise the truncation path.
+    expect(fileBytes).toBeGreaterThan(70_000);
+    // The bug manifested as the piped output being clamped to the pipe buffer
+    // size (exactly 65536 bytes in the reported case).
+    expect(pipeBytes).not.toBe(65_536);
+    // The piped output must match the complete file output byte-for-byte.
+    expect(pipeBytes).toBe(fileBytes);
+  }, 30000);
+});


### PR DESCRIPTION
## Summary

Fixes #214.

Large command output piped to another process was silently truncated at the kernel pipe buffer size (~64KB). Writing the same output to a file (`> out.json`) produced the complete result.

### Root cause

After a command completes, `closeRuntimeAfterCommand()` (`src/cli.ts`) schedules a forced `process.exit()` ~50ms later (force-exit is on by default), **without waiting for `stdout` to drain**. On POSIX, writes to a pipe are **asynchronous** — `console.log(JSON.stringify(...))` only enqueues the data in libuv's write buffer. Once the kernel pipe buffer (~64KB) is full, the remaining bytes stay queued in libuv; the forced `process.exit()` then discards them. File writes are synchronous, which is why `> file` was unaffected.

> The existing `FORCE_EXIT_GRACE_MS = 50` (from #145 / #151) only *delays* the exit by a fixed window; it does not wait for the buffer to actually drain, so outputs larger than the pipe buffer were still truncated.

## Fix

Flush `stdout` before the forced exit, **bounded by a fallback deadline** so a consumer that keeps stdout open but never reads cannot block the exit indefinitely (preserving the anti-hang guarantee). No-op for TTY/file stdout, where writes are synchronous.

```ts
const STDOUT_FLUSH_TIMEOUT_MS = 2000;

const scheduleForcedExit = () => {
  if (shouldForceExit) {
    setTimeout(() => {
      let exited = false;
      const exit = () => {
        if (exited) return;
        exited = true;
        process.exit(process.exitCode ?? 0);
      };
      const fallback = setTimeout(exit, STDOUT_FLUSH_TIMEOUT_MS);
      fallback.unref?.();
      process.stdout.write('', () => {
        clearTimeout(fallback);
        exit();
      });
    }, FORCE_EXIT_GRACE_MS);
  }
};
```

## Behavior proof

A `large-output` stdio MCP server returns a ~200KB text result. Running through a delayed pipe reader (`| (sleep 0.5; cat) | wc -c`) vs a file redirect:

```
=== BEFORE FIX (src/cli.ts @ origin/main) ===
  > file (redirect)        : 200074 bytes
  | (sleep 0.5; cat)|wc -c :  65536 bytes   <- TRUNCATED at the pipe buffer

=== AFTER FIX ===
  > file (redirect)        : 200074 bytes
  | (sleep 0.5; cat)|wc -c : 200074 bytes   <- COMPLETE (matches file)
```

Stalled-reader (anti-hang) check: with stdout piped to a consumer that keeps the fd open but never reads, the CLI still force-exits via the fallback deadline in ~2.25s (code 0) instead of hanging.

## Tests

Adds `tests/cli-stdout-pipe-truncation.integration.test.ts` (POSIX-only, gated with `describe.skipIf(process.platform === 'win32')` since it relies on `sh`/`sleep`/`cat`):

- `does not truncate large output when stdout is a pipe` — asserts the piped output matches the complete file output byte-for-byte (fails without the fix at `65536`).
- `still force-exits when stdout is piped to a consumer that never reads` — spawns the CLI with a paused (non-reading) stdout consumer and asserts the process still exits well within the timeout.

Green gate: `build`, `typecheck`, `lint:oxlint`, `oxfmt --check` all pass; existing `tests/cli-force-exit-behavior.integration.test.ts` still passes.
