### PR TITLE
Fix configured HTTP call selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### CLI
 
 - Prevent large piped CLI output from being truncated during forced shutdown, while keeping stalled readers bounded and treating broken pipes as normal shell behavior. (Issue #214, thanks @badmoo)
+- Resolve configured and ad-hoc HTTP tool selectors consistently so targeted list and call commands keep server names separate from MCP tool names. (Issue #218, thanks @xinFu3576 and @TurboTheTurtle)
 
 ## [0.12.1] - 2026-06-26
 

--- a/src/cli/call-command.ts
+++ b/src/cli/call-command.ts
@@ -138,6 +138,16 @@ async function normalizeParsedCallArguments(
       parsed.selector = undefined;
     }
   }
+  if (ephemeralSpec?.httpUrl && parsed.selector && !looksLikeHttpUrl(parsed.selector)) {
+    const selector = splitServerToolSelector(parsed.selector);
+    if (selector) {
+      if (!ephemeralSpec.name) {
+        nameHints.push(selector.server);
+      }
+      parsed.tool ??= selector.tool;
+      parsed.selector = undefined;
+    }
+  }
 
   const prepared = await prepareEphemeralServerTarget({
     runtime,
@@ -314,6 +324,17 @@ function resolveCallTarget(
   }
 
   return { server, tool };
+}
+
+function splitServerToolSelector(selector: string): { server: string; tool: string } | undefined {
+  const dotIndex = selector.indexOf('.');
+  if (dotIndex <= 0 || dotIndex === selector.length - 1) {
+    return undefined;
+  }
+  return {
+    server: selector.slice(0, dotIndex),
+    tool: selector.slice(dotIndex + 1),
+  };
 }
 
 async function enforceSchemaAwareArgumentTypes(

--- a/src/cli/call-command.ts
+++ b/src/cli/call-command.ts
@@ -131,13 +131,6 @@ async function normalizeParsedCallArguments(
     parsed.server = undefined;
   }
 
-  if (ephemeralSpec?.httpUrl && !ephemeralSpec.name && parsed.tool) {
-    const candidate = parsed.selector && !looksLikeHttpUrl(parsed.selector) ? parsed.selector : undefined;
-    if (candidate) {
-      nameHints.push(candidate);
-      parsed.selector = undefined;
-    }
-  }
   if (ephemeralSpec?.httpUrl && parsed.selector && !looksLikeHttpUrl(parsed.selector)) {
     const selector = splitServerToolSelector(parsed.selector);
     if (selector) {
@@ -145,6 +138,11 @@ async function normalizeParsedCallArguments(
         nameHints.push(selector.server);
       }
       parsed.tool ??= selector.tool;
+      parsed.selector = undefined;
+    } else if (parsed.tool) {
+      if (!ephemeralSpec.name) {
+        nameHints.push(parsed.selector);
+      }
       parsed.selector = undefined;
     }
   }

--- a/tests/cli-call-execution.test.ts
+++ b/tests/cli-call-execution.test.ts
@@ -364,6 +364,35 @@ describe('CLI call execution behavior', () => {
     logSpy.mockRestore();
   });
 
+  it('uses the server prefix as the ad-hoc name when --tool overrides a qualified selector', async () => {
+    const httpUrl = 'http://127.0.0.1:18060/mcp';
+    const { handleCall } = await cliModulePromise;
+    const { runtime, callTool, registerDefinition } = createRuntimeStub({});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handleCall(runtime, [
+      'xhs.selector_tool',
+      '--http-url',
+      httpUrl,
+      '--allow-http',
+      '--tool',
+      'check_login_status',
+    ]);
+
+    expect(callTool).toHaveBeenCalledWith(
+      'xhs',
+      'check_login_status',
+      expect.objectContaining({
+        args: {},
+      })
+    );
+    expect(registerDefinition).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'xhs' }),
+      expect.objectContaining({ overwrite: true })
+    );
+    logSpy.mockRestore();
+  });
+
   it('honors explicit literal dotted tool names for named ad-hoc HTTP servers', async () => {
     const httpUrl = 'http://127.0.0.1:18060/mcp';
     const { handleCall } = await cliModulePromise;

--- a/tests/cli-call-execution.test.ts
+++ b/tests/cli-call-execution.test.ts
@@ -292,6 +292,104 @@ describe('CLI call execution behavior', () => {
     logSpy.mockRestore();
   });
 
+  it('calls configured HTTP servers by server.tool selector', async () => {
+    const { handleCall } = await cliModulePromise;
+    const definition: ServerDefinition = {
+      name: 'xhs',
+      command: { kind: 'http', url: new URL('http://127.0.0.1:18060/mcp') },
+      source: { kind: 'local', path: '<test>' },
+    };
+    const { runtime, callTool, registerDefinition } = createRuntimeStub(
+      {
+        xhs: [{ name: 'check_login_status', inputSchema: { type: 'object', properties: {} } }],
+      },
+      { definitions: [definition] }
+    );
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handleCall(runtime, ['xhs.check_login_status']);
+
+    expect(callTool).toHaveBeenCalledWith(
+      'xhs',
+      'check_login_status',
+      expect.objectContaining({
+        args: {},
+      })
+    );
+    expect(registerDefinition).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
+  it('splits server.tool selectors before calling ad-hoc HTTP servers', async () => {
+    const httpUrl = 'http://127.0.0.1:18060/mcp';
+    const { handleCall } = await cliModulePromise;
+    const { runtime, callTool, registerDefinition } = createRuntimeStub({});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handleCall(runtime, ['xhs.check_login_status', '--http-url', httpUrl, '--allow-http']);
+
+    expect(callTool).toHaveBeenCalledWith(
+      'xhs',
+      'check_login_status',
+      expect.objectContaining({
+        args: {},
+      })
+    );
+    expect(registerDefinition).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'xhs' }),
+      expect.objectContaining({ overwrite: true })
+    );
+    logSpy.mockRestore();
+  });
+
+  it('splits server.tool selectors when ad-hoc HTTP servers also use --name', async () => {
+    const httpUrl = 'http://127.0.0.1:18060/mcp';
+    const { handleCall } = await cliModulePromise;
+    const { runtime, callTool, registerDefinition } = createRuntimeStub({});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handleCall(runtime, ['xhs.check_login_status', '--http-url', httpUrl, '--allow-http', '--name', 'xhs']);
+
+    expect(callTool).toHaveBeenCalledWith(
+      'xhs',
+      'check_login_status',
+      expect.objectContaining({
+        args: {},
+      })
+    );
+    expect(registerDefinition).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'xhs' }),
+      expect.objectContaining({ overwrite: true })
+    );
+    logSpy.mockRestore();
+  });
+
+  it('honors explicit literal dotted tool names for named ad-hoc HTTP servers', async () => {
+    const httpUrl = 'http://127.0.0.1:18060/mcp';
+    const { handleCall } = await cliModulePromise;
+    const { runtime, callTool } = createRuntimeStub({});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handleCall(runtime, [
+      '--http-url',
+      httpUrl,
+      '--allow-http',
+      '--name',
+      'xhs',
+      '--tool',
+      'xhs.check_login_status',
+    ]);
+
+    expect(callTool).toHaveBeenCalledWith(
+      'xhs',
+      'xhs.check_login_status',
+      expect.objectContaining({
+        args: {},
+      })
+    );
+    logSpy.mockRestore();
+  });
+
   it('aborts long-running tools when the timeout elapses', async () => {
     vi.useFakeTimers();
     try {
@@ -448,6 +546,7 @@ function createRuntimeStub(
   runtime: Awaited<ReturnType<(typeof import('../src/runtime.js'))['createRuntime']>>;
   callTool: ReturnType<typeof vi.fn>;
   listTools: ReturnType<typeof vi.fn>;
+  registerDefinition: ReturnType<typeof vi.fn>;
 } {
   const definitions = new Map<string, ServerDefinition>();
   for (const entry of options.definitions ?? []) {
@@ -462,6 +561,9 @@ function createRuntimeStub(
     return tools;
   });
   const close = vi.fn().mockResolvedValue(undefined);
+  const registerDefinition = vi.fn().mockImplementation((definition: ServerDefinition) => {
+    definitions.set(definition.name, definition);
+  });
   const runtime = {
     getDefinitions: () => [...definitions.values()],
     getDefinition: vi.fn().mockImplementation((name: string) => {
@@ -471,12 +573,10 @@ function createRuntimeStub(
       }
       return definition;
     }),
-    registerDefinition: vi.fn().mockImplementation((definition: ServerDefinition) => {
-      definitions.set(definition.name, definition);
-    }),
+    registerDefinition,
     listTools,
     callTool,
     close,
   } as unknown as Awaited<ReturnType<(typeof import('../src/runtime.js'))['createRuntime']>>;
-  return { runtime, callTool, listTools };
+  return { runtime, callTool, listTools, registerDefinition };
 }

--- a/tests/cli-http-selector.integration.test.ts
+++ b/tests/cli-http-selector.integration.test.ts
@@ -1,0 +1,222 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import { createServer, type Server as HttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import express from 'express';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const CLI_ENTRY = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
+
+async function ensureDistBuilt(): Promise<void> {
+  try {
+    await fs.access(CLI_ENTRY);
+  } catch {
+    throw new Error('dist/cli.js is missing; run `pnpm build` before invoking this integration test directly.');
+  }
+}
+
+function runCli(args: string[], configPath: string): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      process.execPath,
+      [CLI_ENTRY, '--config', configPath, ...args],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env, MCPORTER_NO_FORCE_EXIT: '1' },
+        maxBuffer: 1024 * 1024,
+        timeout: 15_000,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(`${error.message}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`));
+          return;
+        }
+        resolve({ stdout, stderr });
+      }
+    );
+  });
+}
+
+describe('mcporter HTTP selector CLI integration', () => {
+  let httpServer: HttpServer;
+  let baseUrl: URL;
+  let tempDir: string;
+  let configuredPath: string;
+  let emptyPath: string;
+  const observedToolNames: string[] = [];
+
+  beforeAll(async () => {
+    await ensureDistBuilt();
+
+    const app = express();
+    app.use(express.json());
+    const server = new McpServer({ name: 'http-selector-e2e', version: '1.0.0' });
+    server.registerTool(
+      'check_login_status',
+      {
+        title: 'Check login status',
+        description: 'Return a deterministic login status',
+        inputSchema: {},
+      },
+      async () => {
+        observedToolNames.push('check_login_status');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ loggedIn: true, observedTool: 'check_login_status' }),
+            },
+          ],
+        };
+      }
+    );
+    server.registerTool(
+      'xhs.check_login_status',
+      {
+        title: 'Literal dotted tool',
+        description: 'Prove that --tool remains literal',
+        inputSchema: {},
+      },
+      async () => {
+        observedToolNames.push('xhs.check_login_status');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ loggedIn: true, observedTool: 'xhs.check_login_status' }),
+            },
+          ],
+        };
+      }
+    );
+
+    app.post('/mcp', async (req, res) => {
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      res.on('close', () => {
+        transport.close().catch(() => {});
+      });
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+    });
+
+    httpServer = createServer(app);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.once('error', reject);
+      httpServer.listen(0, '127.0.0.1', resolve);
+    });
+    const address = httpServer.address() as AddressInfo;
+    baseUrl = new URL(`http://127.0.0.1:${address.port}/mcp`);
+
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-http-selector-e2e-'));
+    configuredPath = path.join(tempDir, 'configured.json');
+    emptyPath = path.join(tempDir, 'empty.json');
+    await fs.writeFile(
+      configuredPath,
+      JSON.stringify({ imports: [], mcpServers: { xhs: { baseUrl: baseUrl.href } } }, null, 2),
+      'utf8'
+    );
+    await fs.writeFile(emptyPath, JSON.stringify({ imports: [], mcpServers: {} }, null, 2), 'utf8');
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('lists a configured HTTP server by name with JSON schemas', async () => {
+    const result = await runCli(['list', 'xhs', '--schema', '--json'], configuredPath);
+    expect(result.stderr).toBe('');
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      mode: 'server',
+      name: 'xhs',
+      status: 'ok',
+      tools: expect.arrayContaining([
+        expect.objectContaining({ name: 'check_login_status' }),
+        expect.objectContaining({ name: 'xhs.check_login_status' }),
+      ]),
+    });
+  });
+
+  it('routes configured and ad-hoc HTTP selectors to the intended literal tool names', async () => {
+    const cases: Array<{ args: string[]; configPath: string; expectedTool: string }> = [
+      {
+        args: ['call', 'xhs.check_login_status', '--output', 'json'],
+        configPath: configuredPath,
+        expectedTool: 'check_login_status',
+      },
+      {
+        args: ['call', 'xhs.check_login_status', '--http-url', baseUrl.href, '--allow-http', '--output', 'json'],
+        configPath: configuredPath,
+        expectedTool: 'check_login_status',
+      },
+      {
+        args: ['call', 'xhs.check_login_status', '--http-url', baseUrl.href, '--allow-http', '--output', 'json'],
+        configPath: emptyPath,
+        expectedTool: 'check_login_status',
+      },
+      {
+        args: [
+          'call',
+          'xhs.check_login_status',
+          '--http-url',
+          baseUrl.href,
+          '--allow-http',
+          '--name',
+          'xhs',
+          '--output',
+          'json',
+        ],
+        configPath: emptyPath,
+        expectedTool: 'check_login_status',
+      },
+      {
+        args: [
+          'call',
+          'xhs.selector_tool',
+          '--http-url',
+          baseUrl.href,
+          '--allow-http',
+          '--tool',
+          'check_login_status',
+          '--output',
+          'json',
+        ],
+        configPath: emptyPath,
+        expectedTool: 'check_login_status',
+      },
+      {
+        args: [
+          'call',
+          '--http-url',
+          baseUrl.href,
+          '--allow-http',
+          '--name',
+          'xhs',
+          '--tool',
+          'xhs.check_login_status',
+          '--output',
+          'json',
+        ],
+        configPath: emptyPath,
+        expectedTool: 'xhs.check_login_status',
+      },
+    ];
+
+    for (const testCase of cases) {
+      const result = await runCli(testCase.args, testCase.configPath);
+      expect(result.stderr).toBe('');
+      expect(JSON.parse(result.stdout)).toEqual({ loggedIn: true, observedTool: testCase.expectedTool });
+    }
+
+    expect(observedToolNames).toEqual(cases.map((testCase) => testCase.expectedTool));
+  }, 30_000);
+});

