### PR TITLE
docs: correct call timeout guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.12.4] - Unreleased
 
+### CLI
+
+- Correct the documented call timeout to 60 seconds and distinguish its `MCPORTER_CALL_TIMEOUT` and `--timeout` overrides from the 30-second list timeout. (PR #230, thanks @KrasimirKralev)
+
 ### OAuth
 
 - Recover rotating refresh tokens after transient OAuth refresh failures without clearing a concurrently persisted winner, and clear only the exact rejected token on `invalid_grant`. (PR #227, thanks @feniix)

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Helpful flags:
 
 > Tip: You can skip the verb entirely—`mcporter firecrawl` automatically runs `mcporter list firecrawl`, and dotted tokens like `mcporter linear.list_issues` dispatch to the call command (typo fixes included).
 
-Timeouts default to 30 s; override with `MCPORTER_LIST_TIMEOUT` or `MCPORTER_CALL_TIMEOUT` when you expect slow startups. OAuth browser handshakes get a separate 5 minute grace period; pass `--oauth-timeout <ms>` (or export `MCPORTER_OAUTH_TIMEOUT_MS`) when you need the CLI to bail out faster while you diagnose stubborn auth flows.
+Server listings default to a 30 s timeout, while calls default to 60 s. Override call timeouts with `MCPORTER_CALL_TIMEOUT` or `--timeout`, and list timeouts with `MCPORTER_LIST_TIMEOUT`. OAuth browser handshakes get a separate 5 minute grace period; pass `--oauth-timeout <ms>` (or export `MCPORTER_OAUTH_TIMEOUT_MS`) when you need the CLI to bail out faster while you diagnose stubborn auth flows.
 
 ### Try an MCP without editing config
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -48,7 +48,7 @@ A quick reference for the primary `mcporter` subcommands. Each command inherits
 - Useful flags:
   - `--server`, `--tool` – alternate way to target a tool.
   - `--` – stop flag parsing so remaining tokens stay literal positional values.
-  - `--timeout <ms>` – override call timeout (defaults to `CALL_TIMEOUT_MS`).
+  - `--timeout <ms>` – override the 60 s call timeout; `MCPORTER_CALL_TIMEOUT` provides the equivalent environment override.
   - `--output text|markdown|json|raw` – choose how to render the `CallResult`.
   - `--save-images <dir>` – persist image content blocks to files under the specified directory.
   - `--raw-strings` – disable numeric coercion for flag-style and positional values.


### PR DESCRIPTION
## Summary

- clarify that server listings default to 30 seconds while calls default to 60 seconds
- document both call-timeout overrides: `MCPORTER_CALL_TIMEOUT` and `--timeout`
- add the user-facing changelog credit for `@KrasimirKralev`

## Contributor credit

Maintainer-owned replacement for #230 because its fork does not permit maintainer edits. This commit preserves the original PR commit author's exact credit with:

`Co-authored-by: KrasimirKralev <krasi@idrobots.com>`

Supersedes #230. Leave #230 open until this replacement lands and the maintainer closes the original PR.

## Proof

- formatting, lint, typecheck, and build checks pass
- generated docs site contains the corrected contract in both documentation surfaces
- packed tarball installs in a clean isolated npm consumer with zero audit findings
- packed `mcporter call --help` exposes `--timeout <ms>`
- source-blind behavior contract: 4/4 clauses pass; obsolete wording absent
- autoreview: no accepted/actionable findings
- public model identifier audit: pass
