### PR TITLE
docs: update moved repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # MCPorter 🧳 - Call MCPs from TypeScript or as CLI
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/steipete/mcporter/main/mcporter.png" alt="MCPorter header banner" width="1100">
+  <img src="https://raw.githubusercontent.com/openclaw/mcporter/main/mcporter.png" alt="MCPorter header banner" width="1100">
 </p>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/mcporter"><img src="https://img.shields.io/npm/v/mcporter?style=for-the-badge&logo=npm&logoColor=white" alt="npm version"></a>
-  <a href="https://github.com/steipete/mcporter/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/steipete/mcporter/ci.yml?branch=main&style=for-the-badge&label=tests" alt="CI Status"></a>
-  <a href="https://github.com/steipete/mcporter"><img src="https://img.shields.io/badge/platforms-macOS%20%7C%20Linux%20%7C%20Windows-blue?style=for-the-badge" alt="Platforms"></a>
+  <a href="https://github.com/openclaw/mcporter/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/openclaw/mcporter/ci.yml?branch=main&style=for-the-badge&label=tests" alt="CI Status"></a>
+  <a href="https://github.com/openclaw/mcporter"><img src="https://img.shields.io/badge/platforms-macOS%20%7C%20Linux%20%7C%20Windows-blue?style=for-the-badge" alt="Platforms"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green?style=for-the-badge" alt="MIT License"></a>
 </p>
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -30,7 +30,7 @@ Global Options:
   -h, --help                     Display help for mcporter config
 
 Run `mcporter config help add` to see transport flags, ad-hoc persistence tips, and schema docs.
-See https://github.com/sweetistics/mcporter/blob/main/docs/config.md for config anatomy, import precedence, and troubleshooting guidance.
+See https://github.com/openclaw/mcporter/blob/main/docs/config.md for config anatomy, import precedence, and troubleshooting guidance.
 ```
 
 # Configuration Guide
@@ -44,7 +44,7 @@ mcporter keeps three configuration buckets in sync: repository-scoped JSON (`con
 1. Create `config/mcporter.json` at the repo root:
    ```jsonc
    {
-     "$schema": "https://raw.githubusercontent.com/steipete/mcporter/main/mcporter.schema.json",
+     "$schema": "https://raw.githubusercontent.com/openclaw/mcporter/main/mcporter.schema.json",
      "mcpServers": {
        "linear": {
          "description": "Linear issues",
@@ -190,7 +190,7 @@ mcporter provides a JSON Schema for config file validation and autocompletion. A
 
 ```jsonc
 {
-  "$schema": "https://raw.githubusercontent.com/steipete/mcporter/main/mcporter.schema.json",
+  "$schema": "https://raw.githubusercontent.com/openclaw/mcporter/main/mcporter.schema.json",
   "mcpServers": { ... }
 }
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ summary: 'Five-minute walk through listing MCP servers, calling a tool, and emit
 
 # Quickstart
 
-This walkthrough uses the public Context7 server so you can follow the tool examples without existing MCP configuration. Add it with `mcporter config add context7 https://mcp.context7.com/mcp` if it is not already discovered from Cursor, Claude Code/Desktop, Codex, Windsurf, OpenCode, or VS Code. See [Configuration](config.md) for more options and the full schema.
+This walkthrough uses the public Context7 server so you can follow the tool examples without existing MCP configuration. Add it with `npx mcporter config add context7 https://mcp.context7.com/mcp` if it is not already discovered from Cursor, Claude Code/Desktop, Codex, Windsurf, OpenCode, or VS Code. See [Configuration](config.md) for more options and the full schema.
 
 ## 1. List the servers mcporter sees
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ summary: 'Five-minute walk through listing MCP servers, calling a tool, and emit
 
 # Quickstart
 
