### PR TITLE
fix(auth): forward request timeout so OAuth listTools isn't capped at 60s

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -325,7 +325,7 @@ export async function runCli(argv: string[]): Promise<void> {
         return;
       }
       const { handleAuth: importedHandleAuth } = await import('./cli/auth-command.js');
-      await importedHandleAuth(runtime, resolvedArgs);
+      await importedHandleAuth(runtime, resolvedArgs, { oauthTimeoutMs: runtimeOptionsWithPath.oauthTimeoutMs });
       return;
     }
 
@@ -441,7 +441,7 @@ async function invokeAuthCommand(runtimeOptions: RuntimeOptions, args: string[])
   ]);
   const runtime = await createRuntime(runtimeOptions);
   try {
-    await importedHandleAuth(runtime, args);
+    await importedHandleAuth(runtime, args, { oauthTimeoutMs: runtimeOptions.oauthTimeoutMs });
   } finally {
     await runtime.close().catch(() => {});
   }
@@ -630,6 +630,7 @@ function createDaemonOnlyRuntime(daemonClient: import('./daemon/client.js').Daem
         autoAuthorize: options?.autoAuthorize,
         allowCachedAuth: options?.allowCachedAuth,
         disableOAuth: options?.disableOAuth,
+        timeoutMs: options?.timeoutMs,
       })) as Awaited<ReturnType<Runtime['listTools']>>,
     callTool: (server, toolName, options) =>
       daemonClient.callTool({

--- a/src/cli/auth-command.ts
+++ b/src/cli/auth-command.ts
@@ -17,12 +17,17 @@ type Runtime = Awaited<ReturnType<typeof createRuntime>>;
 
 type BrowserSuppression = 'default' | 'no-browser';
 
+export interface AuthCommandOptions {
+  readonly oauthTimeoutMs?: number;
+}
+
 const TRUE_VALUES = new Set(['1', 'true', 'yes']);
 const FALSE_VALUES = new Set(['0', 'false', 'no']);
 
-export async function handleAuth(runtime: Runtime, args: string[]): Promise<void> {
+export async function handleAuth(runtime: Runtime, args: string[], options: AuthCommandOptions = {}): Promise<void> {
   const browserSuppression = consumeBrowserSuppression(args, process.env);
   const noBrowser = browserSuppression === 'no-browser';
+  const oauthTimeoutMs = options.oauthTimeoutMs ?? resolveOAuthTimeoutFromEnv();
   let authorizationOutputEmitted = false;
   const markAuthorizationOutputEmitted = () => {
     authorizationOutputEmitted = true;
@@ -89,7 +94,7 @@ export async function handleAuth(runtime: Runtime, args: string[]): Promise<void
           // request. Let it ride for as long as we're willing to wait for the
           // authorization code (MCPORTER_OAUTH_TIMEOUT_MS, default 300s) instead
           // of being killed by the SDK's 60s request cap.
-          timeoutMs: resolveOAuthTimeoutFromEnv(),
+          timeoutMs: oauthTimeoutMs,
           ...(noBrowser
             ? {
                 oauthSessionOptions: buildNoBrowserOAuthOptions(format, markAuthorizationOutputEmitted),

--- a/src/cli/auth-command.ts
+++ b/src/cli/auth-command.ts
@@ -4,7 +4,7 @@ import type { OAuthAuthorizationRequest, OAuthSessionOptions } from '../oauth.js
 import { analyzeConnectionError } from '../error-classifier.js';
 import { clearOAuthCaches } from '../oauth-persistence.js';
 import type { createRuntime } from '../runtime.js';
-import { isOAuthFlowError } from '../runtime/oauth.js';
+import { isOAuthFlowError, resolveOAuthTimeoutFromEnv } from '../runtime/oauth.js';
 import type { EphemeralServerSpec } from './adhoc-server.js';
 import { extractEphemeralServerFlags } from './ephemeral-flags.js';
 import { persistPreparedEphemeralServer, prepareEphemeralServerTarget } from './ephemeral-target.js';
@@ -85,6 +85,11 @@ export async function handleAuth(runtime: Runtime, args: string[]): Promise<void
       const tools = await withInfoLogsSuppressed(noBrowser, () =>
         runtime.listTools(target, {
           autoAuthorize: true,
+          // The interactive OAuth browser flow runs inside this listTools
+          // request. Let it ride for as long as we're willing to wait for the
+          // authorization code (MCPORTER_OAUTH_TIMEOUT_MS, default 300s) instead
+          // of being killed by the SDK's 60s request cap.
+          timeoutMs: resolveOAuthTimeoutFromEnv(),
           ...(noBrowser
             ? {
                 oauthSessionOptions: buildNoBrowserOAuthOptions(format, markAuthorizationOutputEmitted),

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { listConfigLayerPaths } from '../config/path-discovery.js';
 import { withFileLock } from '../fs-json.js';
 import { getDaemonMetadataPath, getDaemonSocketPath } from './paths.js';
+import { DAEMON_PROTOCOL_VERSION } from './protocol.js';
 import type {
   CallToolParams,
   CloseServerParams,
@@ -24,6 +25,7 @@ export interface DaemonClientOptions {
 }
 
 const DEFAULT_DAEMON_TIMEOUT_MS = 30_000;
+const DAEMON_OPERATION_TIMEOUT_GRACE_MS = 5_000;
 const MIN_DAEMON_STATUS_TIMEOUT_MS = 1_000;
 
 export interface DaemonPaths {
@@ -34,6 +36,7 @@ export interface DaemonPaths {
 
 interface DaemonMetadata {
   readonly pid: number;
+  readonly protocolVersion?: number;
   readonly socketPath: string;
   readonly configPath: string;
   readonly configMtimeMs?: number | null;
@@ -69,7 +72,7 @@ export class DaemonClient {
   }
 
   async listTools(params: ListToolsParams): Promise<unknown> {
-    return this.invoke('listTools', params);
+    return this.invoke('listTools', params, withDaemonTransportGrace(params.timeoutMs));
   }
 
   async listResources(params: ListResourcesParams): Promise<unknown> {
@@ -232,6 +235,9 @@ export class DaemonClient {
     if (!metadata) {
       return 'missing';
     }
+    if (metadata.protocolVersion !== DAEMON_PROTOCOL_VERSION) {
+      return 'stale';
+    }
     const currentLayers = normalizeLayers(await collectConfigLayers(this.options));
     const metadataLayers = normalizeLayers(
       metadata.configLayers ?? [{ path: metadata.configPath, mtimeMs: metadata.configMtimeMs ?? null }]
@@ -368,6 +374,13 @@ function resolveDaemonStatusTimeout(override?: number): number | undefined {
     return undefined;
   }
   return Math.max(override, MIN_DAEMON_STATUS_TIMEOUT_MS);
+}
+
+function withDaemonTransportGrace(timeoutMs?: number): number | undefined {
+  if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return timeoutMs;
+  }
+  return timeoutMs + DAEMON_OPERATION_TIMEOUT_GRACE_MS;
 }
 
 async function statConfigMtime(configPath: string): Promise<number | null> {

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -72,7 +72,7 @@ export class DaemonClient {
   }
 
   async listTools(params: ListToolsParams): Promise<unknown> {
-    return this.invoke('listTools', params, withDaemonTransportGrace(params.timeoutMs));
+    return this.invoke('listTools', params, params.timeoutMs);
   }
 
   async listResources(params: ListResourcesParams): Promise<unknown> {
@@ -104,12 +104,13 @@ export class DaemonClient {
 
   private async invoke<T = unknown>(method: DaemonRequestMethod, params: unknown, timeoutMs?: number): Promise<T> {
     await this.ensureDaemon(timeoutMs);
+    const operationBudget = resolveOperationSocketBudget(method, timeoutMs);
     try {
-      return (await this.sendRequest<T>(method, params, timeoutMs)) as T;
+      return (await this.sendRequest<T>(method, params, operationBudget)) as T;
     } catch (error) {
       if (isTransportError(error)) {
         await this.restartDaemon();
-        return (await this.sendRequest<T>(method, params, timeoutMs)) as T;
+        return (await this.sendRequest<T>(method, params, operationBudget)) as T;
       }
       throw error;
     }
@@ -376,11 +377,20 @@ function resolveDaemonStatusTimeout(override?: number): number | undefined {
   return Math.max(override, MIN_DAEMON_STATUS_TIMEOUT_MS);
 }
 
-function withDaemonTransportGrace(timeoutMs?: number): number | undefined {
+function resolveOperationSocketBudget(method: DaemonRequestMethod, timeoutMs?: number): number | undefined {
   if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
     return timeoutMs;
   }
-  return timeoutMs + DAEMON_OPERATION_TIMEOUT_GRACE_MS;
+  if (method === 'listTools') {
+    // The daemon host runs a full `runtime.listTools`, which itself waits up
+    // to `timeoutMs` for an OAuth authorization code during `connect()` and
+    // then another `timeoutMs` for the SDK `tools/list` request. Size the
+    // socket deadline for both sequential phases plus a small round-trip
+    // grace so the transport doesn't expire mid-flight and trigger a
+    // duplicate OAuth attempt on retry.
+    return 2 * timeoutMs + DAEMON_OPERATION_TIMEOUT_GRACE_MS;
+  }
+  return timeoutMs;
 }
 
 async function statConfigMtime(configPath: string): Promise<number | null> {

--- a/src/daemon/host.ts
+++ b/src/daemon/host.ts
@@ -16,15 +16,16 @@ import {
   logEvent,
   shouldLogServer,
 } from './log-context.js';
-import type {
-  CallToolParams,
-  CloseServerParams,
-  DaemonRequest,
-  DaemonResponse,
-  ListResourcesParams,
-  ListToolsParams,
-  ReadResourceParams,
-  StatusResult,
+import {
+  DAEMON_PROTOCOL_VERSION,
+  type CallToolParams,
+  type CloseServerParams,
+  type DaemonRequest,
+  type DaemonResponse,
+  type ListResourcesParams,
+  type ListToolsParams,
+  type ReadResourceParams,
+  type StatusResult,
 } from './protocol.js';
 import {
   buildErrorResponse,
@@ -163,6 +164,7 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
           configPath: options.configPath,
           configLayers,
           socketPath: options.socketPath,
+          protocolVersion: DAEMON_PROTOCOL_VERSION,
           startedAt,
           logPath: options.logPath ?? null,
           configMtimeMs,
@@ -213,6 +215,7 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
     });
     await writeJsonFile(options.metadataPath, {
       pid: process.pid,
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
       socketPath: options.socketPath,
       configPath: options.configPath,
       configLayers,
@@ -268,6 +271,7 @@ function metadataFromStatus(
   fallbackConfigLayers: Array<{ path: string; mtimeMs: number | null }>
 ): {
   pid: number;
+  protocolVersion: number;
   socketPath: string;
   configPath: string;
   configLayers?: StatusResult['configLayers'];
@@ -278,6 +282,7 @@ function metadataFromStatus(
 } {
   return {
     pid: status.pid,
+    protocolVersion: status.protocolVersion,
     socketPath: status.socketPath,
     configPath: status.configPath,
     configLayers: status.configLayers && status.configLayers.length > 0 ? status.configLayers : fallbackConfigLayers,
@@ -295,6 +300,9 @@ function daemonConfigMatches(
   currentConfigMtimeMs: number | null,
   currentDefinitionHash: string
 ): boolean {
+  if (live.protocolVersion !== DAEMON_PROTOCOL_VERSION) {
+    return false;
+  }
   if (live.definitionHash !== currentDefinitionHash) {
     return false;
   }
@@ -483,6 +491,7 @@ async function handleSocketRequest(
     configLayers: Array<{ path: string; mtimeMs: number | null }>;
     configMtimeMs: number | null;
     socketPath: string;
+    protocolVersion: number;
     startedAt: number;
     logPath: string | null;
     definitionHash?: string;
@@ -526,6 +535,7 @@ async function processRequest(
     configLayers: Array<{ path: string; mtimeMs: number | null }>;
     configMtimeMs: number | null;
     socketPath: string;
+    protocolVersion: number;
     startedAt: number;
     logPath: string | null;
     definitionHash?: string;
@@ -596,6 +606,7 @@ async function processRequest(
             autoAuthorize: resolveDaemonListToolsAutoAuthorize(params, definition),
             allowCachedAuth: params.allowCachedAuth ?? true,
             disableOAuth: normalizeDaemonDisableOAuth(params.disableOAuth),
+            timeoutMs: params.timeoutMs,
           });
           markActivity(params.server, activity);
           if (loggable) {
@@ -689,6 +700,7 @@ async function processRequest(
       case 'status': {
         const result: StatusResult = {
           pid: process.pid,
+          protocolVersion: metadata.protocolVersion,
           startedAt: metadata.startedAt,
           configPath: metadata.configPath,
           configLayers: metadata.configLayers,
@@ -748,6 +760,7 @@ export async function __testProcessRequest(
     configLayers: Array<{ path: string; mtimeMs: number | null }>;
     configMtimeMs: number | null;
     socketPath: string;
+    protocolVersion?: number;
     startedAt: number;
     logPath: string | null;
     definitionHash?: string;
@@ -755,5 +768,13 @@ export async function __testProcessRequest(
   logContext: LogContext,
   preParsedRequest?: DaemonRequest
 ): Promise<{ response: DaemonResponse; shouldShutdown: boolean }> {
-  return await processRequest(rawPayload, runtime, managedServers, activity, metadata, logContext, preParsedRequest);
+  return await processRequest(
+    rawPayload,
+    runtime,
+    managedServers,
+    activity,
+    { ...metadata, protocolVersion: metadata.protocolVersion ?? DAEMON_PROTOCOL_VERSION },
+    logContext,
+    preParsedRequest
+  );
 }

--- a/src/daemon/host.ts
+++ b/src/daemon/host.ts
@@ -1,3 +1,4 @@
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import net from 'node:net';
@@ -6,6 +7,7 @@ import { loadDaemonConfig, type ServerDefinition } from '../config.js';
 import { readJsonFile, withFileLock, writeJsonFile } from '../fs-json.js';
 import { isKeepAliveServer } from '../lifecycle.js';
 import { createRuntime, type Runtime } from '../runtime.js';
+import { OAuthTimeoutError } from '../runtime/oauth.js';
 import { collectConfigLayers, statConfigMtime } from './config-layers.js';
 import { hashDaemonDefinitions } from './definition-hash.js';
 import {
@@ -17,6 +19,7 @@ import {
   shouldLogServer,
 } from './log-context.js';
 import {
+  DAEMON_OPERATION_TIMEOUT_CODE,
   DAEMON_PROTOCOL_VERSION,
   type CallToolParams,
   type CloseServerParams,
@@ -525,6 +528,18 @@ function normalizeDaemonDisableOAuth(value: boolean | undefined): boolean {
   return value === true;
 }
 
+function daemonRuntimeErrorCode(error: unknown): string {
+  const errorCode = error && typeof error === 'object' ? (error as { code?: unknown }).code : undefined;
+  if (
+    error instanceof OAuthTimeoutError ||
+    errorCode === ErrorCode.RequestTimeout ||
+    (error instanceof Error && error.message === 'Timeout')
+  ) {
+    return DAEMON_OPERATION_TIMEOUT_CODE;
+  }
+  return 'runtime_error';
+}
+
 async function processRequest(
   rawPayload: string,
   runtime: Runtime,
@@ -734,7 +749,7 @@ async function processRequest(
     }
   } catch (error) {
     return {
-      response: buildErrorResponse(id, 'runtime_error', error),
+      response: buildErrorResponse(id, daemonRuntimeErrorCode(error), error),
       shouldShutdown: false,
     };
   }

--- a/src/daemon/protocol.ts
+++ b/src/daemon/protocol.ts
@@ -1,3 +1,5 @@
+export const DAEMON_PROTOCOL_VERSION = 2;
+
 export type DaemonRequestMethod =
   | 'callTool'
   | 'listTools'
@@ -37,6 +39,7 @@ export interface ListToolsParams {
   readonly autoAuthorize?: boolean;
   readonly allowCachedAuth?: boolean;
   readonly disableOAuth?: boolean;
+  readonly timeoutMs?: number;
 }
 
 export interface ListResourcesParams {
@@ -59,6 +62,7 @@ export interface CloseServerParams {
 
 export interface StatusResult {
   readonly pid: number;
+  readonly protocolVersion: number;
   readonly startedAt: number;
   readonly configPath: string;
   readonly configMtimeMs?: number | null;

--- a/src/daemon/protocol.ts
+++ b/src/daemon/protocol.ts
@@ -1,4 +1,5 @@
 export const DAEMON_PROTOCOL_VERSION = 2;
+export const DAEMON_OPERATION_TIMEOUT_CODE = 'operation_timeout';
 
 export type DaemonRequestMethod =
   | 'callTool'

--- a/src/daemon/runtime-wrapper.ts
+++ b/src/daemon/runtime-wrapper.ts
@@ -69,6 +69,7 @@ class KeepAliveRuntime implements Runtime {
           autoAuthorize: options?.autoAuthorize,
           allowCachedAuth: options?.allowCachedAuth ?? true,
           disableOAuth: options?.disableOAuth,
+          timeoutMs: options?.timeoutMs,
         })
       )) as Awaited<ReturnType<Runtime['listTools']>>;
     }

--- a/src/daemon/runtime-wrapper.ts
+++ b/src/daemon/runtime-wrapper.ts
@@ -10,6 +10,7 @@ import type {
   Runtime,
 } from '../runtime.js';
 import type { DaemonClient } from './client.js';
+import { DAEMON_OPERATION_TIMEOUT_CODE } from './protocol.js';
 
 interface KeepAliveRuntimeOptions {
   readonly daemonClient: DaemonClient | null;
@@ -177,6 +178,9 @@ const NON_FATAL_CODES = new Set([ErrorCode.InvalidRequest, ErrorCode.MethodNotFo
 
 function shouldRestartDaemonServer(error: unknown): boolean {
   if (!error) {
+    return false;
+  }
+  if (typeof error === 'object' && (error as { code?: unknown }).code === DAEMON_OPERATION_TIMEOUT_CODE) {
     return false;
   }
   if (error instanceof McpError) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -61,6 +61,13 @@ export interface ListToolsOptions {
    * headless callers that need cached-token-only behavior.
    */
   readonly disableOAuth?: boolean;
+  /**
+   * Per-request timeout (ms) forwarded to the MCP client so listings don't hit
+   * the SDK's default 60s cap. Required for `auth`, where the interactive OAuth
+   * browser flow runs inside the `tools/list` request and routinely exceeds 60s.
+   * Mirrors {@link CallOptions.timeoutMs}.
+   */
+  readonly timeoutMs?: number;
 }
 
 export type ListResourcesOptions = Partial<ListResourcesRequest['params']> & {
@@ -263,9 +270,17 @@ class McpRuntime implements Runtime {
     let closeError: unknown;
     const tools: ServerToolInfo[] = [];
     try {
+      const timeoutMs = normalizeTimeout(options.timeoutMs);
       let cursor: string | undefined;
       do {
-        const response = await context.client.listTools(cursor ? { cursor } : undefined);
+        // Forward the requested timeout to the MCP client so listings -- and the
+        // interactive OAuth flow that listTools can trigger during `auth` -- don't
+        // hit the SDK's default 60s cap. Mirrors the callTool timeout forwarding.
+        const listPromise = context.client.listTools(
+          cursor ? { cursor } : undefined,
+          timeoutMs ? { timeout: timeoutMs, resetTimeoutOnProgress: true, maxTotalTimeout: timeoutMs } : undefined,
+        );
+        const response = timeoutMs ? await raceWithTimeout(listPromise, timeoutMs) : await listPromise;
         tools.push(
           ...(response.tools ?? []).map((tool) => ({
             name: tool.name,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -84,6 +84,7 @@ export interface ReadResourceOptions {
 
 export interface ConnectOptions {
   readonly maxOAuthAttempts?: number;
+  readonly oauthTimeoutMs?: number;
   readonly skipCache?: boolean;
   readonly allowCachedAuth?: boolean;
   readonly oauthSessionOptions?: OAuthSessionOptions;
@@ -260,17 +261,18 @@ class McpRuntime implements Runtime {
       true
     );
     const useLegacyNoAuthorize = !autoAuthorize && disableOAuth !== true;
+    const timeoutMs = normalizeTimeout(options.timeoutMs);
     const context = await this.connect(server, {
       maxOAuthAttempts: useLegacyNoAuthorize ? 0 : undefined,
       skipCache: useLegacyNoAuthorize,
       allowCachedAuth,
       oauthSessionOptions: options.oauthSessionOptions,
       disableOAuth,
+      oauthTimeoutMs: timeoutMs,
     });
     let closeError: unknown;
     const tools: ServerToolInfo[] = [];
     try {
-      const timeoutMs = normalizeTimeout(options.timeoutMs);
       let cursor: string | undefined;
       do {
         // Forward the requested timeout to the MCP client so listings -- and the
@@ -278,7 +280,7 @@ class McpRuntime implements Runtime {
         // hit the SDK's default 60s cap. Mirrors the callTool timeout forwarding.
         const listPromise = context.client.listTools(
           cursor ? { cursor } : undefined,
-          timeoutMs ? { timeout: timeoutMs, resetTimeoutOnProgress: true, maxTotalTimeout: timeoutMs } : undefined,
+          timeoutMs ? { timeout: timeoutMs, resetTimeoutOnProgress: true, maxTotalTimeout: timeoutMs } : undefined
         );
         const response = timeoutMs ? await raceWithTimeout(listPromise, timeoutMs) : await listPromise;
         tools.push(
@@ -595,7 +597,7 @@ class McpRuntime implements Runtime {
     let connectionDefinition = definition;
     let contextPromise = createClientContext(definition, this.logger, this.clientInfo, {
       maxOAuthAttempts: options.maxOAuthAttempts,
-      oauthTimeoutMs: this.oauthTimeoutMs ?? OAUTH_CODE_TIMEOUT_MS,
+      oauthTimeoutMs: options.oauthTimeoutMs ?? this.oauthTimeoutMs ?? OAUTH_CODE_TIMEOUT_MS,
       onDefinitionPromoted: (promoted) => {
         if (
           this.serverGeneration(normalized) === generation &&

--- a/tests/cli-auth.test.ts
+++ b/tests/cli-auth.test.ts
@@ -32,18 +32,24 @@ describe('mcporter auth ad-hoc support', () => {
     const { handleAuth } = await cliModulePromise;
     const { runtime, listTools } = createRuntimeDouble();
 
-    await handleAuth(runtime, ['--http-url', 'https://mcp.deepwiki.com/sse']);
+    await handleAuth(runtime, ['--http-url', 'https://mcp.deepwiki.com/sse'], { oauthTimeoutMs: 300_000 });
 
-    expect(listTools).toHaveBeenCalledWith('mcp-deepwiki-com-sse', { autoAuthorize: true });
+    expect(listTools).toHaveBeenCalledWith('mcp-deepwiki-com-sse', {
+      autoAuthorize: true,
+      timeoutMs: 300_000,
+    });
   });
 
   it('accepts bare URLs as the auth target', async () => {
     const { handleAuth } = await cliModulePromise;
     const { runtime, listTools } = createRuntimeDouble();
 
-    await handleAuth(runtime, ['https://mcp.supabase.com/mcp']);
+    await handleAuth(runtime, ['https://mcp.supabase.com/mcp'], { oauthTimeoutMs: 300_000 });
 
-    expect(listTools).toHaveBeenCalledWith('mcp-supabase-com-mcp', { autoAuthorize: true });
+    expect(listTools).toHaveBeenCalledWith('mcp-supabase-com-mcp', {
+      autoAuthorize: true,
+      timeoutMs: 300_000,
+    });
   });
 
   it('reuses configured servers when auth target is a URL', async () => {
@@ -62,9 +68,9 @@ describe('mcporter auth ad-hoc support', () => {
       getDefinition: () => definition,
     } as unknown as Awaited<ReturnType<(typeof import('../src/runtime.js'))['createRuntime']>>;
 
-    await handleAuth(runtime, ['https://mcp.vercel.com']);
+    await handleAuth(runtime, ['https://mcp.vercel.com'], { oauthTimeoutMs: 300_000 });
 
-    expect(listTools).toHaveBeenCalledWith('vercel', { autoAuthorize: true });
+    expect(listTools).toHaveBeenCalledWith('vercel', { autoAuthorize: true, timeoutMs: 300_000 });
     expect(registerDefinition).not.toHaveBeenCalled();
   });
 

--- a/tests/cli-oauth-timeout-flag.test.ts
+++ b/tests/cli-oauth-timeout-flag.test.ts
@@ -52,6 +52,47 @@ describe('mcporter --oauth-timeout flag', () => {
     createRuntimeSpy.mockRestore();
   });
 
+  it('uses the override for the auth listTools request timeout', async () => {
+    const definition = {
+      name: 'fake',
+      description: 'Fake HTTP server',
+      command: { kind: 'http' as const, url: new URL('https://example.com/mcp') },
+    };
+    const listToolsSpy = vi.fn(async () => []);
+    const runtimeStub: Runtime = {
+      listServers: vi.fn(() => [definition.name]),
+      getDefinitions: vi.fn(() => [definition]),
+      getDefinition: vi.fn(() => definition),
+      registerDefinition: vi.fn(),
+      listTools: listToolsSpy,
+      callTool: vi.fn(),
+      listResources: vi.fn(),
+      readResource: vi.fn(),
+      connect: vi.fn(),
+      close: vi.fn(async () => {}),
+    };
+    const runtimeModule = await import('../src/runtime.js');
+    const createRuntimeSpy = vi.spyOn(runtimeModule, 'createRuntime').mockResolvedValue(runtimeStub);
+    const { runCli } = await import('../src/cli.js');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const previousNoForce = process.env.MCPORTER_NO_FORCE_EXIT;
+    process.env.MCPORTER_NO_FORCE_EXIT = '1';
+
+    try {
+      await runCli(['--oauth-timeout', '600000', 'auth', 'fake']);
+    } finally {
+      process.env.MCPORTER_NO_FORCE_EXIT = previousNoForce;
+    }
+
+    expect(listToolsSpy).toHaveBeenCalledWith(
+      'fake',
+      expect.objectContaining({ autoAuthorize: true, timeoutMs: 600_000 })
+    );
+
+    logSpy.mockRestore();
+    createRuntimeSpy.mockRestore();
+  });
+
   it('rejects malformed --oauth-timeout values', async () => {
     const { runCli } = await import('../src/cli.js');
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/daemon-client-config-stale.test.ts
+++ b/tests/daemon-client-config-stale.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DAEMON_PROTOCOL_VERSION } from '../src/daemon/protocol.js';
 import { makeShortTempDir } from './fixtures/test-helpers.js';
 
 const sentMethods: string[] = [];
@@ -16,6 +17,9 @@ class MockSocket extends EventEmitter {
   write(data: string, cb?: (err?: Error | null) => void): boolean {
     const payload = JSON.parse(data.toString());
     sentMethods.push(payload.method);
+    if (payload.method === 'stop') {
+      activeStatusPid = findNonRunningPid();
+    }
     const response = buildResponse(payload.method, payload.id);
     queueMicrotask(() => {
       this.emit('data', JSON.stringify(response));
@@ -41,6 +45,7 @@ function buildResponse(method: string, id: string) {
       ok: true,
       result: {
         pid: activeStatusPid,
+        protocolVersion: DAEMON_PROTOCOL_VERSION,
         startedAt: Date.now(),
         configPath: activeConfigPath,
         configMtimeMs: activeConfigMtime,
@@ -93,6 +98,7 @@ describe('DaemonClient config freshness', () => {
           JSON.stringify(
             {
               pid: process.pid,
+              protocolVersion: DAEMON_PROTOCOL_VERSION,
               socketPath: options.socketPath,
               configPath: options.configPath,
               startedAt: Date.now(),
@@ -225,6 +231,7 @@ describe('DaemonClient config freshness', () => {
       JSON.stringify(
         {
           pid: process.pid,
+          protocolVersion: DAEMON_PROTOCOL_VERSION,
           socketPath,
           configPath,
           startedAt: Date.now() - 10_000,
@@ -244,6 +251,43 @@ describe('DaemonClient config freshness', () => {
     expect(sentMethods).toEqual(['status', 'listTools']);
     expect(sentMethods).not.toContain('stop');
     expect(launchDaemonDetached).not.toHaveBeenCalled();
+  });
+
+  it('restarts a daemon whose metadata predates the current protocol', async () => {
+    const tmpDir = await makeShortTempDir('daemon-protocol-stale');
+    process.env.MCPORTER_DAEMON_DIR = tmpDir;
+
+    const configPath = path.join(tmpDir, 'config.json');
+    await fs.writeFile(configPath, JSON.stringify({ mcpServers: {} }), 'utf8');
+    const stat = await fs.stat(configPath);
+    const { metadataPath, socketPath } = resolveDaemonPaths(configPath);
+    activeConfigPath = configPath;
+    activeSocketPath = socketPath;
+    activeConfigMtime = stat.mtimeMs;
+    activeStatusPid = process.pid;
+    activeLayers = [{ path: configPath, mtimeMs: stat.mtimeMs }];
+
+    await fs.mkdir(path.dirname(metadataPath), { recursive: true });
+    await fs.writeFile(
+      metadataPath,
+      JSON.stringify({
+        pid: process.pid,
+        socketPath,
+        configPath,
+        startedAt: Date.now() - 10_000,
+        logPath: null,
+        configMtimeMs: stat.mtimeMs,
+        configLayers: activeLayers,
+      }),
+      'utf8'
+    );
+
+    const client = new DaemonClient({ configPath, configExplicit: true, rootDir: tmpDir });
+    await client.listTools({ server: 'playwright' });
+
+    expect(sentMethods).toContain('stop');
+    expect(launchDaemonDetached).toHaveBeenCalledTimes(1);
+    expect(sentMethods).toContain('listTools');
   });
 });
 

--- a/tests/daemon-client-lifecycle.test.ts
+++ b/tests/daemon-client-lifecycle.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import net from 'node:net';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DAEMON_PROTOCOL_VERSION } from '../src/daemon/protocol.js';
 import { makeShortTempDir } from './fixtures/test-helpers.js';
 
 const launchDaemonDetached = vi.hoisted(() => vi.fn());
@@ -68,6 +69,7 @@ describe('DaemonClient lifecycle reconciliation', () => {
       metadataPath,
       JSON.stringify({
         pid: process.pid,
+        protocolVersion: DAEMON_PROTOCOL_VERSION,
         socketPath,
         configPath,
         configLayers: [{ path: configPath, mtimeMs: (await fs.stat(configPath)).mtimeMs }],
@@ -147,6 +149,7 @@ async function startMockDaemon(
     options.metadataPath,
     JSON.stringify({
       pid,
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
       socketPath: options.socketPath,
       configPath: options.configPath,
       configLayers: [{ path: options.configPath, mtimeMs: stat.mtimeMs }],
@@ -189,6 +192,7 @@ async function startStatusServer(
         request.method === 'status'
           ? {
               pid,
+              protocolVersion: DAEMON_PROTOCOL_VERSION,
               startedAt: Date.now(),
               configPath,
               socketPath,

--- a/tests/daemon-client-timeout.test.ts
+++ b/tests/daemon-client-timeout.test.ts
@@ -2,15 +2,20 @@ import { EventEmitter } from 'node:events';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DAEMON_PROTOCOL_VERSION } from '../src/daemon/protocol.js';
 import { makeShortTempDir } from './fixtures/test-helpers.js';
 
 const timeoutRecords: Array<{ method: string; timeout: number }> = [];
 
 class MockSocket extends EventEmitter {
   currentTimeout = 0;
+  private timeoutHandle?: NodeJS.Timeout;
 
-  setTimeout(ms: number): this {
+  setTimeout(ms: number, callback?: () => void): this {
     this.currentTimeout = ms;
+    if (enforceSocketTimeout && callback) {
+      this.timeoutHandle = setTimeout(callback, ms);
+    }
     return this;
   }
 
@@ -19,6 +24,9 @@ class MockSocket extends EventEmitter {
     timeoutRecords.push({ method: payload.method, timeout: this.currentTimeout });
     const response = buildResponse(payload.method, payload.id);
     setTimeout(() => {
+      if (this.timeoutHandle) {
+        clearTimeout(this.timeoutHandle);
+      }
       this.emit('data', JSON.stringify(response));
       this.emit('end');
     }, responseDelayMs);
@@ -31,12 +39,19 @@ class MockSocket extends EventEmitter {
     return this;
   }
 
-  destroy(): this {
+  destroy(error?: Error): this {
+    if (this.timeoutHandle) {
+      clearTimeout(this.timeoutHandle);
+    }
+    if (error) {
+      queueMicrotask(() => this.emit('error', error));
+    }
     return this;
   }
 }
 
 let responseDelayMs = 5;
+let enforceSocketTimeout = false;
 let activeConfigPath = path.resolve('mcporter.config.json');
 let activeSocketPath = '';
 const createConnection = vi.fn(() => {
@@ -67,6 +82,7 @@ function buildResponse(method: string, id: string) {
       ok: true,
       result: {
         pid: process.pid,
+        protocolVersion: DAEMON_PROTOCOL_VERSION,
         startedAt: Date.now(),
         configPath: activeConfigPath,
         socketPath: activeSocketPath,
@@ -85,6 +101,7 @@ describe('DaemonClient timeouts', () => {
   beforeEach(async () => {
     timeoutRecords.length = 0;
     responseDelayMs = 5;
+    enforceSocketTimeout = false;
     previousDaemonTimeout = process.env.MCPORTER_DAEMON_TIMEOUT_MS;
     previousDaemonDir = process.env.MCPORTER_DAEMON_DIR;
     tmpDaemonDir = await makeShortTempDir('daemon-timeout');
@@ -142,6 +159,30 @@ describe('DaemonClient timeouts', () => {
     expect(callRecord?.timeout).toBe(12_345);
   });
 
+  it('honors per-listTools timeout overrides', async () => {
+    const configPath = 'mcporter.config.json';
+    await writeFreshMetadata(configPath);
+    const client = new DaemonClient({ configPath, configExplicit: true });
+    await client.listTools({ server: 'foo', timeoutMs: 300_000 });
+    const statusRecord = timeoutRecords.find((entry) => entry.method === 'status');
+    const listRecord = timeoutRecords.find((entry) => entry.method === 'listTools');
+    expect(statusRecord?.timeout).toBe(305_000);
+    expect(listRecord?.timeout).toBe(305_000);
+  });
+
+  it('keeps the daemon transport open beyond the listTools operation deadline', async () => {
+    responseDelayMs = 40;
+    enforceSocketTimeout = true;
+    const configPath = 'mcporter.config.json';
+    await writeFreshMetadata(configPath);
+    const client = new DaemonClient({ configPath, configExplicit: true });
+
+    await expect(client.listTools({ server: 'foo', timeoutMs: 20 })).resolves.toEqual({ ok: true });
+
+    const listRecord = timeoutRecords.find((entry) => entry.method === 'listTools');
+    expect(listRecord?.timeout).toBe(5_020);
+  });
+
   it('clamps daemon status preflight timeout for tiny per-call timeouts', async () => {
     const configPath = 'mcporter.config.json';
     await writeFreshMetadata(configPath);
@@ -163,6 +204,7 @@ async function writeFreshMetadata(configPath: string): Promise<void> {
     paths.metadataPath,
     JSON.stringify({
       pid: process.pid,
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
       socketPath: paths.socketPath,
       configPath,
       configLayers: [{ path: activeConfigPath, mtimeMs: null }],

--- a/tests/daemon-client-timeout.test.ts
+++ b/tests/daemon-client-timeout.test.ts
@@ -166,8 +166,11 @@ describe('DaemonClient timeouts', () => {
     await client.listTools({ server: 'foo', timeoutMs: 300_000 });
     const statusRecord = timeoutRecords.find((entry) => entry.method === 'status');
     const listRecord = timeoutRecords.find((entry) => entry.method === 'listTools');
-    expect(statusRecord?.timeout).toBe(305_000);
-    expect(listRecord?.timeout).toBe(305_000);
+    // The status probe uses the raw caller deadline; the listTools socket
+    // deadline covers both the OAuth code wait inside connect() and the
+    // follow-up SDK tools/list request, plus a small round-trip grace.
+    expect(statusRecord?.timeout).toBe(300_000);
+    expect(listRecord?.timeout).toBe(605_000);
   });
 
   it('keeps the daemon transport open beyond the listTools operation deadline', async () => {
@@ -180,7 +183,16 @@ describe('DaemonClient timeouts', () => {
     await expect(client.listTools({ server: 'foo', timeoutMs: 20 })).resolves.toEqual({ ok: true });
 
     const listRecord = timeoutRecords.find((entry) => entry.method === 'listTools');
-    expect(listRecord?.timeout).toBe(5_020);
+    expect(listRecord?.timeout).toBe(5_040);
+  });
+
+  it('leaves callTool operation socket budget unchanged when only listTools budgets OAuth', async () => {
+    const configPath = 'mcporter.config.json';
+    await writeFreshMetadata(configPath);
+    const client = new DaemonClient({ configPath, configExplicit: true });
+    await client.callTool({ server: 'foo', tool: 'bar', timeoutMs: 12_345 });
+    const callRecord = timeoutRecords.find((entry) => entry.method === 'callTool');
+    expect(callRecord?.timeout).toBe(12_345);
   });
 
   it('clamps daemon status preflight timeout for tiny per-call timeouts', async () => {

--- a/tests/daemon-client.test.ts
+++ b/tests/daemon-client.test.ts
@@ -4,6 +4,7 @@ import net from 'node:net';
 import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { DaemonClient, resolveDaemonPaths } from '../src/daemon/client.js';
+import { DAEMON_PROTOCOL_VERSION } from '../src/daemon/protocol.js';
 import { makeShortTempDir } from './fixtures/test-helpers.js';
 
 describe('daemon client', () => {
@@ -107,6 +108,7 @@ describe('daemon client', () => {
       metadataPath,
       JSON.stringify({
         pid: process.pid,
+        protocolVersion: DAEMON_PROTOCOL_VERSION,
         socketPath,
         configPath,
         configLayers: [{ path: configPath, mtimeMs: configStats.mtimeMs }],
@@ -125,6 +127,7 @@ describe('daemon client', () => {
           request.method === 'status'
             ? {
                 pid: process.pid,
+                protocolVersion: DAEMON_PROTOCOL_VERSION,
                 startedAt: Date.now(),
                 configPath,
                 configLayers: [{ path: configPath, mtimeMs: configStats.mtimeMs }],

--- a/tests/daemon-host.test.ts
+++ b/tests/daemon-host.test.ts
@@ -60,7 +60,7 @@ describe('daemon host request handling', () => {
     await __testProcessRequest('', runtime as unknown as Runtime, managedServers, new Map(), metadata, logContext, {
       id: 'list',
       method: 'listTools',
-      params: { server: 'oauth', includeSchema: true },
+      params: { server: 'oauth', includeSchema: true, timeoutMs: 300_000 },
     });
 
     expect(runtime.listTools).toHaveBeenCalledWith('oauth', {
@@ -68,6 +68,7 @@ describe('daemon host request handling', () => {
       autoAuthorize: undefined,
       allowCachedAuth: true,
       disableOAuth: false,
+      timeoutMs: 300_000,
     });
   });
 

--- a/tests/daemon-host.test.ts
+++ b/tests/daemon-host.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../src/daemon/host.js';
 import type { DaemonRequest } from '../src/daemon/protocol.js';
 import type { Runtime } from '../src/runtime.js';
+import { OAuthTimeoutError } from '../src/runtime/oauth.js';
 
 describe('daemon host request handling', () => {
   const metadata = {
@@ -155,6 +156,28 @@ describe('daemon host request handling', () => {
       disableOAuth: false,
     });
   });
+
+  it('marks OAuth listTools timeouts as non-retryable operation errors', async () => {
+    const runtime = createRuntimeDouble();
+    vi.mocked(runtime.listTools).mockRejectedValue(new OAuthTimeoutError('oauth', 5_000));
+
+    const result = await __testProcessRequest(
+      '',
+      runtime as unknown as Runtime,
+      createManagedServers(),
+      new Map(),
+      metadata,
+      logContext,
+      {
+        id: 'list-timeout',
+        method: 'listTools',
+        params: { server: 'oauth', timeoutMs: 5_000 },
+      }
+    );
+
+    expect(result.response.ok).toBe(false);
+    expect(result.response.error?.code).toBe('operation_timeout');
+  });
 });
 
 const describeUnixSocket = process.platform === 'win32' ? describe.skip : describe;
@@ -291,7 +314,10 @@ describe('daemon artifact cleanup', () => {
   });
 });
 
-function createRuntimeDouble(): Pick<Runtime, 'callTool' | 'listTools'> {
+function createRuntimeDouble(): {
+  callTool: ReturnType<typeof vi.fn>;
+  listTools: ReturnType<typeof vi.fn>;
+} {
   return {
     callTool: vi.fn().mockResolvedValue({ ok: true }),
     listTools: vi.fn().mockResolvedValue([]),

--- a/tests/keep-alive-runtime.test.ts
+++ b/tests/keep-alive-runtime.test.ts
@@ -283,4 +283,26 @@ describe('createKeepAliveRuntime', () => {
     expect(daemon.callTool).toHaveBeenCalledTimes(1);
     expect(daemon.closeServer).not.toHaveBeenCalled();
   });
+
+  it('does not restart or retry daemon listTools operation timeouts', async () => {
+    const runtime = new FakeRuntime(definitions);
+    const timeoutError = Object.assign(new Error("OAuth authorization for 'alpha' timed out after 5s; aborting."), {
+      code: 'operation_timeout',
+    });
+    const daemon = {
+      callTool: vi.fn(),
+      closeServer: vi.fn().mockResolvedValue(undefined),
+      listTools: vi.fn().mockRejectedValue(timeoutError),
+      listResources: vi.fn(),
+      readResource: vi.fn(),
+    };
+    const keepAliveRuntime = createKeepAliveRuntime(runtime as unknown as Runtime, {
+      daemonClient: daemon as never,
+      keepAliveServers: new Set(['alpha']),
+    });
+
+    await expect(keepAliveRuntime.listTools('alpha', { timeoutMs: 5_000 })).rejects.toThrow('timed out');
+    expect(daemon.listTools).toHaveBeenCalledTimes(1);
+    expect(daemon.closeServer).not.toHaveBeenCalled();
+  });
 });

--- a/tests/keep-alive-runtime.test.ts
+++ b/tests/keep-alive-runtime.test.ts
@@ -106,13 +106,14 @@ describe('createKeepAliveRuntime', () => {
       disableOAuth: undefined,
     });
 
-    await keepAliveRuntime.listTools('alpha', { includeSchema: true });
+    await keepAliveRuntime.listTools('alpha', { includeSchema: true, timeoutMs: 5_000 });
     expect(daemon.listTools).toHaveBeenCalledWith({
       server: 'alpha',
       includeSchema: true,
       autoAuthorize: undefined,
       allowCachedAuth: true,
       disableOAuth: undefined,
+      timeoutMs: 5_000,
     });
 
     await keepAliveRuntime.listTools('alpha', { allowCachedAuth: false });

--- a/tests/runtime-listtools-timeout.test.ts
+++ b/tests/runtime-listtools-timeout.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ServerDefinition } from '../src/config-schema.js';
+import { createRuntime } from '../src/runtime.js';
+
+type TestRuntime = Awaited<ReturnType<typeof createRuntime>>;
+type ClientContext = Awaited<ReturnType<TestRuntime['connect']>>;
+
+function fakeListToolsContext(listTools: ReturnType<typeof vi.fn>): ClientContext {
+  return {
+    client: {
+      listTools,
+      close: vi.fn().mockResolvedValue(undefined),
+    },
+    transport: { close: vi.fn().mockResolvedValue(undefined) },
+    definition: {
+      name: 'alpha',
+      description: 'test server',
+      command: { kind: 'http', url: new URL('https://alpha.example.com') },
+      source: { kind: 'local', path: '/tmp' },
+    },
+    oauthSession: undefined,
+  } as unknown as ClientContext;
+}
+
+describe('runtime.listTools request timeout forwarding', () => {
+  const definitions: ServerDefinition[] = [
+    {
+      name: 'alpha',
+      description: 'test server',
+      command: { kind: 'http', url: new URL('https://alpha.example.com') },
+      source: { kind: 'local', path: '/tmp' },
+    },
+  ];
+
+  it('forwards timeoutMs to the MCP client so listings (and OAuth during auth) avoid the 60s SDK cap', async () => {
+    const runtime = await createRuntime({ servers: definitions });
+    const listTools = vi.fn().mockResolvedValue({ tools: [] });
+    vi.spyOn(runtime, 'connect').mockResolvedValue(fakeListToolsContext(listTools));
+
+    await runtime.listTools('alpha', { timeoutMs: 5_000 });
+
+    expect(listTools).toHaveBeenCalledWith(undefined, {
+      timeout: 5_000,
+      resetTimeoutOnProgress: true,
+      maxTotalTimeout: 5_000,
+    });
+  });
+
+  it('omits SDK timeout options when timeoutMs is not provided (preserves prior behavior)', async () => {
+    const runtime = await createRuntime({ servers: definitions });
+    const listTools = vi.fn().mockResolvedValue({ tools: [] });
+    vi.spyOn(runtime, 'connect').mockResolvedValue(fakeListToolsContext(listTools));
+
+    await runtime.listTools('alpha');
+
+    expect(listTools).toHaveBeenCalledWith(undefined, undefined);
+  });
+});

--- a/tests/runtime-listtools-timeout.test.ts
+++ b/tests/runtime-listtools-timeout.test.ts
@@ -35,10 +35,11 @@ describe('runtime.listTools request timeout forwarding', () => {
   it('forwards timeoutMs to the MCP client so listings (and OAuth during auth) avoid the 60s SDK cap', async () => {
     const runtime = await createRuntime({ servers: definitions });
     const listTools = vi.fn().mockResolvedValue({ tools: [] });
-    vi.spyOn(runtime, 'connect').mockResolvedValue(fakeListToolsContext(listTools));
+    const connect = vi.spyOn(runtime, 'connect').mockResolvedValue(fakeListToolsContext(listTools));
 
     await runtime.listTools('alpha', { timeoutMs: 5_000 });
 
+    expect(connect).toHaveBeenCalledWith('alpha', expect.objectContaining({ oauthTimeoutMs: 5_000 }));
     expect(listTools).toHaveBeenCalledWith(undefined, {
       timeout: 5_000,
       resetTimeoutOnProgress: true,
@@ -53,6 +54,17 @@ describe('runtime.listTools request timeout forwarding', () => {
 
     await runtime.listTools('alpha');
 
+    expect(listTools).toHaveBeenCalledWith(undefined, undefined);
+  });
+
+  it('normalizes invalid timeoutMs before OAuth connection setup', async () => {
+    const runtime = await createRuntime({ servers: definitions });
+    const listTools = vi.fn().mockResolvedValue({ tools: [] });
+    const connect = vi.spyOn(runtime, 'connect').mockResolvedValue(fakeListToolsContext(listTools));
+
+    await runtime.listTools('alpha', { timeoutMs: 0 });
+
+    expect(connect).toHaveBeenCalledWith('alpha', expect.objectContaining({ oauthTimeoutMs: undefined }));
     expect(listTools).toHaveBeenCalledWith(undefined, undefined);
   });
 });


### PR DESCRIPTION
## Problem

`mcporter auth <server>` runs the interactive OAuth browser flow **inside** the SDK's `tools/list` request, but `listTools` never forwarded a per-request timeout. The SDK's `DEFAULT_REQUEST_TIMEOUT_MSEC` (60s) killed the request before mcporter's own 300s OAuth code wait (`MCPORTER_OAUTH_TIMEOUT_MS`) could complete:

```
[mcporter] Failed to authorize 'mobbin': MCP error -32001: Request timed out
    code: -32001,
    data: { timeout: 60000 }
```

Any OAuth provider whose browser sign-in doesn't finish within 60s is **impossible to authorize**. The generous `MCPORTER_OAUTH_TIMEOUT_MS` (300s) is effectively dead code on this path — the wrapping request dies at 60s first. `--no-browser` doesn't help (and text mode doesn't even surface the URL).

`callTool` already forwards `timeoutMs` to the SDK (`runtime.ts` ~line 320) — `listTools` was missed, and `auth` runs through `listTools({ autoAuthorize: true })`.

## Fix

Extend the existing `callTool` timeout-forwarding pattern to `listTools`:

- **`src/runtime.ts`** — add `timeoutMs?: number` to `ListToolsOptions`; pass `{ timeout, resetTimeoutOnProgress, maxTotalTimeout }` to `client.listTools(...)` as the second arg, with `raceWithTimeout` as an outer guard. Mirrors `callTool` exactly.
- **`src/cli/auth-command.ts`** — pass `timeoutMs: resolveOAuthTimeoutFromEnv()` to the auth `listTools` call, so the request lives at least as long as the OAuth code wait (`MCPORTER_OAUTH_TIMEOUT_MS`, default 300s).

No new env var — the existing `MCPORTER_OAUTH_TIMEOUT_MS` now controls the auth request window end-to-end. Default behavior for plain `listTools` callers is unchanged (no `timeoutMs` → SDK default preserved).

## Verification

- New test `tests/runtime-listtools-timeout.test.ts`: asserts `listTools({ timeoutMs: 5000 })` forwards `{ timeout: 5000, resetTimeoutOnProgress: true, maxTotalTimeout: 5000 }` to the SDK, and that omitting `timeoutMs` passes `undefined` (prior behavior preserved).
- Related suite green (runtime-cache, keep-alive-runtime, runtime-utils, server-proxy, cli-list-*, cli-call-errors: 50 tests).
- End-to-end: authorized a previously-impossible server (Mobbin, Supabase OAuth) with the patched build — `mcporter auth mobbin` succeeds; `mcporter list mobbin` returns 3 tools; `mcporter call mobbin.search_screens …` returns real results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
