### PR TITLE
fix(oauth): serialize interactive authorization per provider session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### OAuth
 
 - Open the Windows OAuth browser via shell-free `rundll32 url.dll,FileProtocolHandler` instead of a `cmd.exe` command string, so quote- or ampersand-bearing authorization URLs cannot run shell side effects. (PR #242, thanks @SebTardif)
+- Serialize interactive OAuth authorization per provider/session: concurrent 401s (background SSE reconnect plus a bridged request) now join one pending PKCE transaction instead of opening duplicate prompts, and keep-alive daemons no longer restart and replay operations on auth failures. (Issue #247, thanks @mkaput)
 
 ### CLI
 

--- a/src/daemon/runtime-wrapper.ts
+++ b/src/daemon/runtime-wrapper.ts
@@ -1,6 +1,7 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { ServerDefinition } from '../config.js';
 import { isKeepAliveServer } from '../lifecycle.js';
+import { isUnauthorizedError } from '../runtime-oauth-support.js';
 import type {
   CallOptions,
   ConnectOptions,
@@ -176,6 +177,11 @@ const NON_FATAL_CODES = new Set([ErrorCode.InvalidRequest, ErrorCode.MethodNotFo
 
 function shouldRestartDaemonServer(error: unknown): boolean {
   if (!error) {
+    return false;
+  }
+  // Restarting cannot repair a missing or rejected credential, and replaying the
+  // operation re-enters interactive authorization, duplicating prompts (issue #247).
+  if (isUnauthorizedError(error)) {
     return false;
   }
   if (error instanceof McpError) {

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import http from 'node:http';
 import { URL } from 'node:url';
 import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
@@ -15,6 +15,9 @@ import { buildOAuthPersistence } from './oauth-persistence.js';
 
 const CALLBACK_HOST = '127.0.0.1';
 const CALLBACK_PATH = '/callback';
+// Mirrors DEFAULT_OAUTH_CODE_TIMEOUT_MS in src/runtime/oauth.ts: a pending interactive
+// authorization older than this is treated as abandoned so a later request can prompt again.
+const INTERACTIVE_AUTHORIZATION_TTL_MS = 300_000;
 
 export interface OAuthAuthorizationRequest {
   authorizationUrl: string;
@@ -82,6 +85,11 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
   private redirectUrlValue: URL;
   private authorizationDeferred: Deferred<string> | null = null;
   private authorizationRedirectStarted = false;
+  // One interactive authorization transaction per provider: concurrent SDK auth() flows
+  // (background GET reconnect + bridged POST both hitting 401) must not each open a
+  // prompt, because only one persisted PKCE verifier can complete (issue #247).
+  private interactiveAuthorization: { challenge: string | null; claimedAt: number } | null = null;
+  private readonly pendingVerifiersByChallenge = new Map<string, string>();
   private server?: http.Server;
 
   private constructor(
@@ -206,6 +214,7 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
           res.end('<html><body><h1>Authorization failed</h1><p>Invalid OAuth state</p></body></html>');
           this.authorizationDeferred?.reject(new Error('Invalid OAuth state'));
           this.authorizationDeferred = null;
+          this.clearInteractiveAuthorization();
           return;
         }
         if (code) {
@@ -215,21 +224,25 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
           res.end('<html><body><h1>Authorization successful</h1><p>You can return to the CLI.</p></body></html>');
           this.authorizationDeferred?.resolve(code);
           this.authorizationDeferred = null;
+          this.clearInteractiveAuthorization();
         } else if (error) {
           res.statusCode = 400;
           res.setHeader('Content-Type', 'text/html');
           res.end(`<html><body><h1>Authorization failed</h1><p>${error}</p></body></html>`);
           this.authorizationDeferred?.reject(new Error(`OAuth error: ${error}`));
           this.authorizationDeferred = null;
+          this.clearInteractiveAuthorization();
         } else {
           res.statusCode = 400;
           res.end('Missing authorization code');
           this.authorizationDeferred?.reject(new Error('Missing authorization code'));
           this.authorizationDeferred = null;
+          this.clearInteractiveAuthorization();
         }
       } catch (error) {
         this.authorizationDeferred?.reject(error);
         this.authorizationDeferred = null;
+        this.clearInteractiveAuthorization();
       }
     });
   }
@@ -276,6 +289,27 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
     this.authorizationRedirectStarted = true;
     this.ensureAuthorizationDeferred();
+    const challenge = authorizationUrl.searchParams.get('code_challenge');
+    if (this.hasActiveInteractiveAuthorization()) {
+      // Join the in-flight transaction: drop this flow's redirect (and its unclaimed
+      // verifier) so exactly one completable prompt exists for this provider.
+      if (challenge) {
+        this.pendingVerifiersByChallenge.delete(challenge);
+      }
+      this.logger.info(`Authorization already pending for ${this.definition.name}; suppressing duplicate prompt.`);
+      return;
+    }
+    // Claim synchronously, before any await, so a concurrent redirect sees the claim.
+    this.interactiveAuthorization = { challenge, claimedAt: Date.now() };
+    const claimedVerifier = challenge ? this.pendingVerifiersByChallenge.get(challenge) : undefined;
+    if (challenge) {
+      this.pendingVerifiersByChallenge.delete(challenge);
+    }
+    if (claimedVerifier) {
+      // Re-persist the claimed flow's verifier: a concurrent flow may have saved its own
+      // between this flow's saveCodeVerifier and this claim.
+      await this.persistence.saveCodeVerifier(claimedVerifier);
+    }
     const request = {
       authorizationUrl: authorizationUrl.toString(),
       redirectUrl: this.redirectUrlValue.toString(),
@@ -294,6 +328,13 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
   }
 
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
+    // Remember every verifier by its S256 challenge so redirectToAuthorization can
+    // re-persist the one belonging to the flow that wins the interactive claim.
+    this.pendingVerifiersByChallenge.set(challengeForVerifier(codeVerifier), codeVerifier);
+    if (this.hasActiveInteractiveAuthorization()) {
+      // A concurrent flow owns the pending prompt; don't clobber its persisted verifier.
+      return;
+    }
     await this.persistence.saveCodeVerifier(codeVerifier);
   }
 
@@ -307,6 +348,10 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
 
   // invalidateCredentials removes cached files to force the next OAuth flow.
   async invalidateCredentials(scope: 'all' | 'client' | 'tokens' | 'verifier'): Promise<void> {
+    if (scope === 'all' || scope === 'verifier') {
+      // The pending transaction's verifier is gone; let the next flow claim a new prompt.
+      this.clearInteractiveAuthorization();
+    }
     await this.persistence.clear(scope);
   }
 
@@ -322,6 +367,7 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
       // If the CLI is tearing down mid-flow, reject the pending wait promise so runtime shutdown isn't blocked.
       this.authorizationDeferred.reject(new Error('OAuth session closed before receiving authorization code.'));
       this.authorizationDeferred = null;
+      this.clearInteractiveAuthorization();
     }
     if (!this.server) {
       return;
@@ -339,6 +385,23 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
       this.authorizationDeferred = createDeferred<string>();
     }
     return this.authorizationDeferred;
+  }
+
+  private hasActiveInteractiveAuthorization(): boolean {
+    if (!this.interactiveAuthorization) {
+      return false;
+    }
+    if (Date.now() - this.interactiveAuthorization.claimedAt > INTERACTIVE_AUTHORIZATION_TTL_MS) {
+      // The prompt outlived the authorization-code timeout; treat it as abandoned.
+      this.interactiveAuthorization = null;
+      return false;
+    }
+    return true;
+  }
+
+  private clearInteractiveAuthorization(): void {
+    this.interactiveAuthorization = null;
+    this.pendingVerifiersByChallenge.clear();
   }
 }
 
