### PR TITLE
fix: resources/list pagination + replay tolerance for protocol drift (MCP 2.0 prep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.12.5] - Unreleased
 
+### CLI
+
+- Follow `resources/list` cursors automatically so paginated MCP resources are returned in full.
+
 ## [0.12.4] - 2026-08-02
 
 ### CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### CLI
 
 - Follow `resources/list` cursors automatically so paginated MCP resources are returned in full.
+- Keep replay recordings usable across MCP protocol-version and mcporter client-version changes.
 
 ## [0.12.4] - 2026-08-02
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -15,6 +15,7 @@ export { MCPORTER_VERSION } from './version.js';
 
 const PACKAGE_NAME = 'mcporter';
 const OAUTH_CODE_TIMEOUT_MS = resolveOAuthTimeoutFromEnv();
+const MAX_RESOURCE_LIST_PAGES = 100;
 
 export interface RuntimeOptions {
   readonly configPath?: string;
@@ -341,7 +342,18 @@ class McpRuntime implements Runtime {
         disableOAuth: effectiveDisableOAuth,
       });
       const { client } = context;
-      return await client.listResources(params as ListResourcesRequest['params']);
+      const requestParams = params as NonNullable<ListResourcesRequest['params']>;
+      let response = await client.listResources(requestParams);
+      if (requestParams.cursor !== undefined) {
+        return response;
+      }
+
+      const resources = [...response.resources];
+      for (let page = 1; page < MAX_RESOURCE_LIST_PAGES && response.nextCursor; page += 1) {
+        response = await client.listResources({ ...requestParams, cursor: response.nextCursor });
+        resources.push(...response.resources);
+      }
+      return { ...response, resources };
     } catch (error) {
       // Fatal listResources errors usually mean the underlying transport has gone away.
       await this.resetConnectionOnError(server, error, context);

--- a/src/runtime/replay-transport.ts
+++ b/src/runtime/replay-transport.ts
@@ -39,13 +39,20 @@ export class ReplayTransport implements Transport {
     }
 
     const expected = this.expectedSends[0];
-    if (!expected || expected.method !== request.method || !isDeepStrictEqual(expected.params, request.params)) {
+    if (
+      !expected ||
+      expected.method !== request.method ||
+      !paramsMatch(request.method, expected.params, request.params)
+    ) {
       throw new Error(formatReplayMismatch(this.opts.server, request, expected));
     }
 
     this.expectedSends.shift();
     if (expected.response) {
-      const response = withActiveRequestId(expected.response, request.id);
+      const response = withActiveRequestId(
+        adaptInitializeResponse(request.method, expected.response, request.params),
+        request.id
+      );
       queueMicrotask(() => this.onmessage?.(response));
     }
   }
@@ -162,6 +169,44 @@ function responseIdOf(message: JSONRPCMessage): string | number | undefined {
   }
   const id = record.id;
   return typeof id === 'string' || typeof id === 'number' ? id : undefined;
+}
+
+function paramsMatch(method: string, expected: unknown, actual: unknown): boolean {
+  if (method !== 'initialize') {
+    return isDeepStrictEqual(expected, actual);
+  }
+  return isDeepStrictEqual(normalizeInitializeParams(expected), normalizeInitializeParams(actual));
+}
+
+function normalizeInitializeParams(params: unknown): unknown {
+  if (!isJsonRpcRecord(params)) {
+    return params;
+  }
+  const normalized = { ...params };
+  delete normalized.protocolVersion;
+  delete normalized.capabilities;
+  delete normalized.clientInfo;
+  return normalized;
+}
+
+function adaptInitializeResponse(method: string, response: JSONRPCMessage, requestParams: unknown): JSONRPCMessage {
+  if (method !== 'initialize' || !isJsonRpcRecord(requestParams) || !('result' in response)) {
+    return response;
+  }
+  const protocolVersion = requestParams.protocolVersion;
+  if (typeof protocolVersion !== 'string' || !isJsonRpcRecord(response.result)) {
+    return response;
+  }
+
+  // SDK v1.30 accepts supported version mismatches but rejects unknown initialize-result versions.
+  return {
+    ...response,
+    result: { ...response.result, protocolVersion },
+  };
+}
+
+function isJsonRpcRecord(value: unknown): value is JsonRpcRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function withActiveRequestId(response: JSONRPCMessage, requestId: string | number | undefined): JSONRPCMessage {

--- a/tests/record-replay.test.ts
+++ b/tests/record-replay.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import type { Transport, TransportSendOptions } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { describe, expect, it } from 'vitest';
@@ -141,6 +142,27 @@ describe('record/replay transports', () => {
         result: { content: [{ type: 'text', text: 'recorded' }] },
       },
     ]);
