### PR TITLE
fix: support Node 22.19 at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,38 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  packaged-runtime-node-22:
+    name: packaged runtime (node 22.19)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      # Development uses Node 24; this job separately proves that the artifact
+      # produced by that toolchain runs at the published runtime floor.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - run: corepack enable
+      - run: corepack prepare pnpm@10.33.2 --activate
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: mkdir -p /tmp/mcporter-node22 && pnpm pack --pack-destination /tmp/mcporter-node22
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.19.0
+
+      - name: Install and exercise the packaged runtime
+        shell: bash
+        run: |
+          cd /tmp/mcporter-node22
+          npm init -y
+          npm install --engine-strict ./mcporter-*.tgz
+          node --input-type=module -e "await import('mcporter')"
+          ./node_modules/.bin/mcporter --help
+
   build:
     name: build (${{ matrix.os }})
     timeout-minutes: 15

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,7 +29,7 @@ Or add it to a project:
 pnpm add mcporter        # or: npm install mcporter / bun add mcporter
 ```
 
-mcporter targets Node 24+ and works under Bun. The package exposes both an importable runtime (`createRuntime`, `callOnce`, `createServerProxy`) and the `mcporter` CLI binary.
+mcporter targets Node 22.19+ and works under Bun. Development and release builds use Node 24. The package exposes both an importable runtime (`createRuntime`, `callOnce`, `createServerProxy`) and the `mcporter` CLI binary.
 
 ## Homebrew
 

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     ]
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=22.19.0"
   },
   "packageManager": "pnpm@10.33.2"
 }


### PR DESCRIPTION
## Summary

- lower the published runtime engine floor from Node 24 to Node 22.19
- keep development and release builds on Node 24
- add a packaged-runtime CI job that builds on Node 24, installs the tarball with `--engine-strict` on Node 22.19, imports the library, and starts the CLI
- document the runtime/build distinction

## Why

The Node 24 floor was introduced alongside the development build move to newer tooling, but the published runtime does not require Node 24 APIs. Pi itself supports Node 22.19, and downstream Recipes integration has been exercised successfully at that floor.

This separates the development toolchain requirement from the actual package runtime contract and adds CI coverage to keep that contract honest.

## Validation

- `./runner pnpm check`
- `./runner pnpm build`
- `./runner pnpm test` — 837 passed, 3 skipped
- packed `mcporter@0.12.4`
- installed the tarball under Node 22.19 with `npm install --engine-strict`
- imported `mcporter` and ran the packaged `mcporter --help` under Node 22.19
- `actionlint .github/workflows/ci.yml`