-This walkthrough assumes you already have an MCP server configured in Cursor, Claude Code/Desktop, Codex, Windsurf, OpenCode, or VS Code. If not, copy [`config/mcporter.example.json`](https://github.com/steipete/mcporter/blob/main/config/mcporter.example.json) into `~/.mcporter/mcporter.json` and edit it — see [Configuration](config.md) for the full schema.
+This walkthrough assumes you already have an MCP server configured in Cursor, Claude Code/Desktop, Codex, Windsurf, OpenCode, or VS Code. If not, add one with `mcporter config add context7 https://mcp.context7.com/mcp` — see [Configuration](config.md) for more options and the full schema.
 
 ## 1. List the servers mcporter sees
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ summary: 'Five-minute walk through listing MCP servers, calling a tool, and emit
 
 # Quickstart
 
-This walkthrough assumes you already have an MCP server configured in Cursor, Claude Code/Desktop, Codex, Windsurf, OpenCode, or VS Code. If not, add one with `mcporter config add context7 https://mcp.context7.com/mcp` — see [Configuration](config.md) for more options and the full schema.
+This walkthrough uses the public Context7 server so you can follow the tool examples without existing MCP configuration. Add it with `mcporter config add context7 https://mcp.context7.com/mcp` if it is not already discovered from Cursor, Claude Code/Desktop, Codex, Windsurf, OpenCode, or VS Code. See [Configuration](config.md) for more options and the full schema.
 
 ## 1. List the servers mcporter sees
 
@@ -17,7 +17,7 @@ You get one row per server with auth status, transport type, and tool count. Add
 ## 2. Inspect a single server
 
 ```bash
-npx mcporter list linear
+npx mcporter list context7
 ```
 
 Single-server output reads like a TypeScript header file: dimmed `/** … */` doc comments above each `function name(...)` signature, with optional parameters summarised so the screen stays scannable. Add flags to drill in:
@@ -34,22 +34,21 @@ Single-server output reads like a TypeScript header file: dimmed `/** … */` do
 
 ```bash
 # Colon-delimited flags (shell-friendly).
-npx mcporter call linear.create_comment issueId:ENG-123 body:'Looks good!'
+npx mcporter call context7.resolve-library-id query:'React hooks docs' libraryName:react
 
 # Function-call style copy/pasted from `mcporter list`.
-npx mcporter call 'linear.create_comment(issueId: "ENG-123", body: "Looks good!")'
-
-# Anything after `--` is a literal positional value.
-npx mcporter call docs.fetch -- --raw-string-with-leading-dashes
+npx mcporter call 'context7.resolve-library-id(query: "React hooks docs", libraryName: "react")'
 ```
 
 Pick the output format with `--output text|markdown|json|raw`. Use `--save-images <dir>` to persist binary content blocks. See [CLI reference](cli-reference.md) for the full flag list.
 
-## 4. Read MCP resources
+## 4. Read MCP resources (optional)
+
+Context7 exposes tools but not resources. If another configured server exposes resources, list or read them with:
 
 ```bash
-npx mcporter resource docs                          # list resources
-npx mcporter resource docs file:///path/to/spec.md  # read a resource
+npx mcporter resource my-resource-server                          # list resources
+npx mcporter resource my-resource-server file:///path/to/spec.md  # read a resource
 ```
 
 Output formatting is shared with `mcporter call` (`--output`, `--json`, `--raw`).
@@ -59,8 +58,8 @@ Output formatting is shared with `mcporter call` (`--output`, `--json`, `--raw`)
 When you want to share a tool with someone who shouldn't have to learn `mcporter call`:
 
 ```bash
-npx mcporter generate-cli linear --bundle dist/linear.js
-node dist/linear.js create-comment --issue-id ENG-123 --body 'Looks good!'
+npx mcporter generate-cli context7 --runtime node --bundler rolldown --bundle dist/context7.js
+node dist/context7.js resolve-library-id --query 'React hooks docs' --library-name react
 ```
 
 Add `--compile <path>` for a Bun-compiled binary, or `--include-tools a,b,c` to ship a subset. Full details in [CLI generator](cli-generator.md).
@@ -68,7 +67,7 @@ Add `--compile <path>` for a Bun-compiled binary, or `--include-tools a,b,c` to 
 ## 6. Emit typed clients for agents
 
 ```bash
-npx mcporter emit-ts linear --mode client --out src/linear-client.ts
+npx mcporter emit-ts context7 --mode client --out src/context7-client.ts
 ```
 
 You get a `.d.ts` interface and a `createServerProxy()`-backed factory. Calls return `CallResult` objects with `.text()`, `.markdown()`, `.json()`, `.images()`, `.content()` helpers — see [Tool calling](tool-calling.md) for the proxy API and [emit-ts](emit-ts.md) for the generator.

--- a/mcporter.schema.json
+++ b/mcporter.schema.json
@@ -388,5 +388,5 @@
   "required": ["mcpServers"],
   "additionalProperties": false,
   "description": "mcporter configuration file schema",
-  "$id": "https://raw.githubusercontent.com/steipete/mcporter/main/mcporter.schema.json"
+  "$id": "https://raw.githubusercontent.com/openclaw/mcporter/main/mcporter.schema.json"
 }