@@ -372,6 +435,10 @@ export interface OAuthLogger {
   info(message: string): void;
   warn(message: string): void;
   error(message: string, error?: unknown): void;
+}
+
+function challengeForVerifier(verifier: string): string {
+  return createHash('sha256').update(verifier).digest('base64url');
 }
 
 function firstRedirectUri(client: OAuthClientInformationMixed | undefined): string | undefined {

--- a/tests/keep-alive-runtime.test.ts
+++ b/tests/keep-alive-runtime.test.ts
@@ -282,4 +282,23 @@ describe('createKeepAliveRuntime', () => {
     expect(daemon.callTool).toHaveBeenCalledTimes(1);
     expect(daemon.closeServer).not.toHaveBeenCalled();
   });
+
+  it('does not restart or replay daemon operations after unauthorized errors', async () => {
+    const runtime = new FakeRuntime(definitions);
+    const daemon = {
+      callTool: vi.fn().mockRejectedValue(new Error('HTTP 401 Unauthorized')),
+      closeServer: vi.fn().mockResolvedValue(undefined),
+      listTools: vi.fn(),
+      listResources: vi.fn(),
+      readResource: vi.fn(),
+    };
+    const keepAliveRuntime = createKeepAliveRuntime(runtime as unknown as Runtime, {
+      daemonClient: daemon as never,
+      keepAliveServers: new Set(['alpha']),
+    });
+
+    await expect(keepAliveRuntime.callTool('alpha', 'ping', {})).rejects.toThrow(/unauthorized/i);
+    expect(daemon.callTool).toHaveBeenCalledTimes(1);
+    expect(daemon.closeServer).not.toHaveBeenCalled();
+  });
 });