--- a/tests/cli-list-formatting.test.ts
+++ b/tests/cli-list-formatting.test.ts
@@ -148,6 +148,50 @@ describe('CLI list formatting', () => {
     metadataSpy.mockRestore();
   });
 
+  it('emits JSON schemas for configured HTTP servers listed by name', async () => {
+    const { handleList } = await cliModulePromise;
+    const toolCache = await import('../src/cli/tool-cache.js');
+    const metadata = [
+      {
+        tool: {
+          name: 'check_login_status',
+          description: 'Check login status',
+          inputSchema: { type: 'object', properties: {} },
+        },
+        methodName: 'check_login_status',
+        options: [],
+      },
+    ];
+    const metadataSpy = vi.spyOn(toolCache, 'loadToolMetadata').mockResolvedValue(metadata as never);
+    const definition: ServerDefinition = {
+      name: 'xhs',
+      command: { kind: 'http', url: new URL('http://127.0.0.1:18060/mcp') },
+      source: { kind: 'local', path: '<test>' },
+    };
+    const registerDefinition = vi.fn();
+    const runtime = {
+      getDefinitions: () => [definition],
+      getDefinition: () => definition,
+      registerDefinition,
+    } as unknown as Awaited<ReturnType<(typeof import('../src/runtime.js'))['createRuntime']>>;
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await handleList(runtime, ['xhs', '--schema', '--json']);
+
+    const payload = JSON.parse(logSpy.mock.calls.at(-1)?.[0] ?? '{}');
+    expect(payload).toMatchObject({
+      mode: 'server',
+      name: 'xhs',
+      status: 'ok',
+      tools: [{ name: 'check_login_status', inputSchema: { type: 'object', properties: {} } }],
+    });
+    expect(registerDefinition).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
+    metadataSpy.mockRestore();
+  });
+
   it('surfaces initialize instructions in single server text and JSON output', async () => {
     const { handleList } = await cliModulePromise;
     const definition: ServerDefinition = {


### PR DESCRIPTION
Closes #218.

Summary:
- Splits server.tool selectors before registering ad-hoc HTTP call targets, so the MCP tool name stays unqualified.
- Adds regression coverage for configured HTTP call selectors, selector-plus-HTTP-url calls, named ad-hoc HTTP selectors, literal dotted `--tool` names, and targeted JSON schema listing.

Behavior proof:
- Against a live local Streamable HTTP MCP server configured as xhs, `list xhs --schema --json` returned both `check_login_status` and `xhs.check_login_status`.
- `call xhs.check_login_status`, `call xhs.check_login_status --http-url ... --allow-http`, and `call xhs.check_login_status --http-url ... --allow-http --name xhs` all returned `loggedIn=true` for `xiaohongshu-mcp` with observed MCP tool `check_login_status`.
- `call --http-url ... --allow-http --name xhs --tool xhs.check_login_status` returned `loggedIn=true` with observed MCP tool `xhs.check_login_status`.
- The server recorded MCP tool names: `check_login_status`, `check_login_status`, `check_login_status`, `xhs.check_login_status`.
