### PR TITLE
feat(chrome-devtools): route autoConnect through OpenClaw extension relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### CLI
 
+- Route `chrome-devtools-mcp --autoConnect` through a paired OpenClaw Chrome-extension relay when one is live on this host, eliminating Chrome's per-session "Allow remote debugging?" dialog; falls back to plain auto-connect otherwise (`MCPORTER_DISABLE_CHROME_DEVTOOLS_RELAY=1` to opt out).
 - Correct the documented call timeout to 60 seconds and distinguish its `MCPORTER_CALL_TIMEOUT` and `--timeout` overrides from the 30-second list timeout. (PR #230, thanks @KrasimirKralev)
 - Isolate long-lived SSE receive streams from ordinary HTTP requests so byte-idle servers cannot stall tool listing and calls. (PR #234, thanks @umutkeltek)
 

--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ What MCPorter handles for you:
 - Stdio commands inherit the directory of the file that defined them (imports or local config).
 - Import precedence matches the array order; omit `imports` to use the default `["cursor", "claude-code", "claude-desktop", "codex", "windsurf", "opencode", "vscode"]`.
 - `chrome-devtools-mcp --autoConnect` receives a small compatibility patch while upstream auto-connect can hang on busy Chrome profiles; set `MCPORTER_DISABLE_CHROME_DEVTOOLS_COMPAT=1` to opt out.
+- When the [OpenClaw Chrome extension relay](https://docs.openclaw.ai/tools/chrome-extension/) is paired on this host, `chrome-devtools-mcp --autoConnect` is transparently rewritten to the relay's loopback CDP endpoint — driving the same signed-in Chrome with no "Allow remote debugging?" dialog at all. mcporter probes `http://127.0.0.1:18799` (override with `MCPORTER_CHROME_DEVTOOLS_RELAY_URL`, loopback only) and falls back to plain `--autoConnect` when the relay is down or unpaired; set `MCPORTER_DISABLE_CHROME_DEVTOOLS_RELAY=1` to opt out.
 
 #### OAuth-protected servers
 

--- a/src/chrome-devtools-relay.ts
+++ b/src/chrome-devtools-relay.ts
@@ -1,0 +1,130 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * OpenClaw browser-extension relay rewrite for chrome-devtools-mcp.
+ *
+ * `--autoConnect` attaches through Chrome's M144+ remote-debugging handshake,
+ * which pops a per-session "Allow remote debugging?" dialog. When the OpenClaw
+ * Chrome extension relay is paired on this host, the same real profile is
+ * reachable over a loopback CDP endpoint with no dialog at all, so mcporter
+ * rewrites the server args to connect there instead. Everything is best-effort:
+ * if the relay secret is missing, the relay is down, or the extension is not
+ * paired, the original --autoConnect args are kept unchanged.
+ */
+
+const AUTO_CONNECT_FLAGS = new Set(['--autoConnect', '--auto-connect']);
+const RELAY_PROBE_TIMEOUT_MS = 750;
+const DEFAULT_RELAY_URL = 'http://127.0.0.1:18799';
+
+export interface ChromeDevtoolsRelayRewrite {
+  readonly args: readonly string[];
+  readonly applied: boolean;
+  readonly endpoint?: string;
+}
+
+export interface ChromeDevtoolsRelayProbeOptions {
+  readonly readToken?: () => string | undefined;
+  readonly probe?: (versionUrl: string, token: string) => Promise<boolean>;
+}
+
+function isChromeDevtoolsToken(token: string): boolean {
+  return (
+    token === 'chrome-devtools-mcp' ||
+    token.startsWith('chrome-devtools-mcp@') ||
+    token.includes('/chrome-devtools-mcp')
+  );
+}
+
+function relayBaseUrl(env: NodeJS.ProcessEnv): URL | undefined {
+  const raw = env.MCPORTER_CHROME_DEVTOOLS_RELAY_URL?.trim() || DEFAULT_RELAY_URL;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return undefined;
+  }
+  // The relay is loopback-only and the Bearer token rides plain HTTP headers.
+  if (url.protocol !== 'http:' || !['127.0.0.1', 'localhost', '[::1]', '::1'].includes(url.hostname)) {
+    return undefined;
+  }
+  return url;
+}
+
+function defaultReadToken(env: NodeJS.ProcessEnv): string | undefined {
+  const stateDir = env.OPENCLAW_STATE_DIR?.trim() || path.join(os.homedir(), '.openclaw');
+  const secretPath = path.join(stateDir, 'credentials', 'browser-extension-relay.secret');
+  let raw: string;
+  try {
+    raw = fs.readFileSync(secretPath, 'utf8');
+  } catch {
+    return undefined;
+  }
+  const token = raw.trim();
+  return /^[0-9a-f]{64}$/.test(token) ? token : undefined;
+}
+
+async function defaultProbe(versionUrl: string, token: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), RELAY_PROBE_TIMEOUT_MS);
+  timer.unref?.();
+  try {
+    const response = await fetch(versionUrl, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: controller.signal,
+    });
+    // 200 requires a paired, connected extension; 503 means relay up but
+    // unpaired, where --autoConnect (with its dialog) still beats failing.
+    return response.status === 200;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function shouldAttemptChromeDevtoolsRelay(
+  command: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  if (env.MCPORTER_DISABLE_CHROME_DEVTOOLS_RELAY === '1') {
+    return false;
+  }
+  const tokens = [command, ...args];
+  return tokens.some(isChromeDevtoolsToken) && args.some((arg) => AUTO_CONNECT_FLAGS.has(arg));
+}
+
+/**
+ * Rewrite `--autoConnect` to `--wsEndpoint/--wsHeaders` against a live, paired
+ * OpenClaw extension relay. Returns the original args when the relay is not
+ * usable for any reason.
+ */
+export async function rewriteChromeDevtoolsArgsForRelay(
+  command: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+  options: ChromeDevtoolsRelayProbeOptions = {}
+): Promise<ChromeDevtoolsRelayRewrite> {
+  if (!shouldAttemptChromeDevtoolsRelay(command, args, env)) {
+    return { args, applied: false };
+  }
+  const base = relayBaseUrl(env);
+  if (!base) {
+    return { args, applied: false };
+  }
+  const token = (options.readToken ?? (() => defaultReadToken(env)))();
+  if (!token) {
+    return { args, applied: false };
+  }
+  const versionUrl = new URL('/json/version', base).toString();
+  const alive = await (options.probe ?? defaultProbe)(versionUrl, token);
+  if (!alive) {
+    return { args, applied: false };
+  }
+  const wsEndpoint = `ws://${base.host}/cdp`;
+  const rewritten = args.filter((arg) => !AUTO_CONNECT_FLAGS.has(arg));
+  rewritten.push('--wsEndpoint', wsEndpoint, '--wsHeaders', JSON.stringify({ Authorization: `Bearer ${token}` }));
+  return { args: rewritten, applied: true, endpoint: wsEndpoint };
+}

--- a/src/runtime/transport.ts
+++ b/src/runtime/transport.ts
@@ -4,6 +4,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport, StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { applyChromeDevtoolsCompat } from '../chrome-devtools-compat.js';
+import { rewriteChromeDevtoolsArgsForRelay } from '../chrome-devtools-relay.js';
 import type { ServerDefinition } from '../config.js';
 import { resolveEnvValue, withEnvOverrides } from '../env.js';
 import { analyzeConnectionError } from '../error-classifier.js';
@@ -320,7 +321,12 @@ async function createStdioClientContext(
       ? { ...process.env, ...resolvedEnvOverrides }
       : { ...process.env };
   const command = resolveCommandArgument(definition.command.command);
-  const commandArgs = resolveCommandArguments(definition.command.args);
+  const resolvedArgs = resolveCommandArguments(definition.command.args);
+  const relay = await rewriteChromeDevtoolsArgsForRelay(command, resolvedArgs, mergedEnv as NodeJS.ProcessEnv);
+  if (relay.applied) {
+    logger.info(`Routing chrome-devtools-mcp through the OpenClaw extension relay at ${relay.endpoint} (no dialog).`);
+  }
+  const commandArgs = [...relay.args];
   const compat = applyChromeDevtoolsCompat(mergedEnv as Record<string, string>, command, commandArgs);
   if (compat.applied) {
     logger.info(`Injecting chrome-devtools-mcp --autoConnect compatibility patch from ${compat.patchPath}.`);

--- a/tests/chrome-devtools-relay.test.ts
+++ b/tests/chrome-devtools-relay.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { rewriteChromeDevtoolsArgsForRelay, shouldAttemptChromeDevtoolsRelay } from '../src/chrome-devtools-relay.js';
+
+const TOKEN = 'a'.repeat(64);
+const AUTO_ARGS = ['-y', 'chrome-devtools-mcp@latest', '--autoConnect'];
+
+describe('chrome-devtools OpenClaw relay rewrite', () => {
+  afterEach(() => {
+    delete process.env.MCPORTER_DISABLE_CHROME_DEVTOOLS_RELAY;
+    delete process.env.MCPORTER_CHROME_DEVTOOLS_RELAY_URL;
+  });
+
+  it('only considers autoConnect chrome-devtools commands', () => {
+    expect(shouldAttemptChromeDevtoolsRelay('npx', AUTO_ARGS)).toBe(true);
+    expect(shouldAttemptChromeDevtoolsRelay('npx', ['-y', 'chrome-devtools-mcp@latest'])).toBe(false);
+    expect(shouldAttemptChromeDevtoolsRelay('npx', ['-y', 'other-mcp', '--autoConnect'])).toBe(false);
+  });
+
+  it('allows opting out via env', () => {
+    expect(shouldAttemptChromeDevtoolsRelay('npx', AUTO_ARGS, { MCPORTER_DISABLE_CHROME_DEVTOOLS_RELAY: '1' })).toBe(
+      false
+    );
+  });
+
+  it('rewrites autoConnect to wsEndpoint against a live paired relay', async () => {
+    const probed: string[] = [];
+    const result = await rewriteChromeDevtoolsArgsForRelay(
+      'npx',
+      AUTO_ARGS,
+      {},
+      {
+        readToken: () => TOKEN,
+        probe: async (url, token) => {
+          probed.push(url, token);
+          return true;
+        },
+      }
+    );
+
+    expect(result.applied).toBe(true);
+    expect(probed).toEqual(['http://127.0.0.1:18799/json/version', TOKEN]);
+    expect(result.args).toEqual([
+      '-y',
+      'chrome-devtools-mcp@latest',
+      '--wsEndpoint',
+      'ws://127.0.0.1:18799/cdp',
+      '--wsHeaders',
+      JSON.stringify({ Authorization: `Bearer ${TOKEN}` }),
+    ]);
+    expect(result.endpoint).toBe('ws://127.0.0.1:18799/cdp');
+  });
+
+  it('honors a custom loopback relay URL', async () => {
+    const result = await rewriteChromeDevtoolsArgsForRelay(
+      'npx',
+      AUTO_ARGS,
+      { MCPORTER_CHROME_DEVTOOLS_RELAY_URL: 'http://localhost:18798' },
+      { readToken: () => TOKEN, probe: async () => true }
+    );
+
+    expect(result.applied).toBe(true);
+    expect(result.args).toContain('ws://localhost:18798/cdp');
+  });
+
+  it('rejects non-loopback relay URLs', async () => {
+    const result = await rewriteChromeDevtoolsArgsForRelay(
+      'npx',
+      AUTO_ARGS,
+      { MCPORTER_CHROME_DEVTOOLS_RELAY_URL: 'http://relay.example.com:18799' },
+      { readToken: () => TOKEN, probe: async () => true }
+    );
+
+    expect(result).toEqual({ args: AUTO_ARGS, applied: false });
+  });
+
+  it('keeps autoConnect when the relay secret is missing', async () => {
+    const result = await rewriteChromeDevtoolsArgsForRelay(
+      'npx',
+      AUTO_ARGS,
+      {},
+      {
+        readToken: () => undefined,
+        probe: async () => true,
+      }
+    );
+
+    expect(result).toEqual({ args: AUTO_ARGS, applied: false });
+  });
+
+  it('keeps autoConnect when the relay is down or unpaired', async () => {
+    const result = await rewriteChromeDevtoolsArgsForRelay(
+      'npx',
+      AUTO_ARGS,
+      {},
+      {
+        readToken: () => TOKEN,
+        probe: async () => false,
+      }
+    );
+
+    expect(result).toEqual({ args: AUTO_ARGS, applied: false });
+  });
+
+  it('leaves unrelated commands untouched without probing', async () => {
+    let probes = 0;
+    const result = await rewriteChromeDevtoolsArgsForRelay(
+      'npx',
+      ['-y', 'some-mcp'],
+      {},
+      {
+        readToken: () => TOKEN,
+        probe: async () => {
+          probes += 1;
+          return true;
+        },
+      }
+    );
+
+    expect(result).toEqual({ args: ['-y', 'some-mcp'], applied: false });
+    expect(probes).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Chrome M144+ shows a per-session "Allow remote debugging?" dialog for `chrome-devtools-mcp --autoConnect`, with no way to persist approval (upstream closed the request as not-planned). The OpenClaw Chrome-extension relay drives the same signed-in Chrome over a loopback CDP endpoint via `chrome.debugger` — no dialog at all.

This adds a best-effort rewrite in the stdio transport: when a server command is `chrome-devtools-mcp` with `--autoConnect` and a paired OpenClaw relay answers on this host, the args become `--wsEndpoint ws://127.0.0.1:18799/cdp --wsHeaders '{"Authorization":"Bearer <host-local secret>"}'`.

- Detection: relay secret at `~/.openclaw/credentials/browser-extension-relay.secret` (or `OPENCLAW_STATE_DIR`) + authenticated `GET /json/version` returning 200 within 750 ms. 503 (relay up, extension unpaired) keeps plain autoConnect.
- Relay URL override: `MCPORTER_CHROME_DEVTOOLS_RELAY_URL` (loopback http only — the Bearer token rides plain headers). Opt out: `MCPORTER_DISABLE_CHROME_DEVTOOLS_RELAY=1`.
- Any failure (no secret, dead relay, bad URL) leaves the original args untouched.
- Companion change: openclaw/openclaw#117915 teaches the relay the one CDP method Puppeteer needs (`Target.getBrowserContexts`).

## Testing

- `pnpm check` + full suite: 848 passed, 3 skipped.
- New `tests/chrome-devtools-relay.test.ts`: rewrite shape, custom loopback URL, non-loopback rejection, missing-secret / dead-relay / unrelated-command fallbacks.
- Live on macOS with a paired relay: `mcporter call --stdio npx --stdio-arg -y --stdio-arg chrome-devtools-mcp@latest --stdio-arg --autoConnect --tool list_pages` listed the real Chrome's shared tabs with zero dialogs; the daemon-spawned process argv shows the rewritten `--wsEndpoint` args.
- Codex autoreview clean (0 findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