--- a/tests/oauth-bridge-get-post-concurrency.test.ts
+++ b/tests/oauth-bridge-get-post-concurrency.test.ts
@@ -1,0 +1,267 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ServerDefinition } from '../src/config.js';
+import { createKeepAliveRuntime } from '../src/daemon/runtime-wrapper.js';
+import { createOAuthSession } from '../src/oauth.js';
+import type { Runtime } from '../src/runtime.js';
+import { createBridgeServer } from '../src/serve.js';
+
+describe('bridged Streamable HTTP reauthorization concurrency', () => {
+  let dataHome: string | undefined;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    if (dataHome) {
+      await fs.rm(dataHome, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps a background GET 401 and bridged tools/list 401 in one pending authorization transaction', async () => {
+    dataHome = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-get-post-oauth-'));
+    vi.stubEnv('XDG_DATA_HOME', dataHome);
+    installFakeCallbackServer();
+
+    const resourceUrl = 'https://mcp.example.test/mcp';
+    const authorizationServer = 'https://auth.example.test';
+    const definition: ServerDefinition = {
+      name: 'test-service-shape',
+      command: { kind: 'http', url: new URL(resourceUrl) },
+      auth: 'oauth',
+      oauthClientId: 'test-client',
+      oauthScope: 'mcp',
+      lifecycle: { mode: 'keep-alive' },
+      source: { kind: 'local', path: '/tmp/mcporter-get-post-oauth.json' },
+    };
+    const authorizationUrls: URL[] = [];
+    const session = await createOAuthSession(
+      definition,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      {
+        suppressBrowserLaunch: true,
+        onAuthorizationUrl: ({ authorizationUrl }) => {
+          authorizationUrls.push(new URL(authorizationUrl));
+        },
+      }
+    );
+    const pendingCallback = session.waitForAuthorizationCode().catch(() => undefined);
+    await session.provider.state?.();
+    await session.provider.saveTokens({
+      access_token: 'synthetic-initial-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+    });
+
+    let rejectProtectedResource = false;
+    let normalGetCount = 0;
+    let protectedRequestCount = 0;
+    let releaseProtectedRequests!: () => void;
+    const protectedRequestsReady = new Promise<void>((resolve) => {
+      releaseProtectedRequests = resolve;
+    });
+    const fetchFn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+
+      if (url.href === resourceUrl && rejectProtectedResource) {
+        protectedRequestCount += 1;
+        if (protectedRequestCount === 2) {
+          releaseProtectedRequests();
+        }
+        await protectedRequestsReady;
+        return Response.json(
+          { error: 'unauthorized' },
+          {
+            status: 401,
+            headers: {
+              'WWW-Authenticate': `Bearer resource_metadata="${authorizationServer}/.well-known/oauth-protected-resource"`,
+            },
+          }
+        );
+      }
+
+      if (url.href === resourceUrl && method === 'GET') {
+        normalGetCount += 1;
+        return new Response(null, { status: 405 });
+      }
+
+      if (url.href === resourceUrl && method === 'POST') {
+        const message = JSON.parse(init?.body as string) as { id?: number; method?: string };
+        if (message.method === 'initialize') {
+          return Response.json({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              protocolVersion: '2025-06-18',
+              capabilities: { tools: {} },
+              serverInfo: { name: 'synthetic-upstream', version: '1' },
+            },
+          });
+        }
+        if (message.method === 'notifications/initialized') {
+          return new Response(null, { status: 202 });
+        }
+        if (message.method === 'tools/list') {
+          return Response.json({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: { tools: [{ name: 'ping', inputSchema: { type: 'object' } }] },
+          });
+        }
+      }
+
+      if (url.pathname.includes('oauth-protected-resource')) {
+        return Response.json({
+          resource: resourceUrl,
+          authorization_servers: [authorizationServer],
+          scopes_supported: ['mcp'],
+        });
+      }
+      if (url.pathname.includes('oauth-authorization-server') || url.pathname.includes('openid-configuration')) {
+        return Response.json({
+          issuer: authorizationServer,
+          authorization_endpoint: `${authorizationServer}/authorize`,
+          token_endpoint: `${authorizationServer}/token`,
+          response_types_supported: ['code'],
+          grant_types_supported: ['authorization_code', 'refresh_token'],
+          code_challenge_methods_supported: ['S256'],
+          scopes_supported: ['mcp'],
+        });
+      }
+      if (url.href === `${authorizationServer}/token` && method === 'POST') {
+        return Response.json({
+          access_token: 'synthetic-recovered-token',
+          token_type: 'Bearer',
+          expires_in: 3600,
+        });
+      }
+      throw new Error(`Unexpected synthetic request: ${method} ${url}`);
+    });
+
+    const upstreamTransport = new StreamableHTTPClientTransport(new URL(resourceUrl), {
+      authProvider: session.provider,
+      fetch: fetchFn as unknown as typeof fetch,
+    });
+    const upstreamClient = new Client({ name: 'mcporter-daemon-shape', version: '0.12.4' });
+    await upstreamClient.connect(upstreamTransport);
+    await vi.waitFor(() => expect(normalGetCount).toBe(1));
+    await session.provider.invalidateCredentials?.('tokens');
+
+    const baseRuntime = makeBaseRuntime(definition);
+    let daemonListCalls = 0;
+    const daemon = {
+      listTools: vi.fn(async () => {
+        daemonListCalls += 1;
+        if (rejectProtectedResource && daemonListCalls > 1) {
+          throw new McpError(ErrorCode.InvalidParams, 'stop after the first bridged attempt');
+        }
+        return (await upstreamClient.listTools()).tools;
+      }),
+      callTool: vi.fn(),
+      listResources: vi.fn(),
+      readResource: vi.fn(),
+      closeServer: vi.fn().mockResolvedValue(undefined),
+    };
+    const runtime = createKeepAliveRuntime(baseRuntime, {
+      daemonClient: daemon as never,
+      keepAliveServers: new Set([definition.name]),
+    });
+    const bridge = createBridgeServer({ runtime, definitions: [definition], servers: [definition.name], bare: true });
+    const codexClient = new Client({ name: 'codex-shape', version: '1' });
+    const [codexTransport, bridgeTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([bridge.connect(bridgeTransport), codexClient.connect(codexTransport)]);
+
+    rejectProtectedResource = true;
+    const backgroundGet = (
+      upstreamTransport as unknown as {
+        _startOrAuthSse(options: { resumptionToken: undefined }): Promise<void>;
+      }
+    )._startOrAuthSse({ resumptionToken: undefined });
+    const bridgedList = codexClient.listTools();
+
+    try {
+      await expect(Promise.allSettled([backgroundGet, bridgedList])).resolves.toEqual([
+        expect.objectContaining({ status: 'rejected' }),
+        expect.objectContaining({ status: 'rejected' }),
+      ]);
+
+      const persistedVerifier = await session.provider.codeVerifier();
+      const persistedChallenge = crypto.createHash('sha256').update(persistedVerifier).digest('base64url');
+      const summary = {
+        authorizationCount: authorizationUrls.length,
+        uniqueStates: new Set(authorizationUrls.map((url) => url.searchParams.get('state'))).size,
+        uniqueRedirects: new Set(authorizationUrls.map((url) => url.searchParams.get('redirect_uri'))).size,
+        uniqueClientIds: new Set(authorizationUrls.map((url) => url.searchParams.get('client_id'))).size,
+        uniqueChallenges: new Set(authorizationUrls.map((url) => url.searchParams.get('code_challenge'))).size,
+        challengesMatchingPersistedVerifier: authorizationUrls.filter(
+          (url) => url.searchParams.get('code_challenge') === persistedChallenge
+        ).length,
+      };
+
+      expect(summary).toEqual({
+        authorizationCount: 1,
+        uniqueStates: 1,
+        uniqueRedirects: 1,
+        uniqueClientIds: 1,
+        uniqueChallenges: 1,
+        challengesMatchingPersistedVerifier: 1,
+      });
+
+      rejectProtectedResource = false;
+      await upstreamTransport.finishAuth('synthetic-authorization-code');
+      await expect(codexClient.listTools()).resolves.toMatchObject({
+        tools: [{ name: 'ping' }],
+      });
+    } finally {
+      await codexClient.close().catch(() => {});
+      await bridge.close().catch(() => {});
+      await upstreamClient.close().catch(() => {});
+      await session.close().catch(() => {});
+      await pendingCallback;
+    }
+  });
+});
+
+function installFakeCallbackServer(): void {
+  let fakeServer: http.Server;
+  fakeServer = {
+    listen: vi.fn((_port?: number, _host?: string, callback?: () => void) => {
+      queueMicrotask(() => callback?.());
+      return fakeServer;
+    }),
+    once: vi.fn(() => fakeServer),
+    on: vi.fn(() => fakeServer),
+    off: vi.fn(() => fakeServer),
+    address: vi.fn(() => ({ address: '127.0.0.1', family: 'IPv4', port: 43123 })),
+    closeAllConnections: vi.fn(),
+    close: vi.fn((callback?: () => void) => {
+      callback?.();
+      return fakeServer;
+    }),
+  } as unknown as http.Server;
+  vi.spyOn(http, 'createServer').mockReturnValue(fakeServer);
+}
+
+function makeBaseRuntime(definition: ServerDefinition): Runtime {
+  return {
+    listServers: () => [definition.name],
+    getDefinitions: () => [definition],
+    getDefinition: () => definition,
+    registerDefinition: vi.fn(),
+    getInstructions: vi.fn(),
+    listTools: vi.fn(),
+    callTool: vi.fn(),
+    listResources: vi.fn(),
+    readResource: vi.fn(),
+    connect: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Runtime;
+}

--- a/tests/oauth-open-external.test.ts
+++ b/tests/oauth-open-external.test.ts
@@ -51,7 +51,7 @@ describe('openExternal', () => {
 
     __oauthInternals.openExternal(url, 'win32', launch as unknown as typeof import('node:child_process').spawn);
 
-    const [exe, args] = launch.mock.calls[0] as [string, string[]];
+    const [exe, args] = launch.mock.calls[0] as unknown as [string, string[]];
     expect(exe).toBe('rundll32');
     expect(args).toEqual(['url.dll,FileProtocolHandler', url]);
     // Must not use cmd /c start (command-interpreter boundary).

--- a/tests/oauth-session.test.ts
+++ b/tests/oauth-session.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import http from 'node:http';
 import os from 'node:os';
@@ -33,6 +34,12 @@ const requestStatus = (target: URL): Promise<number> =>
     req.on('error', reject);
     req.end();
   });
+
+const authorizationUrlFor = (verifier: string) => {
+  const url = new URL('https://auth.example.com/authorize');
+  url.searchParams.set('code_challenge', createHash('sha256').update(verifier).digest('base64url'));
+  return url;
+};
 
 describe('FileOAuthClientProvider session lifecycle', () => {
   const tempDirs: string[] = [];
@@ -349,6 +356,65 @@ describe('FileOAuthClientProvider session lifecycle', () => {
       await (session.provider as StatefulProvider).state();
       await expect(fs.access(isolatedHome.vaultPath)).resolves.toBeUndefined();
       await isolatedHome.assertAmbientVaultUntouched();
+    } finally {
+      await session.close();
+    }
+  });
+
+  it('serializes overlapping interactive authorizations into one completable transaction', async () => {
+    const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
+    tempDirs.push(tokenCacheDir);
+    const definition: ServerDefinition = {
+      name: 'test-oauth-singleflight',
+      description: 'Test OAuth server',
+      command: { kind: 'http', url: new URL('https://example.com/mcp') },
+      auth: 'oauth',
+      tokenCacheDir,
+    };
+    const prompts: URL[] = [];
+    const session = await createOAuthSession(
+      definition,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      {
+        suppressBrowserLaunch: true,
+        onAuthorizationUrl: ({ authorizationUrl }) => {
+          prompts.push(new URL(authorizationUrl));
+        },
+      }
+    );
+    const provider = session.provider;
+
+    try {
+      // Two SDK auth() flows interleave: both save their verifier before either redirects.
+      await provider.saveCodeVerifier?.('verifier-first');
+      await provider.saveCodeVerifier?.('verifier-second');
+      await provider.redirectToAuthorization(authorizationUrlFor('verifier-first'));
+      await provider.redirectToAuthorization(authorizationUrlFor('verifier-second'));
+
+      // Only the first flow prompts, and the persisted verifier matches its challenge.
+      expect(prompts).toHaveLength(1);
+      await expect(provider.codeVerifier?.()).resolves.toBe('verifier-first');
+
+      // A verifier saved while the transaction is pending must not clobber it.
+      await provider.saveCodeVerifier?.('verifier-late');
+      await expect(provider.codeVerifier?.()).resolves.toBe('verifier-first');
+
+      // Completing the callback ends the transaction; the next flow prompts normally.
+      const state = await (session.provider as StatefulProvider).state();
+      const callback = new URL((session.provider as StatefulProvider).redirectUrl.toString());
+      callback.searchParams.set('code', 'auth-code');
+      callback.searchParams.set('state', state);
+      const waitPromise = session.waitForAuthorizationCode();
+      expect(await requestStatus(callback)).toBe(200);
+      await expect(waitPromise).resolves.toBe('auth-code');
+
+      await provider.saveCodeVerifier?.('verifier-next');
+      await provider.redirectToAuthorization(authorizationUrlFor('verifier-next'));
+      expect(prompts).toHaveLength(2);
+      await expect(provider.codeVerifier?.()).resolves.toBe('verifier-next');
+      const trailingWait = session.waitForAuthorizationCode();
+      await session.close();
+      await expect(trailingWait).rejects.toThrow(/closed before receiving authorization code/i);
     } finally {
       await session.close();
     }


### PR DESCRIPTION
## Summary

Fixes #247 with the decided join-in-flight contract: one interactive OAuth authorization transaction per shared provider/session.

Concurrent SDK `auth()` flows sharing one provider (the background Streamable HTTP GET reconnect and a bridged POST both receiving 401) each generated a PKCE challenge and opened a prompt, while only one persisted verifier could complete.

### What changed

- `PersistentOAuthClientProvider.redirectToAuthorization` now claims a single interactive transaction per provider (synchronously, before any await). Overlapping redirects are suppressed: no second browser prompt, no second `onAuthorizationUrl`.
- `saveCodeVerifier` remembers each verifier by its S256 challenge; the claiming redirect re-persists its own flow's verifier, so a concurrent flow's save can never clobber the completable transaction.
- The claim clears when the callback settles (code received, OAuth error, invalid state, or session close), when the verifier is invalidated, or after a 300s abandonment TTL mirroring the authorization-code timeout — so a lost browser tab cannot suppress prompts forever.
- Keep-alive daemon operations no longer restart and replay after unauthorized errors (`shouldRestartDaemonServer` now consults `isUnauthorizedError`): a restart cannot repair a credential, and the replay was a second source of duplicate prompts.
- Also fixes a strict-typecheck error in `tests/oauth-open-external.test.ts` that was breaking `pnpm check` on main (CI's build job only compiles `tsconfig.build.json`, which excludes tests).

### Tests

- `tests/oauth-bridge-get-post-concurrency.test.ts` — the reporter's full regression harness from #247, verbatim apart from strict-TS annotations. Fails on unpatched main with `authorizationCount: 2, uniqueChallenges: 2`; passes with this change: one flow, synthetic completion succeeds, the retried Codex-shaped `tools/list` returns `ping`.
- `tests/oauth-session.test.ts` — unit coverage for the single-flight semantics: one prompt for overlapping flows, persisted verifier matches the claimed challenge, pending saves cannot clobber it, and completion re-arms normal prompting.
- `tests/keep-alive-runtime.test.ts` — unauthorized daemon errors neither restart the server nor replay the operation.

### Proof (Node 24.18.0 / pnpm 10.33.2, macOS)

- `pnpm check` — format, type-aware lint, typecheck clean.
- `pnpm build` — clean.
- `pnpm test` — 904 passed / 3 skipped.
- Codex AutoReview (gpt-5.6-sol, high, branch vs origin/main) — clean, no accepted/actionable findings.

Thanks @mkaput for the exceptional report — the regression harness made this implementable without guesswork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
