### PR TITLE
fix(oauth): open Windows browser without shell-string URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### OAuth
 
+- Launch Windows OAuth browser open via separate `cmd /c start` argv elements so quote-bearing authorization URLs cannot break out of shell quoting. (thanks @SebTardif)
 - Recover rotating refresh tokens after transient OAuth refresh failures without clearing a concurrently persisted winner, and clear only the exact rejected token on `invalid_grant`. (PR #227, thanks @feniix)
 
 ### Distribution
@@ -53,6 +54,7 @@
 
 ### OAuth
 
+- Launch Windows OAuth browser open via separate `cmd /c start` argv elements so quote-bearing authorization URLs cannot break out of shell quoting. (thanks @SebTardif)
 - Treat corrupt cached OAuth tokens and client metadata as missing so connections can re-authenticate, while keeping corrupt callback state data fail-closed. (Issue #207, thanks @KrasimirKralev)
 
 ### Tooling / Dependencies
@@ -63,6 +65,7 @@
 
 ### OAuth
 
+- Launch Windows OAuth browser open via separate `cmd /c start` argv elements so quote-bearing authorization URLs cannot break out of shell quoting. (thanks @SebTardif)
 - Add cache-friendly `disableOAuth` support across headless runtime, CLI, daemon, proxy, and `callOnce` paths so callers can suppress interactive OAuth without losing connection reuse. (Issues #197, #199, #201, thanks @feniix)
 - Recover cleanly from renamed OAuth server entries, invalid refresh tokens, and stale dynamic client registrations without reusing unrelated same-URL credentials.
 - Prevent concurrent OAuth vault updates from briefly exposing empty lock files and losing credential entries under load.
@@ -125,6 +128,7 @@
 
 ### OAuth
 
+- Launch Windows OAuth browser open via separate `cmd /c start` argv elements so quote-bearing authorization URLs cannot break out of shell quoting. (thanks @SebTardif)
 - Add headless OAuth login support via `--no-browser`, `--browser none`, and `MCPORTER_OAUTH_NO_BROWSER`, emitting parseable authorization URLs for remote auth flows. (PR #171 / issue #169, thanks @feniix)
 - Proactively complete OAuth for configured HTTP servers that allow unauthenticated `initialize`/`listTools` but require credentials for tool calls, and close the local callback server promptly after browser authorization. (PR #159, thanks @Spacefish)
 - Refresh expired cached OAuth access tokens during non-interactive `mcporter list` without opening a browser or clearing cached credentials when refresh fails. (Issue #166, thanks @chrisabad)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,6 @@
 
 ### OAuth
 
-- Launch Windows OAuth browser open via separate `cmd /c start` argv elements so quote-bearing authorization URLs cannot break out of shell quoting. (thanks @SebTardif)
 - Treat corrupt cached OAuth tokens and client metadata as missing so connections can re-authenticate, while keeping corrupt callback state data fail-closed. (Issue #207, thanks @KrasimirKralev)
 
 ### Tooling / Dependencies
@@ -65,7 +64,6 @@
 
 ### OAuth
 
-- Launch Windows OAuth browser open via separate `cmd /c start` argv elements so quote-bearing authorization URLs cannot break out of shell quoting. (thanks @SebTardif)
 - Add cache-friendly `disableOAuth` support across headless runtime, CLI, daemon, proxy, and `callOnce` paths so callers can suppress interactive OAuth without losing connection reuse. (Issues #197, #199, #201, thanks @feniix)
 - Recover cleanly from renamed OAuth server entries, invalid refresh tokens, and stale dynamic client registrations without reusing unrelated same-URL credentials.
 - Prevent concurrent OAuth vault updates from briefly exposing empty lock files and losing credential entries under load.
@@ -128,7 +126,6 @@
 
 ### OAuth
 
-- Launch Windows OAuth browser open via separate `cmd /c start` argv elements so quote-bearing authorization URLs cannot break out of shell quoting. (thanks @SebTardif)
 - Add headless OAuth login support via `--no-browser`, `--browser none`, and `MCPORTER_OAUTH_NO_BROWSER`, emitting parseable authorization URLs for remote auth flows. (PR #171 / issue #169, thanks @feniix)
 - Proactively complete OAuth for configured HTTP servers that allow unauthenticated `initialize`/`listTools` but require credentials for tool calls, and close the local callback server promptly after browser authorization. (PR #159, thanks @Spacefish)
 - Refresh expired cached OAuth access tokens during non-interactive `mcporter list` without opening a browser or clearing cached credentials when refresh fails. (Issue #166, thanks @chrisabad)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 
 ### OAuth
 
-- Launch Windows OAuth browser open via `rundll32 url.dll,FileProtocolHandler` with the authorization URL as a separate argv element so quote-bearing URLs never pass through `cmd.exe`. (thanks @SebTardif)
 - Recover rotating refresh tokens after transient OAuth refresh failures without clearing a concurrently persisted winner, and clear only the exact rejected token on `invalid_grant`. (PR #227, thanks @feniix)
 
 ### Distribution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### OAuth
 
-- Launch Windows OAuth browser open via separate `cmd /c start` argv elements so quote-bearing authorization URLs cannot break out of shell quoting. (thanks @SebTardif)
+- Launch Windows OAuth browser open via `rundll32 url.dll,FileProtocolHandler` with the authorization URL as a separate argv element so quote-bearing URLs never pass through `cmd.exe`. (thanks @SebTardif)
 - Recover rotating refresh tokens after transient OAuth refresh failures without clearing a concurrently persisted winner, and clear only the exact rejected token on `invalid_grant`. (PR #227, thanks @feniix)
 
 ### Distribution

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -51,12 +51,13 @@ function openExternal(url: string, platform: NodeJS.Platform = process.platform,
       const child = launch('open', [url], { stdio, detached: true });
       child.unref();
     } else if (platform === 'win32') {
-      // Pass the URL as a separate argv element so Node quotes it.
-      // Never use windowsVerbatimArguments with a single shell string —
-      // quote-bearing OAuth URLs could break out of `start` quoting.
-      const child = launch('cmd', ['/c', 'start', '""', url], {
+      // Shell-free: do not pass the OAuth URL through cmd.exe. Command metacharacters
+      // such as `&` in query strings are still parsed by cmd even when argv is split.
+      // rundll32 FileProtocolHandler treats the URL as a document path, not command text.
+      const child = launch('rundll32', ['url.dll,FileProtocolHandler', url], {
         stdio,
         detached: true,
+        windowsHide: true,
       });
       child.unref();
     } else {

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -51,10 +51,12 @@ function openExternal(url: string, platform: NodeJS.Platform = process.platform,
       const child = launch('open', [url], { stdio, detached: true });
       child.unref();
     } else if (platform === 'win32') {
-      const child = launch('cmd', ['/s', '/c', `start "" "${url}"`], {
+      // Pass the URL as a separate argv element so Node quotes it.
+      // Never use windowsVerbatimArguments with a single shell string —
+      // quote-bearing OAuth URLs could break out of `start` quoting.
+      const child = launch('cmd', ['/c', 'start', '""', url], {
         stdio,
         detached: true,
-        windowsVerbatimArguments: true,
       });
       child.unref();
     } else {

--- a/tests/oauth-open-external.test.ts
+++ b/tests/oauth-open-external.test.ts
@@ -27,7 +27,7 @@ describe('openExternal', () => {
     expect(child.unref).toHaveBeenCalled();
   });
 
-  it('launches cmd.exe start with URL as a separate argv element on Windows', () => {
+  it('opens the browser via rundll32 FileProtocolHandler on Windows (no cmd.exe)', () => {
     const child = new EventEmitter() as EventEmitter & { unref: () => void };
     child.unref = vi.fn();
     const launch = vi.fn(() => child as unknown as ReturnType<typeof import('node:child_process').spawn>);
@@ -35,14 +35,15 @@ describe('openExternal', () => {
 
     __oauthInternals.openExternal(url, 'win32', launch as unknown as typeof import('node:child_process').spawn);
 
-    expect(launch).toHaveBeenCalledWith('cmd', ['/c', 'start', '""', url], {
+    expect(launch).toHaveBeenCalledWith('rundll32', ['url.dll,FileProtocolHandler', url], {
       stdio: 'ignore',
       detached: true,
+      windowsHide: true,
     });
     expect(child.unref).toHaveBeenCalled();
   });
 
-  it('keeps quote-bearing OAuth URLs out of a single cmd shell string on Windows', () => {
+  it('does not pass quote- or ampersand-bearing OAuth URLs through cmd.exe on Windows', () => {
     const child = new EventEmitter() as EventEmitter & { unref: () => void };
     child.unref = vi.fn();
     const launch = vi.fn(() => child as unknown as ReturnType<typeof import('node:child_process').spawn>);
@@ -50,10 +51,12 @@ describe('openExternal', () => {
 
     __oauthInternals.openExternal(url, 'win32', launch as unknown as typeof import('node:child_process').spawn);
 
-    const args = launch.mock.calls[0]?.[1] as string[];
-    expect(args).toEqual(['/c', 'start', '""', url]);
-    // URL must not be interpolated into a shell command string.
-    expect(args.some((a) => a.includes('start "" "') && a.includes(url))).toBe(false);
+    const [exe, args] = launch.mock.calls[0] as [string, string[]];
+    expect(exe).toBe('rundll32');
+    expect(args).toEqual(['url.dll,FileProtocolHandler', url]);
+    // Must not use cmd /c start (command-interpreter boundary).
+    expect(exe.toLowerCase()).not.toContain('cmd');
+    expect(args.some((a) => a === '/c' || a.toLowerCase() === 'start')).toBe(false);
     expect(child.unref).toHaveBeenCalled();
   });
 });

--- a/tests/oauth-open-external.test.ts
+++ b/tests/oauth-open-external.test.ts
@@ -27,7 +27,7 @@ describe('openExternal', () => {
     expect(child.unref).toHaveBeenCalled();
   });
 
-  it('quotes OAuth URLs when launching cmd.exe on Windows', () => {
+  it('launches cmd.exe start with URL as a separate argv element on Windows', () => {
     const child = new EventEmitter() as EventEmitter & { unref: () => void };
     child.unref = vi.fn();
     const launch = vi.fn(() => child as unknown as ReturnType<typeof import('node:child_process').spawn>);
@@ -35,11 +35,25 @@ describe('openExternal', () => {
 
     __oauthInternals.openExternal(url, 'win32', launch as unknown as typeof import('node:child_process').spawn);
 
-    expect(launch).toHaveBeenCalledWith('cmd', ['/s', '/c', `start "" "${url}"`], {
+    expect(launch).toHaveBeenCalledWith('cmd', ['/c', 'start', '""', url], {
       stdio: 'ignore',
       detached: true,
-      windowsVerbatimArguments: true,
     });
+    expect(child.unref).toHaveBeenCalled();
+  });
+
+  it('keeps quote-bearing OAuth URLs out of a single cmd shell string on Windows', () => {
+    const child = new EventEmitter() as EventEmitter & { unref: () => void };
+    child.unref = vi.fn();
+    const launch = vi.fn(() => child as unknown as ReturnType<typeof import('node:child_process').spawn>);
+    const url = 'https://example.com/auth?q="evil"&redirect_uri=http://127.0.0.1:1234/callback';
+
+    __oauthInternals.openExternal(url, 'win32', launch as unknown as typeof import('node:child_process').spawn);
+
+    const args = launch.mock.calls[0]?.[1] as string[];
+    expect(args).toEqual(['/c', 'start', '""', url]);
+    // URL must not be interpolated into a shell command string.
+    expect(args.some((a) => a.includes('start "" "') && a.includes(url))).toBe(false);
     expect(child.unref).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

On Windows, OAuth browser open used `cmd.exe` with the authorization URL inside a shell command string. A quote-bearing URL (from OAuth metadata or a malicious authorization server) can break out of quoting and run additional `cmd` side effects when `mcporter auth` launches the browser.

## Evidence

### Production launch argv (this branch: rundll32, not cmd)

```console
$ node --import tsx -e '
import { __oauthInternals } from "./src/oauth.ts";
const calls = [];
const launch = (cmd, args, opts) => { calls.push({ cmd, args, opts }); return { on(){}, unref(){} }; };
const url = "https://login.example/oauth?q=\"evil\"&x=1&y=2";
__oauthInternals.openExternal(url, "win32", launch);
console.log(JSON.stringify(calls, null, 2));
'
[
  {
    "cmd": "rundll32",
    "args": [
      "url.dll,FileProtocolHandler",
      "https://login.example/oauth?q=\"evil\"&x=1&y=2"
    ],
    "opts": {
      "stdio": "ignore",
      "detached": true,
      "windowsHide": true
    }
  }
]
```

### Focused tests

```console
$ pnpm exec vitest run tests/oauth-open-external.test.ts
 ✓ tests/oauth-open-external.test.ts (3 tests) 3ms
```

Asserted:
- win32 uses `rundll32` + `url.dll,FileProtocolHandler` + URL as separate argv
- quote/ampersand OAuth URL stays one argv element
- exe is never `cmd`; no `/c` / `start` tokens

Before (main): `cmd /s /c start "" "${url}"` with `windowsVerbatimArguments: true` (URL in one shell string).

## Real behavior proof

- **Behavior or issue addressed:** Windows OAuth browser launch must not place the authorization URL inside a `cmd.exe` shell-quoted command string.
- **Real environment tested:** macOS arm64; Windows launch path exercised via injectable `spawn` for platform `win32` on branch `fix/mcporter-audit-2291` head `05655b0`.
- **Exact steps or command run after this patch:** `node --import tsx` spawn spy above; `pnpm exec vitest run tests/oauth-open-external.test.ts`.
- **Evidence after fix:** terminal JSON and vitest PASS above.
- **Observed result after fix:** launch is `rundll32` with URL as a distinct argument; no command interpreter boundary.
- **What was not tested:** interactive browser open on a real Windows desktop (this change is the process argv boundary; desktop only confirms OS association for `FileProtocolHandler`).

## Summary

- Windows `openExternal` uses rundll32 FileProtocolHandler
- Regression tests for normal and quote-bearing OAuth URLs
- CHANGELOG under Unreleased OAuth

## Related

Refs #135 — prior Windows OAuth `openExternal` failure (URL truncated at `&` under `cmd.exe`). That path was mitigated by quoting in #136; this PR removes the `cmd.exe` shell boundary entirely.
