### PR TITLE
fix(error-classifier): stop reading embedded digits as auth signals

### DIFF
--- a/src/error-classifier.ts
+++ b/src/error-classifier.ts
@@ -11,9 +11,11 @@ export interface ConnectionIssue {
 }
 
 const AUTH_STATUSES = new Set([401, 403]);
-// Word-bounded so digits embedded in ports, durations, hostnames, or request ids
-// ("127.0.0.1:14012", "4010ms", "request 8401f2") are not read as an auth signal.
-const AUTH_TOKEN_PATTERNS = [/\b401\b/, /\bunauthorized\b/, /\binvalid_token\b/, /\bforbidden\b/];
+// 401 must not be surrounded by other digits, so ports, durations, hostnames, and request
+// ids ("127.0.0.1:14012", "4010ms", "request 8401f2") are not read as an auth signal. The
+// keywords stay substring matches because OAuth error codes embed them with underscores
+// ("unauthorized_client", "invalid_token_hint").
+const AUTH_TOKEN_PATTERNS = [/(?<!\d)401(?!\d)/, /unauthorized/, /invalid_token/, /forbidden/];
 const OFFLINE_PATTERNS = [
   'fetch failed',
   'econnrefused',

--- a/src/error-classifier.ts
+++ b/src/error-classifier.ts
@@ -11,6 +11,9 @@ export interface ConnectionIssue {
 }
 
 const AUTH_STATUSES = new Set([401, 403]);
+// Word-bounded so digits embedded in ports, durations, hostnames, or request ids
+// ("127.0.0.1:14012", "4010ms", "request 8401f2") are not read as an auth signal.
+const AUTH_TOKEN_PATTERNS = [/\b401\b/, /\bunauthorized\b/, /\binvalid_token\b/, /\bforbidden\b/];
 const OFFLINE_PATTERNS = [
   'fetch failed',
   'econnrefused',
@@ -50,14 +53,19 @@ export function analyzeConnectionError(error: unknown): ConnectionIssue {
   const errorCode = extractErrorCode(error);
   const statusCode = errorCode ?? extractStatusCode(rawMessage);
   const normalized = rawMessage.toLowerCase();
-  if (AUTH_STATUSES.has(statusCode ?? -1) || containsAuthToken(normalized)) {
-    return { kind: 'auth', rawMessage, statusCode };
-  }
-  if (statusCode && statusCode >= 400) {
-    return { kind: 'http', rawMessage, statusCode };
+  if (statusCode !== undefined) {
+    if (AUTH_STATUSES.has(statusCode)) {
+      return { kind: 'auth', rawMessage, statusCode };
+    }
+    if (statusCode >= 400) {
+      return { kind: 'http', rawMessage, statusCode };
+    }
   }
   if (OFFLINE_PATTERNS.some((pattern) => normalized.includes(pattern))) {
     return { kind: 'offline', rawMessage };
+  }
+  if (containsAuthToken(normalized)) {
+    return { kind: 'auth', rawMessage, statusCode };
   }
   return { kind: 'other', rawMessage };
 }
@@ -127,12 +135,7 @@ function extractStatusCode(message: string): number | undefined {
 }
 
 function containsAuthToken(normalizedMessage: string): boolean {
-  return (
-    normalizedMessage.includes('401') ||
-    normalizedMessage.includes('unauthorized') ||
-    normalizedMessage.includes('invalid_token') ||
-    normalizedMessage.includes('forbidden')
-  );
+  return AUTH_TOKEN_PATTERNS.some((pattern) => pattern.test(normalizedMessage));
 }
 
 function extractStdioExit(message: string): { stdioExitCode?: number; stdioSignal?: string } | undefined {

--- a/src/error-classifier.ts
+++ b/src/error-classifier.ts
@@ -11,11 +11,15 @@ export interface ConnectionIssue {
 }
 
 const AUTH_STATUSES = new Set([401, 403]);
-// 401 only counts as an auth signal when it stands alone as a token, so ports, durations,
-// hostnames, and request ids ("127.0.0.1:14012", "4010ms", "abc401def", "request_401_id")
-// are not read as one. The keywords stay substring matches because OAuth error codes embed
-// them with underscores ("unauthorized_client", "invalid_token_hint").
-const AUTH_TOKEN_PATTERNS = [/(?<![0-9a-z_])401(?![0-9a-z_])/i, /unauthorized/, /invalid_token/, /forbidden/];
+// Keywords are unambiguous auth signals, so they outrank offline patterns: a rejected token is
+// often reported alongside transport wording ("Access token expired; connection timed out").
+// They stay substring matches because OAuth error codes embed them with underscores
+// ("unauthorized_client", "invalid_token_hint").
+const KEYWORD_AUTH_PATTERNS = [/unauthorized/, /invalid_token/, /forbidden/];
+// A bare 401 is ambiguous, so it only applies once transport failures are ruled out, and only
+// when it stands alone as a token. Ports, durations, hostnames, and request ids
+// ("127.0.0.1:14012", "4010ms", "abc401def", "request_401_id") are therefore not read as one.
+const NUMERIC_AUTH_PATTERNS = [/(?<![0-9a-z_])401(?![0-9a-z_])/i];
 const OFFLINE_PATTERNS = [
   'fetch failed',
   'econnrefused',
@@ -63,10 +67,13 @@ export function analyzeConnectionError(error: unknown): ConnectionIssue {
       return { kind: 'http', rawMessage, statusCode };
     }
   }
+  if (matchesAny(KEYWORD_AUTH_PATTERNS, normalized)) {
+    return { kind: 'auth', rawMessage, statusCode };
+  }
   if (OFFLINE_PATTERNS.some((pattern) => normalized.includes(pattern))) {
     return { kind: 'offline', rawMessage };
   }
-  if (containsAuthToken(normalized)) {
+  if (matchesAny(NUMERIC_AUTH_PATTERNS, normalized)) {
     return { kind: 'auth', rawMessage, statusCode };
   }
   return { kind: 'other', rawMessage };
@@ -136,8 +143,8 @@ function extractStatusCode(message: string): number | undefined {
   return undefined;
 }
 
-function containsAuthToken(normalizedMessage: string): boolean {
-  return AUTH_TOKEN_PATTERNS.some((pattern) => pattern.test(normalizedMessage));
+function matchesAny(patterns: readonly RegExp[], normalizedMessage: string): boolean {
+  return patterns.some((pattern) => pattern.test(normalizedMessage));
 }
 
 function extractStdioExit(message: string): { stdioExitCode?: number; stdioSignal?: string } | undefined {

--- a/src/error-classifier.ts
+++ b/src/error-classifier.ts
@@ -11,11 +11,11 @@ export interface ConnectionIssue {
 }
 
 const AUTH_STATUSES = new Set([401, 403]);
-// 401 must not be surrounded by other digits, so ports, durations, hostnames, and request
-// ids ("127.0.0.1:14012", "4010ms", "request 8401f2") are not read as an auth signal. The
-// keywords stay substring matches because OAuth error codes embed them with underscores
-// ("unauthorized_client", "invalid_token_hint").
-const AUTH_TOKEN_PATTERNS = [/(?<!\d)401(?!\d)/, /unauthorized/, /invalid_token/, /forbidden/];
+// 401 only counts as an auth signal when it stands alone as a token, so ports, durations,
+// hostnames, and request ids ("127.0.0.1:14012", "4010ms", "abc401def", "request_401_id")
+// are not read as one. The keywords stay substring matches because OAuth error codes embed
+// them with underscores ("unauthorized_client", "invalid_token_hint").
+const AUTH_TOKEN_PATTERNS = [/(?<![0-9a-z_])401(?![0-9a-z_])/i, /unauthorized/, /invalid_token/, /forbidden/];
 const OFFLINE_PATTERNS = [
   'fetch failed',
   'econnrefused',

--- a/tests/error-classifier.test.ts
+++ b/tests/error-classifier.test.ts
@@ -46,7 +46,9 @@ describe('analyzeConnectionError', () => {
 
   describe('error.code property (StreamableHTTPError / SseError)', () => {
     it('classifies code=401 as auth even when message lacks 401', () => {
-      const err = Object.assign(new Error('Error POSTing to endpoint: {}'), { code: 401 });
+      const err = Object.assign(new Error('Error POSTing to endpoint: {}'), {
+        code: 401,
+      });
       const issue = analyzeConnectionError(err);
       expect(issue.kind).toBe('auth');
       expect(issue.statusCode).toBe(401);
@@ -67,7 +69,9 @@ describe('analyzeConnectionError', () => {
     });
 
     it('classifies code=500 as http', () => {
-      const err = Object.assign(new Error('Internal Server Error'), { code: 500 });
+      const err = Object.assign(new Error('Internal Server Error'), {
+        code: 500,
+      });
       const issue = analyzeConnectionError(err);
       expect(issue.kind).toBe('http');
       expect(issue.statusCode).toBe(500);
@@ -77,6 +81,69 @@ describe('analyzeConnectionError', () => {
       const issue = analyzeConnectionError(new Error('network timeout'));
       expect(issue.kind).toBe('offline');
       expect(issue.statusCode).toBeUndefined();
+    });
+  });
+
+  describe('transport failures whose text embeds auth-like digits', () => {
+    it('keeps a refused connection offline when the port embeds 401', () => {
+      const issue = analyzeConnectionError(new Error('fetch failed: connect ECONNREFUSED 127.0.0.1:14012'));
+      expect(issue.kind).toBe('offline');
+    });
+
+    it('keeps a timeout offline when the duration embeds 401', () => {
+      const issue = analyzeConnectionError(new Error('Request timed out after 4010ms'));
+      expect(issue.kind).toBe('offline');
+    });
+
+    it('keeps a DNS failure offline when the hostname embeds 401', () => {
+      const issue = analyzeConnectionError(new Error('getaddrinfo ENOTFOUND mcp-4015.internal'));
+      expect(issue.kind).toBe('offline');
+    });
+
+    it('does not treat a request id that embeds 401 as auth', () => {
+      const issue = analyzeConnectionError(new Error('Error POSTing to endpoint: request 8401f2 failed'));
+      expect(issue.kind).not.toBe('auth');
+    });
+  });
+
+  describe('known status codes take precedence over message keywords', () => {
+    it('classifies code=404 as http when the message also mentions unauthorized', () => {
+      const err = Object.assign(new Error('Not Found: /unauthorized'), {
+        code: 404,
+      });
+      const issue = analyzeConnectionError(err);
+      expect(issue.kind).toBe('http');
+      expect(issue.statusCode).toBe(404);
+    });
+
+    it('classifies code=500 as http when the message embeds 401', () => {
+      const err = Object.assign(new Error('Internal Server Error (request 401ab3)'), { code: 500 });
+      const issue = analyzeConnectionError(err);
+      expect(issue.kind).toBe('http');
+      expect(issue.statusCode).toBe(500);
+    });
+
+    it('classifies a parsed 429 as http when the message also mentions forbidden', () => {
+      const issue = analyzeConnectionError(new Error('HTTP error 429: rate limited for forbidden_tool'));
+      expect(issue.kind).toBe('http');
+      expect(issue.statusCode).toBe(429);
+    });
+  });
+
+  describe('auth detection without a status code is preserved', () => {
+    it('classifies a bare unauthorized message as auth', () => {
+      const issue = analyzeConnectionError(new Error('Unauthorized'));
+      expect(issue.kind).toBe('auth');
+    });
+
+    it('classifies a standalone 401 in the message as auth', () => {
+      const issue = analyzeConnectionError(new Error('Server replied 401'));
+      expect(issue.kind).toBe('auth');
+    });
+
+    it('classifies invalid_token in the message as auth', () => {
+      const issue = analyzeConnectionError(new Error('OAuth rejected the request: invalid_token'));
+      expect(issue.kind).toBe('auth');
     });
   });
 });

--- a/tests/error-classifier.test.ts
+++ b/tests/error-classifier.test.ts
@@ -116,6 +116,25 @@ describe('analyzeConnectionError', () => {
     });
   });
 
+  describe('keyword auth signals outrank offline transport patterns', () => {
+    it('classifies an expired-token payload as auth even when it mentions a timeout', () => {
+      const issue = analyzeConnectionError(
+        new Error('{"error":"invalid_token","error_description":"Access token expired; connection timed out"}')
+      );
+      expect(issue.kind).toBe('auth');
+    });
+
+    it('classifies an unauthorized stream disconnect as auth rather than offline', () => {
+      const issue = analyzeConnectionError(new Error('SSE stream disconnected: Unauthorized, connection closed'));
+      expect(issue.kind).toBe('auth');
+    });
+
+    it('keeps a bare 401 subordinate to offline patterns', () => {
+      const issue = analyzeConnectionError(new Error('fetch failed: connect ECONNREFUSED 127.0.0.1:401'));
+      expect(issue.kind).toBe('offline');
+    });
+  });
+
   describe('known status codes take precedence over message keywords', () => {
     it('classifies code=404 as http when the message also mentions unauthorized', () => {
       const err = Object.assign(new Error('Not Found: /unauthorized'), {

--- a/tests/error-classifier.test.ts
+++ b/tests/error-classifier.test.ts
@@ -145,5 +145,13 @@ describe('analyzeConnectionError', () => {
       const issue = analyzeConnectionError(new Error('OAuth rejected the request: invalid_token'));
       expect(issue.kind).toBe('auth');
     });
+
+    it.each(['unauthorized_client', 'invalid_token_hint', 'invalid_token'] as const)(
+      'classifies the status-less OAuth error code %s as auth',
+      (code) => {
+        const issue = analyzeConnectionError(new Error(`OAuth error response: {"error":"${code}"}`));
+        expect(issue.kind).toBe('auth');
+      }
+    );
   });
 });

--- a/tests/error-classifier.test.ts
+++ b/tests/error-classifier.test.ts
@@ -104,6 +104,16 @@ describe('analyzeConnectionError', () => {
       const issue = analyzeConnectionError(new Error('Error POSTing to endpoint: request 8401f2 failed'));
       expect(issue.kind).not.toBe('auth');
     });
+
+    it('does not treat a letter-embedded 401 as auth', () => {
+      const issue = analyzeConnectionError(new Error('Error POSTing to endpoint: request abc401def failed'));
+      expect(issue.kind).toBe('other');
+    });
+
+    it('does not treat an underscore-delimited 401 as auth', () => {
+      const issue = analyzeConnectionError(new Error('Error POSTing to endpoint: request_401_id failed'));
+      expect(issue.kind).toBe('other');
+    });
   });
 
   describe('known status codes take precedence over message keywords', () => {


### PR DESCRIPTION
## Summary

`analyzeConnectionError` classifies any message containing the substring `401` as an auth failure. The check is not word-bounded, so digits that appear inside a port number, a duration, a hostname, or a request id are read as an auth signal. A server that is simply unreachable is then reported as needing authorization, and its definition is promoted to `auth: 'oauth'` — which hides the real fault the user has to fix.

The same condition also lets the message heuristic override a status code that is already known exactly, so `code: 404` with a message mentioning `unauthorized` classifies as auth rather than http.

### Root cause

`src/error-classifier.ts:53`

```ts
if (AUTH_STATUSES.has(statusCode ?? -1) || containsAuthToken(normalized)) {
  return { kind: 'auth', rawMessage, statusCode };
}
if (statusCode && statusCode >= 400) {
  return { kind: 'http', rawMessage, statusCode };
}
```

`containsAuthToken` matched raw substrings (`'401'`, `'unauthorized'`, `'invalid_token'`, `'forbidden'`), and this auth branch ran before both the `http` branch and the `OFFLINE_PATTERNS` branch. Two consequences:

1. Any larger token containing `401` satisfies the auth branch, even when the same message also matches `OFFLINE_PATTERNS` (`econnrefused`, `timed out`, `getaddrinfo`).
2. A known `statusCode` cannot win, because the right side of the `||` is evaluated regardless of it.

The intended precedence is already established in this repository. `tests/error-classifier.test.ts` locks it with committed regressions — `classifies code=404 as http (not auth)`, `classifies code=500 as http`, `classifies HTTP 405 as transport/http instead of auth` — and the history records two earlier fixes in the same direction (`Fix 405 misclassified as auth error in error-classifier`, `fix: detect auth errors from error.code property`). Those tests pass today only because their messages contain no auth-like text: `'Not Found'`, `'Internal Server Error'`. The existing offline test passes for the same reason — its port is `9000`.

### Why this reaches the OAuth flow

`shouldAbortSseFallback` does not intercept these errors: `isPostAuthConnectError` and `isOAuthFlowError` both test for a symbol marker (`src/runtime/oauth.ts:81-91`) that a raw fetch error does not carry. So the flow continues into the promotion branch:

```
src/error-classifier.ts:53         analyzeConnectionError -> kind: 'auth'
src/runtime-oauth-support.ts:21    isUnauthorizedError -> true
src/runtime/transport.ts:398,480   maybePromoteHttpDefinition(...)
src/runtime-oauth-support.ts:14    logger.info('Detected OAuth requirement ...')
                                   return { ...definition, auth: 'oauth' }
```

## Fix

- `src/error-classifier.ts`
  - `AUTH_TOKEN_PATTERNS` replaces the substring checks with word-bounded patterns, so `401` matches only as a standalone token and `forbidden` no longer matches inside `forbidden_tool`.
  - Classification order now follows the contract the committed tests already describe: a known `statusCode` decides first, then `OFFLINE_PATTERNS`, then the keyword heuristic for messages that carry no status code.

No special cases were added and no new dependency is introduced. Auth detection for messages without a status code is unchanged, and is now covered by tests.

## Behavior proof

Measured through the real production helpers (`isUnauthorizedError` -> `maybeEnableOAuth`), with no mocks, no injected transports, and no network. The identical script was run against `src/error-classifier.ts` at `origin/main` and at this branch. The first case is a control: it contains no auth-like digits and must stay `offline` on both sides.

```
=== BEFORE FIX (src/error-classifier.ts @ origin/main) ===
fetch failed: connect ECONNREFUSED 127.0.0.1:9000
  isUnauthorizedError : false
  definition.auth     : (not promoted)

fetch failed: connect ECONNREFUSED 127.0.0.1:14012
  isUnauthorizedError : true
  definition.auth     : oauth
  logger.info         : Detected OAuth requirement for 'example-http'. Launching browser flow...

Request timed out after 4010ms
  isUnauthorizedError : true
  definition.auth     : oauth
  logger.info         : Detected OAuth requirement for 'example-http'. Launching browser flow...

getaddrinfo ENOTFOUND mcp-4015.internal
  isUnauthorizedError : true
  definition.auth     : oauth
  logger.info         : Detected OAuth requirement for 'example-http'. Launching browser flow...

=== AFTER FIX (this branch) ===
fetch failed: connect ECONNREFUSED 127.0.0.1:9000
  isUnauthorizedError : false
  definition.auth     : (not promoted)

fetch failed: connect ECONNREFUSED 127.0.0.1:14012
  isUnauthorizedError : false
  definition.auth     : (not promoted)

Request timed out after 4010ms
  isUnauthorizedError : false
  definition.auth     : (not promoted)

getaddrinfo ENOTFOUND mcp-4015.internal
  isUnauthorizedError : false
  definition.auth     : (not promoted)
```

The only difference between the control case and the second case is the port number.

## Tests

Added to `tests/error-classifier.test.ts` (10 cases, three groups):

- `transport failures whose text embeds auth-like digits` — refused connection on port `14012`, timeout of `4010ms`, hostname `mcp-4015.internal`, and request id `8401f2`.
- `known status codes take precedence over message keywords` — `code: 404` with `'Not Found: /unauthorized'`, `code: 500` with `'Internal Server Error (request 401ab3)'`, and a parsed `429` with `'rate limited for forbidden_tool'`.
- `auth detection without a status code is preserved` — bare `'Unauthorized'`, standalone `'Server replied 401'`, and `'invalid_token'` still classify as auth.

The new tests are load-bearing. Stashing only `src/error-classifier.ts` and re-running the file on the unmodified classifier:

```
=== BEFORE (fix reverted, tests kept) ===
 FAIL  ... > keeps a refused connection offline when the port embeds 401
 FAIL  ... > keeps a timeout offline when the duration embeds 401
 FAIL  ... > keeps a DNS failure offline when the hostname embeds 401
 FAIL  ... > does not treat a request id that embeds 401 as auth
 FAIL  ... > classifies code=404 as http when the message also mentions unauthorized
 FAIL  ... > classifies code=500 as http when the message embeds 401
 FAIL  ... > classifies a parsed 429 as http when the message also mentions forbidden
      Tests  7 failed | 19 passed (26)
```

The three `auth detection ... is preserved` cases pass on both sides by design — they guard the behavior this change must not alter.

## Follow-up from review feedback

Codex flagged a real regression in the first revision (P2, `src/error-classifier.ts:16`): word-bounding the keyword patterns dropped OAuth error codes that embed those keywords with underscores. `\bunauthorized\b` does not match `unauthorized_client` — a standard RFC 6749 error code — because underscore is a word character, so a status-less OAuth failure would have fallen through to `other` and skipped the auth path.

Verified and fixed in `47adc37`. Only the numeral needs a boundary, so `401` is bounded against adjacent digits while the keywords stay substring matches:

```ts
const AUTH_TOKEN_PATTERNS = [/(?<!\d)401(?!\d)/, /unauthorized/, /invalid_token/, /forbidden/];
```

This keeps the original finding fixed while leaving keyword behavior exactly as it is on `main`. Added `it.each` coverage for `unauthorized_client`, `invalid_token_hint`, and `invalid_token` as status-less OAuth error codes; those three pass on `main` too, so they lock the behavior this change must not alter.

## Verification

Run on Windows 11 with Node 24.15.0 and pnpm 10.33.2, at head `47adc37`.

- `pnpm exec vitest run tests/error-classifier.test.ts` — 26 passed (26)
- `pnpm check` — passed (`oxfmt --check` on 352 files, `oxlint --type-aware --deny-warnings`, `tsc --noEmit`)
- `pnpm test` — 808 passed, 48 skipped (856); 128 test files passed, 3 skipped
- `CHANGELOG.md` is untouched, since it is release-owned for this repository's PR flow.

One pre-existing unhandled error is reported by the full suite in `tests/runtime-integration.test.ts` (a `DOMException: ABORT_ERR` raised from `StreamableHTTPClientTransport.close` during teardown). It reproduces on unmodified `main` at `7259c8c` on this machine — baseline there was 795 passed with the same single error — so it is unrelated to this change. It is the reason `pnpm test` exits non-zero locally in both runs.


