### PR TITLE
test: committed dual-era MCP fixture servers + end-to-end suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Tooling / Dependencies
 
 - Migrate mcporter runtime and serve bridges to the MCP TypeScript SDK v2 client/server packages while retaining SDK v1 as a legacy test fixture.
+- Add committed MCP 2025-11-25 and 2026-07-28 fixture servers with end-to-end CLI and bridge coverage over stdio and Streamable HTTP.
 
 ## [0.12.4] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### CLI
 
 - Follow `resources/list` cursors automatically so paginated MCP resources are returned in full.
+- Raise Node's untouched Happy-Eyeballs connect-attempt timeout from 250 ms to 1500 ms while preserving explicit user overrides.
 - Keep replay recordings usable across MCP protocol-version and mcporter client-version changes.
 - Support MCP protocol revision 2026-07-28 with automatic modern/legacy negotiation while preserving legacy server compatibility.
 - Support interactive form and URL elicitation in terminals across legacy and 2026-07-28 multi-round-trip servers, with immediate declines and a terminal hint in headless contexts.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,12 +7,15 @@ import { logError, logInfo } from './cli/logger-context.js';
 import { isRecordReplayModeActive, isReplayModeActive } from './cli/record-replay-env.js';
 import { DEBUG_HANG, dumpActiveHandles, terminateChildProcesses } from './cli/runtime-debug.js';
 import { resolveConfigPath } from './config/path-discovery.js';
+import { configureAutoSelectFamilyAttemptTimeout } from './network-family-autoselection.js';
 import type { Runtime, RuntimeOptions } from './runtime.js';
 import { createInteractiveElicitationResponder } from './runtime/elicitation.js';
 
 export { parseCallArguments } from './cli/call-arguments.js';
 export { extractListFlags } from './cli/list-flags.js';
 export { resolveCallTimeout } from './cli/timeouts.js';
+
+configureAutoSelectFamilyAttemptTimeout();
 
 const FORCE_EXIT_GRACE_MS = 50;
 const STDOUT_FLUSH_TIMEOUT_MS = 2000;

--- a/src/daemon/host.ts
+++ b/src/daemon/host.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { loadConfigSnapshot, type DaemonConfig, type ServerDefinition } from '../config.js';
 import { readJsonFile, withFileLock, writeJsonFile } from '../fs-json.js';
 import { isKeepAliveServer } from '../lifecycle.js';
+import { configureAutoSelectFamilyAttemptTimeout } from '../network-family-autoselection.js';
 import { isProcessRunning } from '../process-utils.js';
 import { createRuntime, type Runtime } from '../runtime.js';
 import { createNonInteractiveElicitationResponder } from '../runtime/elicitation.js';
@@ -51,6 +52,7 @@ interface DaemonHostOptions {
 }
 
 export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