--- a/scripts/generate-json-schema.ts
+++ b/scripts/generate-json-schema.ts
@@ -9,7 +9,7 @@ import { writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { RawConfigSchema } from '../src/config-schema.js';
 
-export const CONFIG_SCHEMA_ID = 'https://raw.githubusercontent.com/steipete/mcporter/main/mcporter.schema.json';
+export const CONFIG_SCHEMA_ID = 'https://raw.githubusercontent.com/openclaw/mcporter/main/mcporter.schema.json';
 export const CONFIG_SCHEMA_DRAFT = 'https://json-schema.org/draft/2020-12/schema';
 
 export function buildConfigJsonSchema(): Record<string, unknown> {


### PR DESCRIPTION
## Summary

- update README badges and header asset to use the canonical `openclaw/mcporter` repository path
- update docs and generated JSON Schema metadata to use canonical repository links
- replace the missing/unsafe starter-config link with a verified `mcporter config add` command

## Exact candidate

- head: `9a03247867edee6e652065c1465611eb282fc6f5`
- base: `c6940ef8e5e74ce9b97dd1e39d78aa15c95a4f24`
- contributor credit preserved with a `Co-authored-by` trailer for @ebbsanchez

## Verification

- `git diff --check origin/main...HEAD` — passed
- `pnpm check` — passed
- `pnpm test` — 129 files passed, 1 skipped; 833 tests passed, 3 skipped
- `pnpm build` — passed
- `pnpm docs:site` — passed
- `npx mcporter config add context7 https://mcp.context7.com/mcp --dry-run` — passed; the documented no-install setup command emitted the expected config without writing
- `pnpm generate:schema` followed by formatting — deterministic
- `pnpm mcporter config --config /tmp/mcporter-pr225-nonexistent.json add context7 https://mcp.context7.com/mcp --dry-run` — emitted the expected config without writing
- `pnpm mcporter list https://mcp.context7.com/mcp --status --exit-code` — healthy; 2 tools
- direct Context7 tool call — passed
- Node/Rolldown-generated Context7 CLI invocation — passed
- Context7 typed-client generation — passed
- canonical GitHub, raw asset, schema, releases, and badge URLs — HTTP 200 without redirects
- `pnpm pack --dry-run --json` — passed
- `pnpm audit --audit-level high --json` — 0 vulnerabilities
- `pnpm outdated --format json` — no outdated direct dependencies
- autoreview — clean; no accepted/actionable findings; correctness confidence 0.98
- review-fix autoreview — clean; no accepted/actionable findings; correctness confidence 0.96

## Public Model Identifier Gate

PASS. The exact candidate diff introduces no model identifiers. Pre-existing packaged OpenAI labels are publicly documented at:

- https://developers.openai.com/api/docs/models/gpt-5.1
- https://developers.openai.com/api/docs/models/gpt-5-pro

Remaining matches are generic product families or local session labels, not provider model identifiers.
