### PR TITLE
docs: add safety guidance for generated CLIs and replay fixtures

### DIFF
--- a/docs/cli-generator.md
+++ b/docs/cli-generator.md
@@ -125,18 +125,45 @@ Conceptual wrapper pseudocode (not a built-in mcporter API):
 
 ```ts
 const operation = normalize({ server, tool, arguments });
-const decision = await gateway.evaluate(operation);
+let decision;
+let outcome = 'evaluation_failed';
+let result;
+let failure;
 
-if (decision.action === 'block') throw new Error(decision.reason);
-if (decision.action === 'approve' && !(await approvals.confirm(decision))) {
-  throw new Error('Approval declined');
+try {
+  decision = await gateway.evaluate(operation);
+
+  if (decision.action === 'block') {
+    outcome = 'blocked';
+    failure = 'policy_block';
+    throw new Error(decision.reason);
+  }
+
+  if (decision.action === 'approve' && !(await approvals.confirm(decision))) {
+    outcome = 'approval_declined';
+    failure = 'approval_declined';
+    throw new Error('Approval declined');
+  }
+
+  try {
+    result = await generatedCli.call(tool, arguments);
+    outcome = 'succeeded';
+    return result;
+  } catch (error) {
+    outcome = 'execution_failed';
+    failure = classifyError(error);
+    throw error;
+  }
+} catch (error) {
+  failure ??= classifyError(error);
+  throw error;
+} finally {
+  await audit.append(redact({ operation, decision, outcome, result, failure }));
 }
-
-const result = await generatedCli.call(tool, arguments);
-await audit.append(redact({ operation, decision, result }));
-return result;
 ```
 
+The `finally` path records a redacted outcome for blocked requests, declined
+approvals, policy-evaluation failures, execution failures, and successful calls.
 The wrapper governs only calls routed through it. Direct execution of the
 generated artifact bypasses that policy boundary.
 

--- a/docs/cli-generator.md
+++ b/docs/cli-generator.md
@@ -106,6 +106,40 @@ npx mcporter generate-cli --command "npx -y chrome-devtools-mcp@latest"
 - `mcporter generate-cli --from <artifact>` replays the stored invocation against the latest mcporter build. `--server`, `--runtime`, `--timeout`, `--minify/--no-minify`, `--bundle`, `--compile`, `--output`, and `--dry-run` let you override specific pieces of the stored metadata when necessary.
 - Because the metadata lives inside the artifact, any template, bundle, or compiled binary can be refreshed after a generator upgrade without juggling sidecar files.
 
+## Policy boundary for generated CLIs
+
+A generated CLI or typed client can be invoked independently of the MCP client
+that originally configured the server. It therefore does not automatically
+inherit that client's approval prompts, tool-call policies, or audit trail.
+
+Use `--include-tools` to reduce the generated surface, but do not treat a static
+tool list as dynamic authorization. Deployments that need per-call policy should
+route the generated command through an external wrapper or policy gateway that:
+
+1. normalizes the server, tool name, and arguments;
+2. evaluates current policy and requests approval when required;
+3. blocks the call or invokes the generated CLI; and
+4. persists a redacted decision and result record.
+
+Conceptual wrapper pseudocode (not a built-in mcporter API):
+
+```ts
+const operation = normalize({ server, tool, arguments });
+const decision = await gateway.evaluate(operation);
+
+if (decision.action === 'block') throw new Error(decision.reason);
+if (decision.action === 'approve' && !(await approvals.confirm(decision))) {
+  throw new Error('Approval declined');
+}
+
+const result = await generatedCli.call(tool, arguments);
+await audit.append(redact({ operation, decision, result }));
+return result;
+```
+
+The wrapper governs only calls routed through it. Direct execution of the
+generated artifact bypasses that policy boundary.
+
 ## Status
 
 - ✅ `generate-cli` subcommand implemented with schema-aware proxy generation.

--- a/docs/record-replay.md
+++ b/docs/record-replay.md
@@ -60,7 +60,9 @@ Preserve JSON-RPC methods, request order, IDs, and parameter shapes so strict
 replay still exercises the intended behavior.
 
 Prefer fixtures recorded from a synthetic MCP server. Never commit the raw
-capture, and review the redacted NDJSON as text before sharing it. A useful
-regression test runs the wrapper against `mcporter replay`, asserts the expected
-policy decision and tool result, and confirms that the fixture contains none of
-the original sensitive values.
+capture, and review the redacted NDJSON as text before sharing it. Applications
+that use the [external policy wrapper described in the generated CLI
+guidance](./cli-generator.md#policy-boundary-for-generated-clis) can optionally
+run that application-owned wrapper against `mcporter replay`, assert the
+expected policy decision and tool result, and confirm that the fixture contains
+none of the original sensitive values.

--- a/docs/record-replay.md
+++ b/docs/record-replay.md
@@ -50,3 +50,17 @@ Each line is one JSON-RPC envelope with an added `_meta` object:
 Replay is strict. For each server, mcporter expects requests to arrive in the same order with the same JSON-RPC method and deeply equal `params`. If the next request differs, replay fails with an error that names the incoming request and the next recorded request it expected.
 
 This makes recordings useful as reproducible bug fixtures: a replay either follows the captured MCP exchange exactly or fails at the first point where the workflow diverges.
+
+## Safe regression fixtures
+
+Recording is not automatic redaction. Before using a capture as a regression
+fixture, copy it to a separate working file and replace credentials, tokens,
+personal data, customer content, and sensitive paths with synthetic values.
+Preserve JSON-RPC methods, request order, IDs, and parameter shapes so strict
+replay still exercises the intended behavior.
+
+Prefer fixtures recorded from a synthetic MCP server. Never commit the raw
+capture, and review the redacted NDJSON as text before sharing it. A useful
+regression test runs the wrapper against `mcporter replay`, asserts the expected
+policy decision and tool result, and confirms that the fixture contains none of
+the original sensitive values.


### PR DESCRIPTION
## Summary

- document that generated CLIs and typed clients do not automatically inherit the original MCP client's approval UI or audit path
- describe a conceptual, application-owned wrapper for normalize, evaluate, approve/block, execute, and redacted audit steps
- clarify that `--include-tools` reduces static surface but is not dynamic authorization
- add safe handling guidance for record/replay regression fixtures

## Why

Generated MCP surfaces can be invoked independently of the client that
originally configured the server. Applications that require per-call policy
need an explicit wrapper boundary, and direct execution of the generated
artifact must be understood as a bypass of that wrapper.

Recordings also contain raw JSON-RPC arguments and responses. The added guidance
recommends synthetic servers, separate redacted working copies, shape-preserving
replacements, textual review, and assertions that original sensitive values are
absent before a capture is shared or committed.

The wrapper pseudocode is explicitly conceptual and application-owned. It does
not claim a new mcporter API or built-in adapter.

## Validation

- `git diff --check`
- follow-up commit `7987ee1` records redacted outcomes for blocked, declined, policy-evaluation failure, execution failure, and successful paths

This changes only two existing Markdown files; no runtime API, template,
dependency, or configuration schema is modified.