+  configureAutoSelectFamilyAttemptTimeout();
   const configLayers = await collectConfigLayers({
     configPath: options.configExplicit ? options.configPath : undefined,
     rootDir: options.rootDir,

--- a/src/network-family-autoselection.ts
+++ b/src/network-family-autoselection.ts
@@ -1,0 +1,27 @@
+import net from 'node:net';
+
+const NODE_DEFAULT_ATTEMPT_TIMEOUT_MS = 250;
+const MCPORTER_ATTEMPT_TIMEOUT_MS = 1_500;
+const NODE_OPTION = '--network-family-autoselection-attempt-timeout';
+
+interface AutoSelectFamilyDefaults {
+  getDefaultAutoSelectFamilyAttemptTimeout(): number;
+  setDefaultAutoSelectFamilyAttemptTimeout(value: number): void;
+}
+
+export function configureAutoSelectFamilyAttemptTimeout(
+  defaults: AutoSelectFamilyDefaults = net,
+  nodeOptions = process.env.NODE_OPTIONS
+): boolean {
+  if (hasExplicitNodeOption(nodeOptions)) return false;
+  if (defaults.getDefaultAutoSelectFamilyAttemptTimeout() !== NODE_DEFAULT_ATTEMPT_TIMEOUT_MS) return false;
+
+  // Node's 250 ms Happy-Eyeballs attempt window is too short for otherwise reachable MCP endpoints on slower links.
+  defaults.setDefaultAutoSelectFamilyAttemptTimeout(MCPORTER_ATTEMPT_TIMEOUT_MS);
+  return true;
+}
+
+function hasExplicitNodeOption(nodeOptions: string | undefined): boolean {
+  if (!nodeOptions) return false;
+  return new RegExp(`(?:^|\\s)${NODE_OPTION}(?:=|\\s|$)`).test(nodeOptions);
+}

--- a/tests/e2e-fixture-servers.test.ts
+++ b/tests/e2e-fixture-servers.test.ts
@@ -1,0 +1,370 @@
+import { execFile, spawn, type ChildProcess } from 'node:child_process';
+import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  Client as ModernClient,
+  StreamableHTTPClientTransport as ModernHttpTransport,
+} from '@modelcontextprotocol/client';
+import { Client as LegacyClient } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport as LegacyHttpTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { ServerDefinition } from '../src/config.js';
+import { waitForChildExit } from '../src/process-utils.js';
+import { createRuntime } from '../src/runtime.js';
+import { makeShortTempDir } from './fixtures/test-helpers.js';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+const CLI_ENTRY = path.join(REPO_ROOT, 'dist', 'cli.js');
+const LEGACY_SERVER = path.join(REPO_ROOT, 'tests', 'servers', 'legacy', 'server.ts');
+const MODERN_SERVER = path.join(REPO_ROOT, 'tests', 'servers', 'modern', 'server.ts');
+const TSX_CLI = createRequire(import.meta.url).resolve('tsx/cli');
+const transports = ['stdio', 'http'] as const;
+const fixtureKinds = ['legacy', 'modern'] as const;
+
+type TransportKind = (typeof transports)[number];
+type FixtureKind = (typeof fixtureKinds)[number];
+type RawServerConfig = Record<string, unknown>;
+type CliResult = { stdout: string; stderr: string; exitCode: number };
+
+let legacyHttp: RunningFixture;
+let modernHttp: RunningFixture;
+
+interface RunningFixture {
+  child: ChildProcess;
+  url: string;
+  stderr: () => string;
+}
+
+beforeAll(async () => {
+  await fs.access(CLI_ENTRY).catch(() => {
+    throw new Error('dist/cli.js is missing; run `pnpm build` before invoking this e2e file directly.');
+  });
+  [legacyHttp, modernHttp] = await Promise.all([
+    startHttpFixture('legacy', LEGACY_SERVER),
+    startHttpFixture('modern', MODERN_SERVER),
+  ]);
+}, 20_000);
+
+afterAll(async () => {
+  await Promise.all([stopChild(legacyHttp?.child), stopChild(modernHttp?.child)]);
+});
+
+describe.each(fixtureKinds)('%s fixture through the real CLI', (fixture) => {
+  describe.each(transports)('%s', (transport) => {
+    it('lists, calls, fails, reports structured output, completes progress work, and reads resources', async () => {
+      await withConfig({ fixture: configFor(fixture, transport) }, async (configPath, env) => {
+        const listed = await runCli(['list', 'fixture', '--json', '--verbose', '--no-oauth'], configPath, env);
+        expect(listed.exitCode, listed.stderr).toBe(0);
+        const listPayload = parseJson<{
+          tools: Array<{ name: string }>;
+          protocolVersion?: string;
+          era?: string;
+        }>(listed.stdout);
+        expect(listPayload.tools.map((tool) => tool.name)).toContain('echo');
+        if (fixture === 'legacy') {
+          expect(listPayload.tools.length).toBeGreaterThan(60);
+          expect(listPayload.tools.at(-1)?.name).toBe('many_tools_60');
+        } else {
+          expect(listPayload.protocolVersion).toBe('2026-07-28');
+          expect(listPayload.era).toBe('modern');
+        }
+
+        const echo = await runCli(['call', 'fixture.echo', 'text=fixture-echo', '--output', 'json'], configPath, env);
+        expect(echo.exitCode, echo.stderr).toBe(0);
+        expect(echo.stdout).toContain('fixture-echo');
+
+        const add = await runCli(['call', 'fixture.add', 'a=19', 'b=23', '--output', 'json'], configPath, env);
+        expect(add.exitCode, add.stderr).toBe(0);
+        expect(parseJson<{ result: number }>(add.stdout)).toEqual({ result: 42 });
+
+        const failed = await runCli(['call', 'fixture.fail', '--output', 'json'], configPath, env);
+        expect(failed.exitCode).not.toBe(0);
+        expect(`${failed.stdout}\n${failed.stderr}`).toContain(`${fixture} requested failure`);
+
+        const longTask = await runCli(['call', 'fixture.long_task', 'steps=3', '--output', 'text'], configPath, env);
+        expect(longTask.exitCode, longTask.stderr).toBe(0);
+        expect(longTask.stdout).toContain(`${fixture} long task completed 3 steps`);
+
+        const resources = await runCli(['resource', 'fixture', '--json'], configPath, env);
+        expect(resources.exitCode, resources.stderr).toBe(0);
+        const resourcePayload = parseJson<{ resources: Array<{ uri: string }> }>(resources.stdout);
+        expect(resourcePayload.resources.map((resource) => resource.uri)).toContain(`fixture://${fixture}/welcome`);
+
+        const welcome = await runCli(
+          ['resource', 'fixture', `fixture://${fixture}/welcome`, '--output', 'text'],
+          configPath,
+          env
+        );
+        expect(welcome.exitCode, welcome.stderr).toBe(0);
+        expect(welcome.stdout).toContain(`hello from the ${fixture} fixture`);
+
+        if (fixture === 'legacy') {
+          const binary = await runCli(
+            ['resource', 'fixture', 'fixture://legacy/binary', '--output', 'json'],
+            configPath,
+            env
+          );
+          expect(binary.exitCode, binary.stderr).toBe(0);
+          expect(binary.stdout).toContain('AAEC/f7/');
+        }
+      });
+    }, 30_000);
+  });
+});
+
+describe.each(transports)('legacy long-tail over %s', (transport) => {
+  it('declines headless elicitation with a hint and handles unsupported sampling', async () => {
+    await withConfig({ fixture: configFor('legacy', transport) }, async (configPath, env) => {
+      const elicited = await runCli(['call', 'fixture.elicit_name', '--output', 'text'], configPath, env);
+      expect(elicited.exitCode).toBe(0);
+      expect(elicited.stderr).toContain('Server requested interactive input; run mcporter in a terminal.');
+      expect(elicited.stdout).toContain('elicitation decline');
+
+      const sampled = await runCli(['call', 'fixture.sample_poem', '--output', 'text'], configPath, env);
+      expect(sampled.exitCode).toBe(0);
+      expect(sampled.stdout).toContain('sampling declined or unsupported by client');
+    });
+  });
+});
+
+describe.each(transports)('modern MRTR and identity over %s', (transport) => {
+  it('declines cleanly through the CLI and reports per-request client identity', async () => {
+    await withConfig({ fixture: configFor('modern', transport) }, async (configPath, env) => {
+      const declined = await runCli(
+        ['call', 'fixture.confirm_delete', 'target=old-record', '--output', 'text'],
+        configPath,
+        env
+      );
+      expect(declined.exitCode).toBe(0);
+      expect(declined.stderr).toContain('Server requested interactive input; run mcporter in a terminal.');
+      expect(declined.stdout).toContain('delete declined for old-record');
+
+      const whoami = await runCli(['call', 'fixture.whoami', '--output', 'json'], configPath, env);
+      expect(whoami.exitCode, whoami.stderr).toBe(0);
+      expect(parseJson(whoami.stdout)).toMatchObject({
+        clientInfo: { name: 'mcporter' },
+        protocolVersion: '2026-07-28',
+      });
+    });
+  });
+
+  it('completes through createRuntime with a scripted elicitation handler', async () => {
+    const definition = runtimeDefinition('modern', transport);
+    const runtime = await createRuntime({
+      servers: [definition],
+      elicitationHandler: async (request) => {
+        expect(request.params.message).toBe('Delete runtime-record?');
+        return { action: 'accept', content: { confirm: true } };
+      },
+    });
+    try {
+      const result = (await runtime.callTool('fixture', 'confirm_delete', {
+        args: { target: 'runtime-record' },
+      })) as { content?: Array<{ type: string; text?: string }> };
+      expect(result.content?.[0]?.text).toBe('deleted runtime-record');
+    } finally {
+      await runtime.close();
+    }
+  });
+});
+
+it('bridges both fixtures to pinned modern and legacy HTTP clients through mcporter serve', async () => {
+  await withConfig(
+    {
+      legacy: { ...configFor('legacy', 'http'), lifecycle: 'keep-alive' },
+      modern: { ...configFor('modern', 'http'), lifecycle: 'keep-alive' },
+    },
+    async (configPath, env, tempDir) => {
+      const daemon = await runCli(['daemon', 'start', '--log'], configPath, env);
+      const daemonLogs = daemon.exitCode === 0 ? '' : await readDaemonLogs(path.join(tempDir, 'daemon'));
+      expect(daemon.exitCode, `${daemon.stdout}\n${daemon.stderr}\n${daemonLogs}`).toBe(0);
+      const bridge = await startBridge(configPath, env);
+      const modernClient = new ModernClient(
+        { name: 'fixture-modern-bridge-client', version: '1.0.0' },
+        { versionNegotiation: { mode: { pin: '2026-07-28' } } }
+      );
+      const legacyClient = new LegacyClient({ name: 'fixture-legacy-bridge-client', version: '1.0.0' });
+      try {
+        await modernClient.connect(new ModernHttpTransport(new URL(bridge.url)));
+        expect(modernClient.getProtocolEra()).toBe('modern');
+        const modernTools = await modernClient.listTools();
+        expect(modernTools.tools.map((tool) => tool.name)).toEqual(
+          expect.arrayContaining(['legacy__echo', 'modern__echo'])
+        );
+        await expect(
+          modernClient.callTool({ name: 'modern__echo', arguments: { text: 'modern bridge' } })
+        ).resolves.toMatchObject({ content: [{ type: 'text', text: 'modern bridge' }] });
+
+        await legacyClient.connect(new LegacyHttpTransport(new URL(bridge.url)));
+        const legacyTools = await legacyClient.listTools();
+        expect(legacyTools.tools.map((tool) => tool.name)).toEqual(
+          expect.arrayContaining(['legacy__echo', 'modern__echo'])
+        );
+        await expect(
+          legacyClient.callTool({ name: 'legacy__echo', arguments: { text: 'legacy bridge' } })
+        ).resolves.toMatchObject({ content: [{ type: 'text', text: 'legacy bridge' }] });
+      } finally {
+        await Promise.allSettled([modernClient.close(), legacyClient.close()]);
+        await stopChild(bridge.child);
+        await runCli(['daemon', 'stop'], configPath, { ...env, MCPORTER_DAEMON_DIR: path.join(tempDir, 'daemon') });
+      }
+    }
+  );
+}, 40_000);
+
+function configFor(fixture: FixtureKind, transport: TransportKind): RawServerConfig {
+  if (transport === 'http') {
+    return {
+      description: `${fixture} committed fixture over HTTP`,
+      baseUrl: fixture === 'legacy' ? legacyHttp.url : modernHttp.url,
+      ...(fixture === 'legacy' ? { protocolVersion: 'legacy' } : {}),
+    };
+  }
+  return {
+    description: `${fixture} committed fixture over stdio`,
+    command: process.execPath,
+    args: [TSX_CLI, fixture === 'legacy' ? LEGACY_SERVER : MODERN_SERVER, '--stdio'],
+    ...(fixture === 'legacy' ? { protocolVersion: 'legacy' } : {}),
+  };
+}
+
+function runtimeDefinition(fixture: FixtureKind, transport: TransportKind): ServerDefinition {
+  const base = {
+    name: 'fixture',
+    description: `${fixture} committed fixture`,
+    source: { kind: 'local' as const, path: REPO_ROOT },
+    ...(fixture === 'legacy' ? { protocolVersion: 'legacy' as const } : {}),
+  };
+  if (transport === 'http') {
+    return {
+      ...base,
+      command: { kind: 'http', url: new URL(fixture === 'legacy' ? legacyHttp.url : modernHttp.url) },
+    };
+  }
+  return {
+    ...base,
+    command: {
+      kind: 'stdio',
+      command: process.execPath,
+      args: [TSX_CLI, fixture === 'legacy' ? LEGACY_SERVER : MODERN_SERVER, '--stdio'],
+      cwd: REPO_ROOT,
+    },
+  };
+}
+
+async function withConfig<T>(
+  servers: Record<string, RawServerConfig>,
+  run: (configPath: string, env: NodeJS.ProcessEnv, tempDir: string) => Promise<T>
+): Promise<T> {
+  const tempDir = await makeShortTempDir('mcp-fixture');
+  const configPath = path.join(tempDir, 'mcporter.json');
+  await fs.writeFile(configPath, JSON.stringify({ mcpServers: servers }, null, 2), 'utf8');
+  const env = {
+    ...process.env,
+    FORCE_COLOR: '0',
+    NO_COLOR: '1',
+    MCPORTER_CONFIG: configPath,
+    MCPORTER_DAEMON_DIR: path.join(tempDir, 'daemon'),
+    MCPORTER_NO_FORCE_EXIT: '1',
+  };
+  try {
+    return await run(configPath, env, tempDir);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function runCli(args: string[], configPath: string, env: NodeJS.ProcessEnv): Promise<CliResult> {
+  return await new Promise<CliResult>((resolve) => {
+    execFile(
+      process.execPath,
+      [CLI_ENTRY, '--config', configPath, ...args],
+      { cwd: REPO_ROOT, env, timeout: 20_000, maxBuffer: 5 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        const code = error && typeof error.code === 'number' ? error.code : error ? 1 : 0;
+        resolve({ stdout, stderr, exitCode: code });
+      }
+    );
+  });
+}
+
+function parseJson<T = Record<string, unknown>>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+async function startHttpFixture(fixture: FixtureKind, serverPath: string): Promise<RunningFixture> {
+  const child = spawn(process.execPath, [TSX_CLI, serverPath, '--http', '0'], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stdout?.resume();
+  child.stderr?.setEncoding('utf8');
+  let captured = '';
+  const url = await new Promise<string>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${fixture} fixture did not become ready:\n${captured}`)), 10_000);
+    child.stderr?.on('data', (chunk: string) => {
+      captured += chunk;
+      const match = captured.match(/listening on (http:\/\/127\.0\.0\.1:\d+\/mcp)/);
+      if (match?.[1]) {
+        clearTimeout(timer);
+        resolve(match[1]);
+      }
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer);
+      reject(new Error(`${fixture} fixture exited before ready (${code ?? signal}):\n${captured}`));
+    });
+  });
+  return { child, url, stderr: () => captured };
+}
+
+async function startBridge(configPath: string, env: NodeJS.ProcessEnv): Promise<RunningFixture> {
+  const child = spawn(process.execPath, [CLI_ENTRY, '--config', configPath, 'serve', '--http', '0'], {
+    cwd: REPO_ROOT,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stdout?.resume();
+  child.stderr?.setEncoding('utf8');
+  let captured = '';
+  const url = await new Promise<string>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`mcporter serve did not become ready:\n${captured}`)), 15_000);
+    child.stderr?.on('data', (chunk: string) => {
+      captured += chunk;
+      const match = captured.match(/bridge (http:\/\/127\.0\.0\.1:\d+\/mcp)/);
+      if (match?.[1]) {
+        clearTimeout(timer);
+        resolve(match[1]);
+      }
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer);
+      reject(new Error(`mcporter serve exited before ready (${code ?? signal}):\n${captured}`));
+    });
+  });
+  return { child, url, stderr: () => captured };
+}
+
+async function stopChild(child: ChildProcess | undefined): Promise<void> {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  child.kill('SIGTERM');
+  try {
+    await waitForChildExit(child, 2_000);
+  } catch {
+    child.kill('SIGKILL');
+    await waitForChildExit(child, 2_000).catch(() => {});
+  }
+}
+
+async function readDaemonLogs(root: string): Promise<string> {
+  const entries = await fs.readdir(path.join(root, 'daemon')).catch(() => []);
+  const logs = await Promise.all(
+    entries
+      .filter((entry) => entry.endsWith('.log'))
+      .map((entry) => fs.readFile(path.join(root, 'daemon', entry), 'utf8'))
+  );
+  return logs.join('\n');
+}

--- a/tests/network-family-autoselection.test.ts
+++ b/tests/network-family-autoselection.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { configureAutoSelectFamilyAttemptTimeout } from '../src/network-family-autoselection.js';
+
+describe('Happy-Eyeballs connect attempt timeout', () => {
+  it('raises Node stock default to 1500ms', () => {
+    const defaults = {
+      getDefaultAutoSelectFamilyAttemptTimeout: vi.fn(() => 250),
+      setDefaultAutoSelectFamilyAttemptTimeout: vi.fn(),
+    };
+
+    expect(configureAutoSelectFamilyAttemptTimeout(defaults, undefined)).toBe(true);
+    expect(defaults.setDefaultAutoSelectFamilyAttemptTimeout).toHaveBeenCalledWith(1_500);
+  });
+
+  it('respects an existing API override', () => {
+    const defaults = {
+      getDefaultAutoSelectFamilyAttemptTimeout: vi.fn(() => 900),
+      setDefaultAutoSelectFamilyAttemptTimeout: vi.fn(),
+    };
+
+    expect(configureAutoSelectFamilyAttemptTimeout(defaults, undefined)).toBe(false);
+    expect(defaults.setDefaultAutoSelectFamilyAttemptTimeout).not.toHaveBeenCalled();
+  });
+
+  it('respects an explicit NODE_OPTIONS override even when it matches Node stock default', () => {
+    const defaults = {
+      getDefaultAutoSelectFamilyAttemptTimeout: vi.fn(() => 250),
+      setDefaultAutoSelectFamilyAttemptTimeout: vi.fn(),
+    };
+
+    expect(
+      configureAutoSelectFamilyAttemptTimeout(defaults, '--network-family-autoselection-attempt-timeout=250')
+    ).toBe(false);
+    expect(defaults.setDefaultAutoSelectFamilyAttemptTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/tests/servers/legacy/README.md
+++ b/tests/servers/legacy/README.md
@@ -1,0 +1,3 @@
+# Legacy MCP fixture server
+
+This deterministic fixture exercises the broad MCP 2025-11-25 surface: paginated tools, structured output, progress and logging notifications, sampling and elicitation, resources and subscriptions, templates and completions, prompts, and runtime list changes. Run it from the repository root with `pnpm exec tsx tests/servers/legacy/server.ts --stdio` or `pnpm exec tsx tests/servers/legacy/server.ts --http 3000`; Streamable HTTP is served at `/mcp`.

--- a/tests/servers/legacy/package.json
+++ b/tests/servers/legacy/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@mcporter/test-server-legacy",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx server.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "express": "^5.2.1",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "tsx": "^4.23.1"
+  }
+}

--- a/tests/servers/legacy/server.ts
+++ b/tests/servers/legacy/server.ts
@@ -1,0 +1,385 @@
+import { randomUUID } from 'node:crypto';
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { completable } from '@modelcontextprotocol/sdk/server/completable.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  CallToolRequestSchema,
+  ErrorCode,
+  isInitializeRequest,
+  ListToolsRequestSchema,
+  McpError,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
+  type CallToolResult,
+  type Tool,
+} from '@modelcontextprotocol/sdk/types.js';
+import express from 'express';
+import { z } from 'zod';
+
+const PAGE_SIZE = 25;
+const TOUCH_URI = 'fixture://legacy/mutable';
+
+interface ToolSpec {
+  definition: Tool;
+  run: (
+    args: Record<string, unknown>,
+    extra: {
+      _meta?: { progressToken?: string | number };
+      sendNotification(notification: {
+        method: 'notifications/progress';
+        params: { progressToken: string | number; progress: number; total?: number; message?: string };
+      }): Promise<void>;
+    }
+  ) => CallToolResult | Promise<CallToolResult>;
+}
+
+export function createLegacyServer(): McpServer {
+  const server = new McpServer(
+    { name: 'mcporter-legacy-fixture', version: '1.0.0' },
+    {
+      capabilities: {
+        logging: {},
+        resources: { listChanged: true, subscribe: true },
+        tools: { listChanged: true },
+      },
+      instructions: 'Deterministic MCP 2025-11-25 fixture covering the legacy protocol surface.',
+    }
+  );
+  const tools = new Map<string, ToolSpec>();
+  const subscriptions = new Set<string>();
+
+  const addTool = (spec: ToolSpec) => tools.set(spec.definition.name, spec);
+  const objectSchema = (properties: Record<string, object> = {}, required: string[] = []) => ({
+    type: 'object' as const,
+    properties,
+    ...(required.length > 0 ? { required } : {}),
+    additionalProperties: false,
+  });
+  const textResult = (text: string): CallToolResult => ({ content: [{ type: 'text', text }] });
+
+  addTool({
+    definition: {
+      name: 'echo',
+      description: 'Return the supplied text unchanged.',
+      inputSchema: objectSchema({ text: { type: 'string' } }, ['text']),
+    },
+    run: (args) => textResult(String(args.text)),
+  });
+  addTool({
+    definition: {
+      name: 'add',
+      description: 'Add two numbers with structured output.',
+      inputSchema: objectSchema({ a: { type: 'number' }, b: { type: 'number' } }, ['a', 'b']),
+      outputSchema: objectSchema({ result: { type: 'number' } }, ['result']),
+    },
+    run: (args) => {
+      const output = { result: Number(args.a) + Number(args.b) };
+      return { content: [{ type: 'text', text: JSON.stringify(output) }], structuredContent: output };
+    },
+  });
+  addTool({
+    definition: {
+      name: 'long_task',
+      description: 'Emit deterministic progress notifications before completing.',
+      inputSchema: objectSchema({ steps: { type: 'integer', minimum: 1, maximum: 5, default: 3 } }),
+    },
+    run: async (args, extra) => {
+      const steps = typeof args.steps === 'number' ? args.steps : 3;
+      const progressToken = extra._meta?.progressToken;
+      if (progressToken !== undefined) {
+        for (let progress = 1; progress <= steps; progress += 1) {
+          await extra.sendNotification({
+            method: 'notifications/progress',
+            params: { progressToken, progress, total: steps, message: `legacy step ${progress}/${steps}` },
+          });
+        }
+      }
+      return textResult(`legacy long task completed ${steps} steps`);
+    },
+  });
+  addTool({
+    definition: {
+      name: 'log_spam',
+      description: 'Emit logging notifications at several levels.',
+      inputSchema: objectSchema(),
+    },
+    run: async () => {
+      for (const level of ['debug', 'info', 'warning', 'error'] as const) {
+        await server.sendLoggingMessage({ level, logger: 'legacy-fixture', data: `${level} fixture log` });
+      }
+      return textResult('emitted 4 log messages');
+    },
+  });
+  addTool({
+    definition: { name: 'fail', description: 'Return an MCP tool error result.', inputSchema: objectSchema() },
+    run: () => ({ content: [{ type: 'text', text: 'legacy requested failure' }], isError: true }),
+  });
+  addTool({
+    definition: { name: 'throw', description: 'Raise a JSON-RPC protocol error.', inputSchema: objectSchema() },
+    run: () => {
+      throw new McpError(ErrorCode.InternalError, 'legacy protocol error');
+    },
+  });
+  addTool({
+    definition: {
+      name: 'annotated',
+      title: 'Annotated Legacy Tool',
+      description: 'Expose all stable 2025 tool annotations.',
+      inputSchema: objectSchema(),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    },
+    run: () => textResult('annotations are metadata'),
+  });
+  addTool({
+    definition: {
+      name: 'sample_poem',
+      description: 'Ask the client to sample a short poem.',
+      inputSchema: objectSchema(),
+    },
+    run: async () => {
+      try {
+        const sampled = await server.server.createMessage({
+          maxTokens: 40,
+          messages: [
+            { role: 'user', content: { type: 'text', text: 'Write a two-line poem about deterministic tests.' } },
+          ],
+        });
+        return textResult(`sampling result: ${JSON.stringify(sampled.content)}`);
+      } catch {
+        return textResult('sampling declined or unsupported by client');
+      }
+    },
+  });
+  addTool({
+    definition: {
+      name: 'elicit_name',
+      description: 'Ask the client for a name using form elicitation.',
+      inputSchema: objectSchema(),
+    },
+    run: async () => {
+      try {
+        const response = await server.server.elicitInput({
+          mode: 'form',
+          message: 'What name should the fixture greet?',
+          requestedSchema: {
+            type: 'object',
+            properties: { name: { type: 'string', title: 'Name' } },
+            required: ['name'],
+          },
+        });
+        if (response.action !== 'accept') return textResult(`elicitation ${response.action}`);
+        const name = typeof response.content?.name === 'string' ? response.content.name : 'unknown';
+        return textResult(`hello ${name}`);
+      } catch {
+        return textResult('elicitation declined or unsupported by client');
+      }
+    },
+  });
+  addTool({
+    definition: {
+      name: 'touch_resource',
+      description: 'Notify subscribers that the mutable resource changed.',
+      inputSchema: objectSchema(),
+    },
+    run: async () => {
+      if (subscriptions.has(TOUCH_URI)) await server.server.sendResourceUpdated({ uri: TOUCH_URI });
+      return textResult('resource touched');
+    },
+  });
+  let optionalToolEnabled = false;
+  addTool({
+    definition: {
+      name: 'toggle_tool',
+      description: 'Toggle a runtime-registered tool and emit list_changed.',
+      inputSchema: objectSchema(),
+    },
+    run: async () => {
+      optionalToolEnabled = !optionalToolEnabled;
+      if (optionalToolEnabled) {
+        addTool({
+          definition: {
+            name: 'runtime_tool',
+            description: 'A dynamically registered fixture tool.',
+            inputSchema: objectSchema(),
+          },
+          run: () => textResult('runtime tool enabled'),
+        });
+      } else {
+        tools.delete('runtime_tool');
+      }
+      await server.server.sendToolListChanged();
+      return textResult(`runtime tool ${optionalToolEnabled ? 'enabled' : 'disabled'}`);
+    },
+  });
+  for (let index = 1; index <= 60; index += 1) {
+    const name = `many_tools_${String(index).padStart(2, '0')}`;
+    addTool({
+      definition: { name, description: `Pagination fixture tool ${index}.`, inputSchema: objectSchema() },
+      run: () => textResult(name),
+    });
+  }
+
+  server.server.setRequestHandler(ListToolsRequestSchema, (request) => {
+    const cursor = request.params?.cursor;
+    const start = cursor === undefined ? 0 : Number.parseInt(cursor, 10);
+    if (!Number.isSafeInteger(start) || start < 0) throw new McpError(ErrorCode.InvalidParams, 'Invalid tools cursor');
+    const definitions = [...tools.values()].map((tool) => tool.definition);
+    const end = start + PAGE_SIZE;
+    return { tools: definitions.slice(start, end), ...(end < definitions.length ? { nextCursor: String(end) } : {}) };
+  });
+  server.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+    const spec = tools.get(request.params.name);
+    if (!spec) throw new McpError(ErrorCode.InvalidParams, `Unknown tool '${request.params.name}'`);
+    return await spec.run((request.params.arguments ?? {}) as Record<string, unknown>, extra);
+  });
+  server.server.setRequestHandler(SubscribeRequestSchema, (request) => {
+    subscriptions.add(request.params.uri);
+    return {};
+  });
+  server.server.setRequestHandler(UnsubscribeRequestSchema, (request) => {
+    subscriptions.delete(request.params.uri);
+    return {};
+  });
+
+  server.registerResource(
+    'welcome',
+    'fixture://legacy/welcome',
+    { title: 'Welcome text', description: 'Static UTF-8 fixture text.', mimeType: 'text/plain' },
+    async (uri) => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: 'hello from the legacy fixture' }] })
+  );
+  server.registerResource(
+    'mutable',
+    TOUCH_URI,
+    { title: 'Mutable text', description: 'Resource used for subscription notifications.', mimeType: 'text/plain' },
+    async (uri) => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: 'legacy mutable resource' }] })
+  );
+  server.registerResource(
+    'details',
+    'fixture://legacy/details',
+    { title: 'Fixture details', mimeType: 'application/json' },
+    async (uri) => ({ contents: [{ uri: uri.href, mimeType: 'application/json', text: '{"era":"legacy"}' }] })
+  );
+  server.registerResource(
+    'binary',
+    'fixture://legacy/binary',
+    { title: 'Binary bytes', description: 'Small deterministic binary payload.', mimeType: 'application/octet-stream' },
+    async (uri) => ({
+      contents: [
+        {
+          uri: uri.href,
+          mimeType: 'application/octet-stream',
+          blob: Buffer.from([0, 1, 2, 253, 254, 255]).toString('base64'),
+        },
+      ],
+    })
+  );
+  server.registerResource(
+    'file',
+    new ResourceTemplate('file:///{path}', {
+      list: async () => ({ resources: [{ uri: 'file:///alpha.txt', name: 'alpha.txt', mimeType: 'text/plain' }] }),
+      complete: {
+        path: (value) => ['alpha.txt', 'beta.txt', 'notes/readme.md'].filter((path) => path.startsWith(value)),
+      },
+    }),
+    { title: 'Virtual file', description: 'Template resource with path completion.', mimeType: 'text/plain' },
+    async (uri, variables) => ({
+      contents: [{ uri: uri.href, mimeType: 'text/plain', text: `legacy file ${String(variables.path)}` }],
+    })
+  );
+
+  server.registerPrompt(
+    'fixture_status',
+    { title: 'Fixture status', description: 'A prompt without arguments.' },
+    async () => ({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Describe the legacy fixture status.' } }],
+    })
+  );
+  server.registerPrompt(
+    'greet',
+    {
+      title: 'Greeting prompt',
+      description: 'A prompt with a completable style argument.',
+      argsSchema: {
+        style: completable(z.string(), (value) =>
+          ['brief', 'formal', 'playful'].filter((style) => style.startsWith(value))
+        ),
+        name: z.string(),
+      },
+    },
+    async ({ style, name }) => ({
+      messages: [{ role: 'user', content: { type: 'text', text: `Greet ${name} in a ${style} style.` } }],
+    })
+  );
+
+  return server;
+}
+
+async function serveStdio(): Promise<void> {
+  const server = createLegacyServer();
+  await server.connect(new StdioServerTransport());
+}
+
+async function serveHttp(port: number): Promise<void> {
+  const app = express();
+  app.use(express.json());
+  const sessions = new Map<string, { transport: StreamableHTTPServerTransport; server: McpServer }>();
+
+  app.all('/mcp', async (request, response) => {
+    try {
+      const sessionId = request.headers['mcp-session-id'];
+      let session = typeof sessionId === 'string' ? sessions.get(sessionId) : undefined;
+      if (!session && request.method === 'POST' && isInitializeRequest(request.body)) {
+        const server = createLegacyServer();
+        let transport!: StreamableHTTPServerTransport;
+        transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: randomUUID,
+          enableJsonResponse: true,
+          onsessioninitialized: (id) => {
+            sessions.set(id, { transport, server });
+          },
+        });
+        transport.onclose = () => {
+          const id = transport.sessionId;
+          if (id) sessions.delete(id);
+        };
+        await server.connect(transport);
+        session = { transport, server };
+      }
+      if (!session) {
+        response
+          .status(400)
+          .json({ jsonrpc: '2.0', error: { code: -32000, message: 'Missing or invalid session' }, id: null });
+        return;
+      }
+      await session.transport.handleRequest(request, response, request.body);
+    } catch (error) {
+      if (!response.headersSent) {
+        response.status(500).json({
+          jsonrpc: '2.0',
+          error: { code: -32603, message: error instanceof Error ? error.message : String(error) },
+          id: null,
+        });
+      }
+    }
+  });
+
+  const httpServer = app.listen(port, '127.0.0.1', () => {
+    const address = httpServer.address();
+    if (!address || typeof address === 'string') throw new Error('Legacy fixture did not bind a TCP port');
+    console.error(`legacy fixture listening on http://127.0.0.1:${address.port}/mcp`);
+  });
+}
+
+function parseMode(argv: string[]): { mode: 'stdio' } | { mode: 'http'; port: number } {
+  if (argv.length === 0 || (argv.length === 1 && argv[0] === '--stdio')) return { mode: 'stdio' };
+  if (argv[0] === '--http' && argv.length === 2) {
+    const port = Number.parseInt(argv[1] ?? '', 10);
+    if (Number.isInteger(port) && port >= 0 && port <= 65_535) return { mode: 'http', port };
+  }
+  throw new Error('Usage: server.ts [--stdio | --http <port>]');
+}
+
+const mode = parseMode(process.argv.slice(2));
+if (mode.mode === 'stdio') await serveStdio();
+else await serveHttp(mode.port);

--- a/tests/servers/legacy/server.ts
+++ b/tests/servers/legacy/server.ts
@@ -34,6 +34,19 @@ interface ToolSpec {
   ) => CallToolResult | Promise<CallToolResult>;
 }
 
+function objectSchema(properties: Record<string, object> = {}, required: string[] = []) {
+  return {
+    type: 'object' as const,
+    properties,
+    ...(required.length > 0 ? { required } : {}),
+    additionalProperties: false,
+  };
+}
+
+function textResult(text: string): CallToolResult {
+  return { content: [{ type: 'text', text }] };
+}
+
 export function createLegacyServer(): McpServer {
   const server = new McpServer(
     { name: 'mcporter-legacy-fixture', version: '1.0.0' },
@@ -50,13 +63,6 @@ export function createLegacyServer(): McpServer {
   const subscriptions = new Set<string>();
 
   const addTool = (spec: ToolSpec) => tools.set(spec.definition.name, spec);
-  const objectSchema = (properties: Record<string, object> = {}, required: string[] = []) => ({
-    type: 'object' as const,
-    properties,
-    ...(required.length > 0 ? { required } : {}),
-    additionalProperties: false,
-  });
-  const textResult = (text: string): CallToolResult => ({ content: [{ type: 'text', text }] });
 
   addTool({
     definition: {

--- a/tests/servers/modern/README.md
+++ b/tests/servers/modern/README.md
@@ -1,0 +1,3 @@
+# Modern MCP fixture server
+
+This deterministic fixture exercises MCP 2026-07-28 discovery and per-request identity, cacheable lists, structured tool output, streamed progress, multi-round-trip form elicitation with protected request state, resources, prompts, and `subscriptions/listen` tool changes, while retaining the SDK's stateless 2025 fallback. Run it from the repository root with `pnpm exec tsx tests/servers/modern/server.ts --stdio` or `pnpm exec tsx tests/servers/modern/server.ts --http 3000`; Streamable HTTP is served at `/mcp`.

--- a/tests/servers/modern/package.json
+++ b/tests/servers/modern/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@mcporter/test-server-modern",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx server.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/server": "^2.0.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "tsx": "^4.23.1"
+  }
+}

--- a/tests/servers/modern/server.ts
+++ b/tests/servers/modern/server.ts
@@ -1,0 +1,259 @@
+import { createServer } from 'node:http';
+import { Readable } from 'node:stream';
+import {
+  acceptedContent,
+  CLIENT_INFO_META_KEY,
+  createMcpHandler,
+  createRequestStateCodec,
+  inputRequired,
+  inputResponse,
+  McpServer,
+  PROTOCOL_VERSION_META_KEY,
+  ResourceTemplate,
+  type ServerContext,
+} from '@modelcontextprotocol/server';
+import { serveStdio as serveMcpStdio } from '@modelcontextprotocol/server/stdio';
+import { z } from 'zod';
+
+const confirmationSchema = z.object({ confirm: z.boolean() });
+const requestStateCodec = createRequestStateCodec<{ operation: 'delete' }>({
+  key: 'mcporter-modern-fixture-request-state-key',
+  ttlSeconds: 300,
+});
+let runtimeToolEnabled = false;
+
+export function createModernServer(notifyHttpToolsChanged?: () => void): McpServer {
+  const server = new McpServer(
+    { name: 'mcporter-modern-fixture', version: '1.0.0' },
+    {
+      capabilities: { tools: { listChanged: true } },
+      instructions: 'Deterministic MCP 2026-07-28 fixture with the SDK legacy fallback enabled.',
+      cacheHints: {
+        'tools/list': { ttlMs: 1_000, cacheScope: 'private' },
+        'resources/list': { ttlMs: 1_000, cacheScope: 'private' },
+      },
+      requestState: { verify: requestStateCodec.verify },
+    }
+  );
+
+  server.registerTool(
+    'echo',
+    { description: 'Return the supplied text unchanged.', inputSchema: z.object({ text: z.string() }) },
+    async ({ text }) => ({ content: [{ type: 'text', text }] })
+  );
+  server.registerTool(
+    'add',
+    {
+      description: 'Add two numbers with structured output.',
+      inputSchema: z.object({ a: z.number(), b: z.number() }),
+      outputSchema: z.object({ result: z.number() }),
+    },
+    async ({ a, b }) => {
+      const output = { result: a + b };
+      return { content: [{ type: 'text', text: JSON.stringify(output) }], structuredContent: output };
+    }
+  );
+  server.registerTool(
+    'long_task',
+    {
+      description: 'Emit progress on the modern response stream before completing.',
+      inputSchema: z.object({ steps: z.number().int().min(1).max(5).default(3) }),
+    },
+    async ({ steps }, ctx) => {
+      const progressToken = ctx.mcpReq._meta?.progressToken;
+      if (progressToken !== undefined) {
+        for (let progress = 1; progress <= steps; progress += 1) {
+          await ctx.mcpReq.notify({
+            method: 'notifications/progress',
+            params: { progressToken, progress, total: steps, message: `modern step ${progress}/${steps}` },
+          });
+        }
+      }
+      return { content: [{ type: 'text', text: `modern long task completed ${steps} steps` }] };
+    }
+  );
+  server.registerTool('fail', { description: 'Return an MCP tool error result.' }, async () => ({
+    content: [{ type: 'text', text: 'modern requested failure' }],
+    isError: true,
+  }));
+  server.registerTool(
+    'confirm_delete',
+    {
+      description: 'Require a protected multi-round-trip confirmation before deleting.',
+      inputSchema: z.object({ target: z.string().default('fixture-item') }),
+    },
+    async ({ target }, ctx) => confirmDelete(target, ctx)
+  );
+  server.registerTool(
+    'whoami',
+    { description: 'Return the per-request MCP client identity and protocol revision.' },
+    async (ctx) => {
+      const envelope = ctx.mcpReq.envelope as Record<string, unknown> | undefined;
+      const clientInfo = envelope?.[CLIENT_INFO_META_KEY] ?? server.server.getClientVersion();
+      const protocolVersion = envelope?.[PROTOCOL_VERSION_META_KEY] ?? server.server.getNegotiatedProtocolVersion();
+      const output = { clientInfo: clientInfo ?? null, protocolVersion: protocolVersion ?? null };
+      return { content: [{ type: 'text', text: JSON.stringify(output) }], structuredContent: output };
+    }
+  );
+
+  let runtimeTool = runtimeToolEnabled ? registerRuntimeTool(server) : undefined;
+  server.registerTool(
+    'toggle_tool',
+    { description: 'Toggle a runtime tool and notify modern listen streams.' },
+    async () => {
+      runtimeToolEnabled = !runtimeToolEnabled;
+      if (runtimeToolEnabled && !runtimeTool) runtimeTool = registerRuntimeTool(server);
+      if (!runtimeToolEnabled && runtimeTool) {
+        runtimeTool.remove();
+        runtimeTool = undefined;
+      }
+      notifyHttpToolsChanged?.();
+      return { content: [{ type: 'text', text: `runtime tool ${runtimeToolEnabled ? 'enabled' : 'disabled'}` }] };
+    }
+  );
+
+  server.registerResource(
+    'welcome',
+    'fixture://modern/welcome',
+    {
+      title: 'Modern welcome text',
+      description: 'Static MCP 2026-07-28 fixture text.',
+      mimeType: 'text/plain',
+      cacheHint: { ttlMs: 1_000, cacheScope: 'private' },
+    },
+    async (uri) => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: 'hello from the modern fixture' }] })
+  );
+  server.registerResource(
+    'document',
+    new ResourceTemplate('fixture://modern/docs/{name}', {
+      list: async () => ({
+        resources: [{ uri: 'fixture://modern/docs/intro', name: 'intro', mimeType: 'text/plain' }],
+      }),
+      complete: { name: (value) => ['intro', 'reference'].filter((name) => name.startsWith(value)) },
+    }),
+    { title: 'Modern document', description: 'Template-backed modern resource.', mimeType: 'text/plain' },
+    async (uri, variables) => ({
+      contents: [{ uri: uri.href, mimeType: 'text/plain', text: `modern document ${String(variables.name)}` }],
+    })
+  );
+  server.registerPrompt(
+    'summarize_fixture',
+    { title: 'Summarize fixture', description: 'One modern fixture prompt.' },
+    async () => ({
+      messages: [{ role: 'user', content: { type: 'text', text: 'Summarize the MCP 2026-07-28 fixture.' } }],
+    })
+  );
+
+  return server;
+}
+
+async function confirmDelete(target: string, ctx: ServerContext) {
+  const response = inputResponse(ctx.mcpReq.inputResponses, 'confirmation');
+  const state = ctx.mcpReq.requestState<{ operation: 'delete' }>();
+  if (!state || response.kind === 'missing') {
+    return inputRequired({
+      inputRequests: {
+        confirmation: inputRequired.elicit({
+          message: `Delete ${target}?`,
+          requestedSchema: confirmationSchema,
+        }),
+      },
+      requestState: await requestStateCodec.mint({ operation: 'delete' }, ctx),
+    });
+  }
+  if (state.operation !== 'delete') throw new Error('Unexpected confirmation request state');
+  if (response.kind !== 'elicit' || response.action !== 'accept') {
+    return { content: [{ type: 'text' as const, text: `delete declined for ${target}` }] };
+  }
+  const accepted = acceptedContent(ctx.mcpReq.inputResponses, 'confirmation', confirmationSchema);
+  if (accepted?.confirm !== true) {
+    return { content: [{ type: 'text' as const, text: `delete declined for ${target}` }] };
+  }
+  return { content: [{ type: 'text' as const, text: `deleted ${target}` }] };
+}
+
+function registerRuntimeTool(server: McpServer) {
+  return server.registerTool(
+    'runtime_tool',
+    { description: 'A dynamically registered modern fixture tool.' },
+    async () => ({
+      content: [{ type: 'text', text: 'runtime tool enabled' }],
+    })
+  );
+}
+
+function serveStdio(): void {
+  serveMcpStdio(() => createModernServer());
+}
+
+async function serveHttp(port: number): Promise<void> {
+  let publishToolsChanged: (() => void) | undefined;
+  const handler = createMcpHandler(() => createModernServer(() => publishToolsChanged?.()));
+  publishToolsChanged = () => handler.notify.toolsChanged();
+  const httpServer = createServer((request, response) => {
+    const url = new URL(request.url ?? '/', `http://${request.headers.host ?? '127.0.0.1'}`);
+    if (url.pathname !== '/mcp') {
+      response.writeHead(404).end('Not found');
+      return;
+    }
+    void handler
+      .fetch(toWebRequest(request))
+      .then((webResponse) => writeWebResponse(response, webResponse))
+      .catch((error: unknown) => {
+        if (!response.headersSent) response.writeHead(500, { 'content-type': 'text/plain; charset=utf-8' });
+        response.end(error instanceof Error ? error.message : String(error));
+      });
+  });
+  httpServer.once('close', () => void handler.close());
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(port, '127.0.0.1', () => {
+      httpServer.off('error', reject);
+      resolve();
+    });
+  });
+  const address = httpServer.address();
+  if (!address || typeof address === 'string') throw new Error('Modern fixture did not bind a TCP port');
+  console.error(`modern fixture listening on http://127.0.0.1:${address.port}/mcp`);
+}
+
+function toWebRequest(request: import('node:http').IncomingMessage): Request {
+  const url = new URL(request.url ?? '/', `http://${request.headers.host ?? '127.0.0.1'}`);
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (Array.isArray(value)) for (const entry of value) headers.append(name, entry);
+    else if (value !== undefined) headers.set(name, value);
+  }
+  const method = request.method ?? 'GET';
+  const init: RequestInit & { duplex?: 'half' } = { method, headers };
+  if (method !== 'GET' && method !== 'HEAD') {
+    init.body = Readable.toWeb(request) as unknown as BodyInit;
+    init.duplex = 'half';
+  }
+  return new Request(url, init);
+}
+
+function writeWebResponse(response: import('node:http').ServerResponse, webResponse: Response): void {
+  response.statusCode = webResponse.status;
+  webResponse.headers.forEach((value, name) => response.setHeader(name, value));
+  if (!webResponse.body) {
+    response.end();
+    return;
+  }
+  const body = Readable.fromWeb(webResponse.body as never);
+  body.on('error', (error) => response.destroy(error));
+  body.pipe(response);
+}
+
+function parseMode(argv: string[]): { mode: 'stdio' } | { mode: 'http'; port: number } {
+  if (argv.length === 0 || (argv.length === 1 && argv[0] === '--stdio')) return { mode: 'stdio' };
+  if (argv[0] === '--http' && argv.length === 2) {
+    const port = Number.parseInt(argv[1] ?? '', 10);
+    if (Number.isInteger(port) && port >= 0 && port <= 65_535) return { mode: 'http', port };
+  }
+  throw new Error('Usage: server.ts [--stdio | --http <port>]');
+}
+
+const mode = parseMode(process.argv.slice(2));
+if (mode.mode === 'stdio') serveStdio();
+else await serveHttp(mode.port);