+  });
+
+  it('replays initialize recordings across protocol and client version drift', async () => {
+    const recordPath = await writeRecording([
+      send('linear', 1, 'initialize', {
+        protocolVersion: '2099-01-01',
+        capabilities: { sampling: {} },
+        clientInfo: { name: 'mcporter', version: '0.1.0' },
+      }),
+      recv('linear', 1, {
+        protocolVersion: '2099-01-01',
+        capabilities: {},
+        serverInfo: { name: 'recorded-server', version: '1.0.0' },
+      }),
+      notification('linear', 'notifications/initialized'),
+    ]);
+    const transport = new ReplayTransport({ recordPath, server: 'linear' });
+    const client = new Client({ name: 'mcporter', version: MCPORTER_VERSION }, { capabilities: {} });
+
+    await expect(client.connect(transport)).resolves.toBeUndefined();
+    await expect(client.close()).resolves.toBeUndefined();
   });
 
   it('skips recorded requests that never received a response', async () => {

--- a/tests/runtime-compose.test.ts
+++ b/tests/runtime-compose.test.ts
@@ -347,6 +347,96 @@ describe('mcporter composability', () => {
     }
   });
 
+  it('aggregates cursor-paginated resources when no cursor is provided', async () => {
+    mocks.listResourcesMock
+      .mockResolvedValueOnce({
+        resources: [{ uri: 'memo://one', name: 'One' }],
+        nextCursor: 'page-2',
+      })
+      .mockResolvedValueOnce({ resources: [{ uri: 'memo://two', name: 'Two' }] });
+    const runtime = await createRuntime({
+      servers: [
+        {
+          name: 'resources',
+          command: { kind: 'http' as const, url: new URL('https://resources.example.com/mcp') },
+        },
+      ],
+    });
+
+    try {
+      const result = (await runtime.listResources('resources')) as {
+        resources: Array<{ uri: string; name: string }>;
+      };
+
+      expect(result.resources).toEqual([
+        { uri: 'memo://one', name: 'One' },
+        { uri: 'memo://two', name: 'Two' },
+      ]);
+      expect(mocks.listResourcesMock).toHaveBeenNthCalledWith(1, {});
+      expect(mocks.listResourcesMock).toHaveBeenNthCalledWith(2, { cursor: 'page-2' });
+    } finally {
+      await runtime.close();
+    }
+  });
+
+  it('returns one resource page when the caller provides a cursor', async () => {
+    mocks.listResourcesMock.mockResolvedValueOnce({
+      resources: [{ uri: 'memo://two', name: 'Two' }],
+      nextCursor: 'page-3',
+    });
+    const runtime = await createRuntime({
+      servers: [
+        {
+          name: 'resources',
+          command: { kind: 'http' as const, url: new URL('https://resources.example.com/mcp') },
+        },
+      ],
+    });
+
+    try {
+      await expect(runtime.listResources('resources', { cursor: 'page-2' })).resolves.toEqual({
+        resources: [{ uri: 'memo://two', name: 'Two' }],
+        nextCursor: 'page-3',
+      });
+      expect(mocks.listResourcesMock).toHaveBeenCalledOnce();
+      expect(mocks.listResourcesMock).toHaveBeenCalledWith({ cursor: 'page-2' });
+    } finally {
+      await runtime.close();
+    }
+  });
+
+  it('caps automatic resource pagination at 100 pages and returns the partial result', async () => {
+    mocks.listResourcesMock.mockImplementation(async (params?: { cursor?: string }) => {
+      const page = params?.cursor ? Number(params.cursor.slice('page-'.length)) : 1;
+      return {
+        resources: [{ uri: `memo://${page}`, name: `Page ${page}` }],
+        nextCursor: `page-${page + 1}`,
+      };
+    });
+    const runtime = await createRuntime({
+      servers: [
+        {
+          name: 'resources',
+          command: { kind: 'http' as const, url: new URL('https://resources.example.com/mcp') },
+        },
+      ],
+    });
+
+    try {
+      const result = (await runtime.listResources('resources')) as {
+        resources: Array<{ uri: string; name: string }>;
+        nextCursor?: string;
+      };
+
+      expect(result.resources).toHaveLength(100);
+      expect(result.resources.at(-1)).toEqual({ uri: 'memo://100', name: 'Page 100' });
+      expect(result.nextCursor).toBe('page-101');
+      expect(mocks.listResourcesMock).toHaveBeenCalledTimes(100);
+    } finally {
+      await runtime.close();
+    }
+  });
+
   it('uses disableOAuth on cold callTool/listTools helper connections', async () => {
     const runtime = await createRuntime({
       servers: [


### PR DESCRIPTION
Preparation for the MCP 2026-07-28 ("MCP 2.0") migration. Two independent fixes on the current SDK v1 line:

- **resources/list pagination**: the runtime now follows `nextCursor` and aggregates all pages (bounded at 100), matching what tools/list already did. Callers passing an explicit `cursor` still get single-page behavior.
- **Replay tolerance**: replay recordings no longer break when the negotiated `protocolVersion`, client `capabilities`, or mcporter `clientInfo` drift from what was recorded. `initialize` frames are matched on structure, and the recorded initialize result is adapted to the version the live client requested (SDK v1.30 rejects unknown initialize-result versions). This keeps every existing recording usable across the upcoming SDK v2 bump.

Both covered by focused regression tests (pagination aggregate/explicit-cursor/cap; replay across a synthetic `2099-01-01` recording). Full suite: 908 passed. Autoreview clean.

Part 1 of the MCP 2.0 series; next: SDK v2 migration with dual-era negotiation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
