### PR TITLE
docs: correct call-timeout default (60s, not 30s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Helpful flags:
 
 > Tip: You can skip the verb entirely—`mcporter firecrawl` automatically runs `mcporter list firecrawl`, and dotted tokens like `mcporter linear.list_issues` dispatch to the call command (typo fixes included).
 
-Timeouts default to 30 s; override with `MCPORTER_LIST_TIMEOUT` or `MCPORTER_CALL_TIMEOUT` when you expect slow startups. OAuth browser handshakes get a separate 5 minute grace period; pass `--oauth-timeout <ms>` (or export `MCPORTER_OAUTH_TIMEOUT_MS`) when you need the CLI to bail out faster while you diagnose stubborn auth flows.
+Listing defaults to a 30 s timeout and calls default to 60 s; override with `MCPORTER_LIST_TIMEOUT` or `MCPORTER_CALL_TIMEOUT` when you expect slow startups. OAuth browser handshakes get a separate 5 minute grace period; pass `--oauth-timeout <ms>` (or export `MCPORTER_OAUTH_TIMEOUT_MS`) when you need the CLI to bail out faster while you diagnose stubborn auth flows.
 
 ### Try an MCP without editing config
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -48,7 +48,7 @@ A quick reference for the primary `mcporter` subcommands. Each command inherits
 - Useful flags:
   - `--server`, `--tool` – alternate way to target a tool.
   - `--` – stop flag parsing so remaining tokens stay literal positional values.
-  - `--timeout <ms>` – override call timeout (defaults to `CALL_TIMEOUT_MS`).
+  - `--timeout <ms>` – override call timeout (defaults to `MCPORTER_CALL_TIMEOUT`, or 60 s).
   - `--output text|markdown|json|raw` – choose how to render the `CallResult`.
   - `--save-images <dir>` – persist image content blocks to files under the specified directory.
   - `--raw-strings` – disable numeric coercion for flag-style and positional values.


### PR DESCRIPTION
## What Problem This Solves

Two docs claim the **call** timeout defaults to 30 s, but the code defaults it to **60 s**. Only the *list* timeout is 30 s.

In `src/cli/timeouts.ts`:

```ts
const DEFAULT_LIST_TIMEOUT_MS = 30_000;
const DEFAULT_CALL_TIMEOUT_MS = 60_000;
...
export const LIST_TIMEOUT_MS = parseTimeout(process.env.MCPORTER_LIST_TIMEOUT, DEFAULT_LIST_TIMEOUT_MS);

export function resolveCallTimeout(override?: number): number {
  if (typeof override === 'number' && Number.isFinite(override) && override > 0) return override;
  return parseTimeout(process.env.MCPORTER_CALL_TIMEOUT, DEFAULT_CALL_TIMEOUT_MS);
}
```

`resolveCallTimeout` is what `mcporter call` uses (`src/cli/call-command.ts:74`), and the command's own timeout error message names the same env var: *"Override `MCPORTER_CALL_TIMEOUT` or pass `--timeout` to adjust."* (`src/cli/call-command.ts:533`).

Two doc sites are wrong:

1. **`README.md`** — "Timeouts default to 30 s; override with `MCPORTER_LIST_TIMEOUT` or `MCPORTER_CALL_TIMEOUT`…" lumps both env vars under a single 30 s figure, so a reader expects `mcporter call` to abort at 30 s when it actually runs to 60 s.
2. **`docs/cli-reference.md`** — "`--timeout <ms>` – override call timeout (defaults to `CALL_TIMEOUT_MS`)" references a symbol that does not exist in the codebase; the real knob is the `MCPORTER_CALL_TIMEOUT` env var (default 60 s).

## Why This Change Was Made

Docs-correctness only. The diff touches two Markdown lines and no production code, config, or defaults:

- README now states listing defaults to 30 s and calls default to 60 s, keeping both env-var override names.
- The CLI reference now names the actual env var (`MCPORTER_CALL_TIMEOUT`) and the real 60 s default instead of the non-existent `CALL_TIMEOUT_MS`.

## User Impact

No runtime change. Readers relying on the docs now get the correct call-timeout default (60 s) and the correct env-var name to override it, so timeout expectations for `mcporter call` match observed behavior.

## Evidence

Claims verified against current `main` (`710840f`):

- `src/cli/timeouts.ts:1-2` — `DEFAULT_LIST_TIMEOUT_MS = 30_000`, `DEFAULT_CALL_TIMEOUT_MS = 60_000`.
- `src/cli/timeouts.ts:23` — call default falls back to `MCPORTER_CALL_TIMEOUT` / `DEFAULT_CALL_TIMEOUT_MS` (60 s).
- `src/cli/call-command.ts:74` — `mcporter call` resolves its timeout via `resolveCallTimeout`.
- `src/cli/call-command.ts:533` — user-facing timeout error names `MCPORTER_CALL_TIMEOUT`, matching the corrected docs.

`git diff --check` is clean; the change is limited to `README.md` and `docs/cli-reference.md`.

_Generated by [Claude Code](https://claude.ai/code/session_01VFYwKK9F66vQt1DHS7arXq)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyCyUoKuziyohDwb5XaghB)_