### PR TITLE
fix(oauth): invalidate cache on server URL changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### OAuth
 
 - Recover rotating refresh tokens after transient OAuth refresh failures without clearing a concurrently persisted winner, and clear only the exact rejected token on `invalid_grant`. (PR #227, thanks @feniix)
+- Treat a configured server URL change as a new OAuth trust boundary, clearing cached credentials permanently even if the URL is later reverted. (Issue #231, thanks @sourman)
 
 ### Distribution
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -150,6 +150,7 @@ Use `--scope home|project` with `mcporter config add` to pick the write target e
 - Mirrors `mcporter auth`. `login` completes OAuth (or token provisioning) for either a named server or an ad-hoc URL. When a hosted MCP returns 401/403, mcporter automatically promotes that target to OAuth and re-runs the flow, matching the behavior documented in `docs/adhoc.md`.
 - `--no-browser` suppresses automatic browser launch and prints the authorization URL to stdout so it can be copied from a headless host. `--browser none` is accepted as a compatibility alias, and `MCPORTER_OAUTH_NO_BROWSER=1` / `true` / `yes` enables the same behavior by environment.
 - In `--json --no-browser` mode, stdout contains a JSON object with `authorizationUrl` and `redirectUrl`; diagnostics stay off stdout so scripts can parse the result. Treat emitted authorization URLs as sensitive operational output.
+- A configured server name is an OAuth trust boundary. Changing its URL clears cached tokens, dynamic client registration, PKCE verifier, and callback state from the shared vault and any `tokenCacheDir`; changing the URL back does not restore the old credentials, so re-authentication is required.
 - `logout` wipes the shared vault entry, legacy `~/.mcporter/<name>/` caches, and the custom `tokenCacheDir` when present. Pass `--all` to clear everything.
 
 ### `mcporter config doctor`

--- a/src/oauth-persistence.ts
+++ b/src/oauth-persistence.ts
@@ -29,6 +29,7 @@ import {
   getOAuthVaultPath,
   loadVaultEntry,
   loadVaultEntryForRecovery,
+  reconcileVaultServerUrl,
   saveVaultEntry,
 } from './oauth-vault.js';
 import { legacyMcporterDir } from './paths.js';
@@ -168,15 +169,19 @@ class DirectoryPersistence implements OAuthPersistence {
   private readonly clientInfoPath: string;
   private readonly codeVerifierPath: string;
   private readonly statePath: string;
+  private readonly serverUrlPath: string;
 
   constructor(
     private readonly root: string,
-    private readonly logger?: Logger
+    private readonly logger?: Logger,
+    private readonly serverUrl?: string,
+    private readonly skipUrlMarkerWhenMissing = false
   ) {
     this.tokenPath = path.join(root, 'tokens.json');
     this.clientInfoPath = path.join(root, 'client.json');
     this.codeVerifierPath = path.join(root, 'code_verifier.txt');
     this.statePath = path.join(root, 'state.txt');
+    this.serverUrlPath = path.join(root, 'server_url.txt');
   }
 
   describe(): string {
@@ -187,12 +192,51 @@ class DirectoryPersistence implements OAuthPersistence {
     await fs.mkdir(this.root, { recursive: true });
   }
 
+  private async reconcileServerUrl(): Promise<void> {
+    if (!this.serverUrl) {
+      return;
+    }
+    const serverUrl = this.serverUrl;
+    if (this.skipUrlMarkerWhenMissing) {
+      try {
+        await fs.access(this.root);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          return;
+        }
+        throw error;
+      }
+    }
+    await this.ensureDir();
+    await withFileLock(this.tokenPath, async () => {
+      let previousUrl: string | undefined;
+      try {
+        previousUrl = (await fs.readFile(this.serverUrlPath, 'utf8')).trim();
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw error;
+        }
+      }
+      if (previousUrl === serverUrl) {
+        return;
+      }
+      // Keep the marker after invalidation so A -> B -> A cannot revive A's
+      // old directory-backed credentials.
+      if (previousUrl !== undefined) {
+        await this.clearFiles('all');
+      }
+      await writeTextFileAtomic(this.serverUrlPath, serverUrl);
+    });
+  }
+
   async readTokens(): Promise<OAuthTokens | undefined> {
+    await this.reconcileServerUrl();
     const tokens = await this.readJsonOrUndefined<OAuthTokens>(this.tokenPath);
     return tokens ? withHiddenOAuthTokenGeneration(tokens) : undefined;
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
+    await this.reconcileServerUrl();
     await this.ensureDir();
     // Locked so clearRejectedCredentials cannot compare-then-unlink across a
     // concurrent write.
@@ -206,6 +250,7 @@ class DirectoryPersistence implements OAuthPersistence {
     expectedTokens?: OAuthTokens,
     expectedClientInfo?: OAuthClientInformationMixed
   ): Promise<void> {
+    await this.reconcileServerUrl();
     await withFileLock(this.tokenPath, async () => {
       if (expectedTokens) {
         const current = await this.readJsonOrUndefined<OAuthTokens>(this.tokenPath);
@@ -233,11 +278,13 @@ class DirectoryPersistence implements OAuthPersistence {
   }
 
   async readClientInfo(): Promise<OAuthClientInformationMixed | undefined> {
+    await this.reconcileServerUrl();
     const info = await this.readJsonOrUndefined<OAuthClientInformationMixed>(this.clientInfoPath);
     return info ? withHiddenOAuthClientGeneration(info) : undefined;
   }
 
   async saveClientInfo(info: OAuthClientInformationMixed): Promise<void> {
+    await this.reconcileServerUrl();
     await this.ensureDir();
     await withFileLock(this.tokenPath, async () => {
       await writeJsonFile(this.clientInfoPath, withOAuthClientGeneration(info));
@@ -245,6 +292,7 @@ class DirectoryPersistence implements OAuthPersistence {
   }
 
   async readCodeVerifier(): Promise<string | undefined> {
+    await this.reconcileServerUrl();
     try {
       return (await fs.readFile(this.codeVerifierPath, 'utf8')).trim();
     } catch (error) {
@@ -256,11 +304,13 @@ class DirectoryPersistence implements OAuthPersistence {
   }
 
   async saveCodeVerifier(value: string): Promise<void> {
+    await this.reconcileServerUrl();
     await this.ensureDir();
     await writeTextFileAtomic(this.codeVerifierPath, value);
   }
 
   async readState(): Promise<string | undefined> {
+    await this.reconcileServerUrl();
     // Deliberately NOT corrupt-tolerant: a corrupt OAuth state must fail the
     // flow closed. Returning undefined here would skip the CSRF state check on
     // the authorization callback (see oauth.ts), so only the credential caches
@@ -287,11 +337,17 @@ class DirectoryPersistence implements OAuthPersistence {
   }
 
   async saveState(value: string): Promise<void> {
+    await this.reconcileServerUrl();
     await this.ensureDir();
     await writeJsonFile(this.statePath, value);
   }
 
   async clear(scope: OAuthClearScope): Promise<void> {
+    await this.reconcileServerUrl();
+    await this.clearFiles(scope);
+  }
+
+  private async clearFiles(scope: OAuthClearScope): Promise<void> {
     const files: string[] = [];
     if (scope === 'all' || scope === 'tokens') {
       files.push(this.tokenPath);
@@ -329,43 +385,56 @@ class VaultPersistence implements OAuthPersistence {
     return `${getOAuthVaultPath()} (vault)`;
   }
 
+  private async reconcileServerUrl(): Promise<void> {
+    await reconcileVaultServerUrl(this.definition);
+  }
+
   async readTokens(): Promise<OAuthTokens | undefined> {
+    await this.reconcileServerUrl();
     const recovery = await loadVaultEntryForRecovery(this.definition);
     this.tokenSnapshots = recovery.tokenSnapshots;
     return recovery.entry?.tokens;
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
+    await this.reconcileServerUrl();
     await saveVaultEntry(this.definition, { tokens: prepareStoredTokens(tokens) });
   }
 
   async readClientInfo(): Promise<OAuthClientInformationMixed | undefined> {
+    await this.reconcileServerUrl();
     const recovery = await loadVaultEntryForRecovery(this.definition);
     this.clientSnapshots = recovery.clientSnapshots;
     return recovery.entry?.clientInfo;
   }
 
   async saveClientInfo(info: OAuthClientInformationMixed): Promise<void> {
+    await this.reconcileServerUrl();
     await saveVaultEntry(this.definition, { clientInfo: info });
   }
 
   async readCodeVerifier(): Promise<string | undefined> {
+    await this.reconcileServerUrl();
     return (await loadVaultEntry(this.definition))?.codeVerifier;
   }
 
   async saveCodeVerifier(value: string): Promise<void> {
+    await this.reconcileServerUrl();
     await saveVaultEntry(this.definition, { codeVerifier: value });
   }
 
   async readState(): Promise<string | undefined> {
+    await this.reconcileServerUrl();
     return (await loadVaultEntry(this.definition))?.state;
   }
 
   async saveState(value: string): Promise<void> {
+    await this.reconcileServerUrl();
     await saveVaultEntry(this.definition, { state: value });
   }
 
   async clear(scope: OAuthClearScope): Promise<void> {
+    await this.reconcileServerUrl();
     await clearVaultEntry(this.definition, scope);
   }
 
@@ -373,6 +442,7 @@ class VaultPersistence implements OAuthPersistence {
     expectedTokens?: OAuthTokens,
     expectedClientInfo?: OAuthClientInformationMixed
   ): Promise<void> {
+    await this.reconcileServerUrl();
     await clearVaultTokensIfMatching(
       this.definition,
       expectedTokens,
@@ -510,15 +580,16 @@ class CompositePersistence implements OAuthPersistence {
 export async function buildOAuthPersistence(definition: ServerDefinition, logger?: Logger): Promise<OAuthPersistence> {
   const vault = new VaultPersistence(definition);
   const stores: OAuthPersistence[] = [vault];
+  const serverUrl = definition.command.kind === 'http' ? definition.command.url.toString() : undefined;
 
   if (definition.tokenCacheDir) {
-    stores.unshift(new DirectoryPersistence(definition.tokenCacheDir, logger));
+    stores.unshift(new DirectoryPersistence(definition.tokenCacheDir, logger, serverUrl));
   }
 
   // Migrate legacy default per-server cache (~/.mcporter/<name>) into the vault if present.
   const legacyDir = path.join(legacyMcporterDir(), definition.name);
   if (!definition.tokenCacheDir && legacyDir) {
-    const legacy = new DirectoryPersistence(legacyDir, logger);
+    const legacy = new DirectoryPersistence(legacyDir, logger, serverUrl, true);
     const legacyTokens = await legacy.readTokens();
     const legacyClient = await legacy.readClientInfo();
     const legacyVerifier = await legacy.readCodeVerifier();

--- a/src/oauth-vault.ts
+++ b/src/oauth-vault.ts
@@ -30,6 +30,7 @@ export interface VaultEntry {
 interface VaultFile {
   version: 1;
   entries: Record<VaultKey, VaultEntry>;
+  serverUrls?: Record<string, string>;
 }
 
 interface VaultReadState {
@@ -94,6 +95,56 @@ export function vaultKeyForDefinition(definition: ServerDefinition): VaultKey {
   };
   const hash = crypto.createHash('sha256').update(JSON.stringify(descriptor)).digest('hex').slice(0, 16);
   return `${definition.name}|${hash}`;
+}
+
+// A configured name is the user's stable identity for an MCP server. Its URL
+// is therefore a trust boundary: changing it must retire every credential that
+// could otherwise become reachable again if the URL is later reverted.
+export async function reconcileVaultServerUrl(definition: ServerDefinition): Promise<void> {
+  if (definition.command.kind !== 'http') {
+    return;
+  }
+  const serverUrl = definition.command.url.toString();
+  await withFileLock(getOAuthVaultPath(), async () => {
+    const { vault, needsRepair } = await readVaultState();
+    const serverUrls = stringRecord(vault.serverUrls);
+    const previousUrl = serverUrls[definition.name];
+    const namedEntryUrls = Object.values(vault.entries)
+      .filter((entry) => isVaultEntry(entry) && entry.serverName === definition.name)
+      .flatMap((entry) => (typeof entry.serverUrl === 'string' ? [entry.serverUrl] : []));
+    const urlChanged =
+      (previousUrl !== undefined && previousUrl !== serverUrl) || namedEntryUrls.some((url) => url !== serverUrl);
+
+    if (urlChanged) {
+      const invalidatedUrls = new Set([serverUrl, previousUrl, ...namedEntryUrls].filter((url) => url !== undefined));
+      for (const [key, entry] of Object.entries(vault.entries)) {
+        if (
+          isVaultEntry(entry) &&
+          (entry.serverName === definition.name ||
+            (isLegacyOAuthRenameCandidate(definition, entry) &&
+              entry.serverUrl !== undefined &&
+              invalidatedUrls.has(entry.serverUrl)))
+        ) {
+          delete vault.entries[key];
+        }
+      }
+    }
+
+    if (previousUrl === serverUrl && !urlChanged && !needsRepair) {
+      return;
+    }
+    vault.serverUrls = { ...serverUrls, [definition.name]: serverUrl };
+    await writeVault(vault);
+  });
+}
+
+function stringRecord(value: unknown): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+  );
 }
 
 export async function loadVaultEntry(definition: ServerDefinition): Promise<VaultEntry | undefined> {

--- a/tests/oauth-persistence.test.ts
+++ b/tests/oauth-persistence.test.ts
@@ -28,6 +28,11 @@ const mkDef = (name: string, tokenCacheDir?: string): ServerDefinition => ({
   tokenCacheDir,
 });
 
+const withUrl = (definition: ServerDefinition, url: string): ServerDefinition => ({
+  ...definition,
+  command: { kind: 'http', url: new URL(url) },
+});
+
 describe('oauth persistence', () => {
   const originalEnv = { ...process.env };
   const tempRoots: string[] = [];
@@ -121,6 +126,68 @@ describe('oauth persistence', () => {
     expect(cacheTokens?.access_token).toBe('new-token');
     const entry = await loadVaultEntry(definition);
     expect(entry?.tokens?.access_token).toBe('new-token');
+  });
+
+  it('preserves cached OAuth state when the configured server URL is unchanged', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-url-same-'));
+    tempRoots.push(tmp);
+    homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(path.join(tmp, 'home'));
+    hasSpy = true;
+    process.env.XDG_DATA_HOME = path.join(tmp, 'data');
+
+    const definition = mkDef('supabase', path.join(tmp, 'cache'));
+    const initial = await buildOAuthPersistence(definition);
+    await initial.saveTokens({ access_token: 'token-a', token_type: 'Bearer' });
+    await initial.saveClientInfo({ client_id: 'client-a' });
+    await initial.saveCodeVerifier('verifier-a');
+    await initial.saveState('state-a');
+
+    const unchanged = await buildOAuthPersistence(withUrl(definition, 'https://example.com/mcp'));
+    await expect(unchanged.readTokens()).resolves.toMatchObject({ access_token: 'token-a' });
+    await expect(unchanged.readClientInfo()).resolves.toMatchObject({ client_id: 'client-a' });
+    await expect(unchanged.readCodeVerifier()).resolves.toBe('verifier-a');
+    await expect(unchanged.readState()).resolves.toBe('state-a');
+  });
+
+  it('invalidates cached OAuth state when the configured server URL changes', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-url-change-'));
+    tempRoots.push(tmp);
+    homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(path.join(tmp, 'home'));
+    hasSpy = true;
+    process.env.XDG_DATA_HOME = path.join(tmp, 'data');
+
+    const original = mkDef('supabase', path.join(tmp, 'cache'));
+    const initial = await buildOAuthPersistence(original);
+    await initial.saveTokens({ access_token: 'token-a', token_type: 'Bearer' });
+    await initial.saveClientInfo({ client_id: 'client-a' });
+    await initial.saveCodeVerifier('verifier-a');
+    await initial.saveState('state-a');
+
+    const changed = await buildOAuthPersistence(withUrl(original, 'https://other.example.com/mcp'));
+    await expect(changed.readTokens()).resolves.toBeUndefined();
+    await expect(changed.readClientInfo()).resolves.toBeUndefined();
+    await expect(changed.readCodeVerifier()).resolves.toBeUndefined();
+    await expect(changed.readState()).resolves.toBeUndefined();
+  });
+
+  it('does not restore cached OAuth state when a changed server URL is reverted', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-url-revert-'));
+    tempRoots.push(tmp);
+    homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(path.join(tmp, 'home'));
+    hasSpy = true;
+    process.env.XDG_DATA_HOME = path.join(tmp, 'data');
+
+    const original = mkDef('supabase', path.join(tmp, 'cache'));
+    const initial = await buildOAuthPersistence(original);
+    await initial.saveTokens({ access_token: 'token-a', token_type: 'Bearer' });
+    await initial.saveClientInfo({ client_id: 'client-a' });
+
+    const changed = await buildOAuthPersistence(withUrl(original, 'https://other.example.com/mcp'));
+    await expect(changed.readTokens()).resolves.toBeUndefined();
+
+    const reverted = await buildOAuthPersistence(original);
+    await expect(reverted.readTokens()).resolves.toBeUndefined();
+    await expect(reverted.readClientInfo()).resolves.toBeUndefined();
   });
 
   it.runIf(process.platform !== 'win32')(


### PR DESCRIPTION
## Summary

- treat a configured server name plus URL as the OAuth trust boundary
- clear shared-vault and directory-backed OAuth state when that URL changes
- persist the current URL so changing it back cannot resurrect old credentials
- document the re-authentication behavior and add the changelog credit

## Proof

- `pnpm exec vitest run tests/oauth-persistence.test.ts tests/oauth-session.test.ts tests/runtime-transport.test.ts` — 88 passed
- `pnpm check` — passed
- `pnpm test` — 840 passed, 3 skipped
- source-blind local MCP proof: same URL reused the seeded token; changed URL and changed-then-reverted both withheld it and reported auth required
- autoreview local — clean, no accepted/actionable findings

## Live Supabase gap

The current machine has no configured Supabase server, no Supabase credential environment variables, no local Supabase OAuth-vault entry, and no Supabase item in the approved Molty vault. Provider-specific live proof was therefore unavailable; deterministic regression and live local MCP transport proof cover the decided semantics.

Closes #231