--- a/tests/servers/modern/server.ts
+++ b/tests/servers/modern/server.ts
@@ -32,7 +32,7 @@ export function createModernServer(notifyHttpToolsChanged?: () => void): McpServ
         'tools/list': { ttlMs: 1_000, cacheScope: 'private' },
         'resources/list': { ttlMs: 1_000, cacheScope: 'private' },
       },
-      requestState: { verify: requestStateCodec.verify },
+      requestState: { verify: (state, ctx) => requestStateCodec.verify(state, ctx) },
     }
   );
 


### PR DESCRIPTION
Permanent in-repo test infrastructure for both MCP protocol generations, plus one robustness fix.

**Committed fixture servers**
- `tests/servers/legacy` (SDK v1, 2025-11-25 era): 71 paginated tools, structured output/outputSchema, progress, logging, protocol + tool errors, annotations, sampling, elicitation, text/blob/template resources with completion, resources/subscribe + list_changed, prompts, ping, instructions.
- `tests/servers/modern` (SDK v2, 2026-07-28): server/discover, cache hints (ttlMs/cacheScope), MRTR `confirm_delete` with sealed requestState, per-request identity (`whoami` proves stateless `_meta` client info), subscriptions/listen list changes, resources/templates/prompts, legacy HTTP fallback via `createMcpHandler`. Both run standalone over stdio or Streamable HTTP.

**E2E suite** (`tests/e2e-fixture-servers.test.ts`, 11 tests): drives the built `dist/cli.js` against both fixtures over both transports — list (pagination proven), calls (structured output, failures, progress), resources, headless elicitation decline + hint, scripted elicitation through `createRuntime` completing an MRTR confirmation, per-request identity assertion, and `mcporter serve` bridging both fixtures to a pinned-modern v2 client and a legacy v1 client simultaneously.

**Fix**: raise Node's Happy-Eyeballs `autoSelectFamilyAttemptTimeout` from the stock 250ms to 1500ms in CLI/daemon startup (untouched-default detection preserves user overrides). The 250ms default made real-world servers unreachable on high-latency networks — reproduced against production MCP endpoints, where curl succeeded and mcporter failed identically back to v0.12.4.

Proof: `pnpm check` clean; full suite 941 passed / 3 skipped (including the new e2e); autoreview clean. Part 4 of the MCP 2.0 series (#254, #255, #256). Next: README documenting MCP 2.0 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
