### PR TITLE
fix: eight protocol/transport defects in MCP 2.0 negotiation, replay, and bridging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Preserve transport capabilities and request metadata through recording wrappers so modern HTTP cancellation remains stream-based.
 - Replay accepted modern elicitation rounds with the caller's handler instead of unconditionally declining them.
 - Preserve primitive tool output schemas through `mcporter serve` and project structured results correctly for both legacy and modern clients.
+- Stop resource pagination when a server repeats its cursor, returning the bounded partial result without duplicate-page churn.
 
 ### Config
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Replay accepted modern elicitation rounds with the caller's handler instead of unconditionally declining them.
 - Preserve primitive tool output schemas through `mcporter serve` and project structured results correctly for both legacy and modern clients.
 - Stop resource pagination when a server repeats its cursor, returning the bounded partial result without duplicate-page churn.
+- Re-emit recorded progress, logging, and list-change notifications during replay in their recorded order relative to responses.
 
 ### Config
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Support MCP protocol revision 2026-07-28 with automatic modern/legacy negotiation while preserving legacy server compatibility.
 - Support interactive form and URL elicitation in terminals across legacy and 2026-07-28 multi-round-trip servers, with immediate declines and a terminal hint in headless contexts.
 - Keep legacy SSE fallback on legacy negotiation and preserve pinned modern-version negotiation errors instead of masking them with a secondary SSE failure.
+- Recover legacy stdio servers that exit on modern discovery by retrying initialization once with a fresh legacy-mode process.
 
 ### Config
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Support interactive form and URL elicitation in terminals across legacy and 2026-07-28 multi-round-trip servers, with immediate declines and a terminal hint in headless contexts.
 - Keep legacy SSE fallback on legacy negotiation and preserve pinned modern-version negotiation errors instead of masking them with a secondary SSE failure.
 - Recover legacy stdio servers that exit on modern discovery by retrying initialization once with a fresh legacy-mode process.
+- Use the SDK's 60-second stdio discovery timeout for slow-starting modern servers, configurable with `MCPORTER_STDIO_PROBE_TIMEOUT_MS`.
 
 ### Config
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Use the SDK's 60-second stdio discovery timeout for slow-starting modern servers, configurable with `MCPORTER_STDIO_PROBE_TIMEOUT_MS`.
 - Preserve transport capabilities and request metadata through recording wrappers so modern HTTP cancellation remains stream-based.
 - Replay accepted modern elicitation rounds with the caller's handler instead of unconditionally declining them.
+- Preserve primitive tool output schemas through `mcporter serve` and project structured results correctly for both legacy and modern clients.
 
 ### Config
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Recover legacy stdio servers that exit on modern discovery by retrying initialization once with a fresh legacy-mode process.
 - Use the SDK's 60-second stdio discovery timeout for slow-starting modern servers, configurable with `MCPORTER_STDIO_PROBE_TIMEOUT_MS`.
 - Preserve transport capabilities and request metadata through recording wrappers so modern HTTP cancellation remains stream-based.
+- Replay accepted modern elicitation rounds with the caller's handler instead of unconditionally declining them.
 
 ### Config
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Keep replay recordings usable across MCP protocol-version and mcporter client-version changes.
 - Support MCP protocol revision 2026-07-28 with automatic modern/legacy negotiation while preserving legacy server compatibility.
 - Support interactive form and URL elicitation in terminals across legacy and 2026-07-28 multi-round-trip servers, with immediate declines and a terminal hint in headless contexts.
+- Keep legacy SSE fallback on legacy negotiation and preserve pinned modern-version negotiation errors instead of masking them with a secondary SSE failure.
 
 ### Config
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Keep legacy SSE fallback on legacy negotiation and preserve pinned modern-version negotiation errors instead of masking them with a secondary SSE failure.
 - Recover legacy stdio servers that exit on modern discovery by retrying initialization once with a fresh legacy-mode process.
 - Use the SDK's 60-second stdio discovery timeout for slow-starting modern servers, configurable with `MCPORTER_STDIO_PROBE_TIMEOUT_MS`.
+- Preserve transport capabilities and request metadata through recording wrappers so modern HTTP cancellation remains stream-based.
 
 ### Config
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Helpful flags:
 
 > Tip: You can skip the verb entirely—`mcporter firecrawl` automatically runs `mcporter list firecrawl`, and dotted tokens like `mcporter linear.list_issues` dispatch to the call command (typo fixes included).
 
-Server listings default to a 30 s timeout, while calls default to 60 s. Override call timeouts with `MCPORTER_CALL_TIMEOUT` or `--timeout`, and list timeouts with `MCPORTER_LIST_TIMEOUT`. OAuth browser handshakes get a separate 5 minute grace period; pass `--oauth-timeout <ms>` (or export `MCPORTER_OAUTH_TIMEOUT_MS`) when you need the CLI to bail out faster while you diagnose stubborn auth flows.
+Server listings default to a 30 s timeout, while calls default to 60 s. Override call timeouts with `MCPORTER_CALL_TIMEOUT` or `--timeout`, and list timeouts with `MCPORTER_LIST_TIMEOUT`. Automatic stdio protocol discovery uses the SDK's 60 s timeout so slow-starting modern servers are not mistaken for legacy; set `MCPORTER_STDIO_PROBE_TIMEOUT_MS` to a positive integer when a different startup bound is needed. OAuth browser handshakes get a separate 5 minute grace period; pass `--oauth-timeout <ms>` (or export `MCPORTER_OAUTH_TIMEOUT_MS`) when you need the CLI to bail out faster while you diagnose stubborn auth flows.
 
 ### Try an MCP without editing config
 

--- a/docs/record-replay.md
+++ b/docs/record-replay.md
@@ -53,6 +53,8 @@ This makes recordings useful as reproducible bug fixtures: a replay either follo
 
 Recordings made against modern servers include the initial `server/discover` probe. Replay matches that probe by method because its negotiation metadata can vary between client versions. Older recordings whose first request is `initialize` are automatically replayed in legacy negotiation mode.
 
+Programmatic runtimes replay elicitation with the caller-supplied handler. When a recording accepted an elicitation request, provide a handler that makes the same decision so the strict retry request matches the capture; without one, headless replay keeps the normal non-interactive decline behavior.
+
 ## Safe regression fixtures
 
 Recording is not automatic redaction. Before using a capture as a regression

--- a/docs/record-replay.md
+++ b/docs/record-replay.md
@@ -43,7 +43,7 @@ Each line is one JSON-RPC envelope with an added `_meta` object:
 {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"..."}]},"_meta":{"dir":"recv","server":"linear","ts":"2026-05-16T12:00:00.100Z"}}
 ```
 
-`_meta.dir` is `send`, `recv`, or `lifecycle`. Replay strips `_meta` before delivering a response. Lifecycle events such as transport start and close are recorded for diagnostics but ignored during replay.
+`_meta.dir` is `send`, `recv`, or `lifecycle`. Replay strips `_meta` before delivering responses and inbound notifications, preserving notification order around the recorded response. Lifecycle events such as transport start and close are recorded for diagnostics but ignored during replay.
 
 ## Deterministic matching
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -198,9 +198,7 @@ class McpRuntime implements Runtime {
       oauthTimeoutMs: options.oauthTimeoutMs ?? OAUTH_CODE_TIMEOUT_MS,
       recordPath,
       replayPath,
-      elicitationHandler: replayPath
-        ? defaultResponder.handler
-        : (options.elicitationHandler ?? defaultResponder.handler),
+      elicitationHandler: options.elicitationHandler ?? defaultResponder.handler,
     });
   }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -379,7 +379,10 @@ class McpRuntime implements Runtime {
         specTypeSchemas.ListResourcesResult
       );
       const resources = [...response.resources];
+      const seenCursors = new Set<string>();
       for (let page = 1; page < MAX_RESOURCE_LIST_PAGES && response.nextCursor; page += 1) {
+        if (seenCursors.has(response.nextCursor)) break;
+        seenCursors.add(response.nextCursor);
         response = await client.request(
           { method: 'resources/list', params: { ...requestParams, cursor: response.nextCursor } },
           specTypeSchemas.ListResourcesResult

--- a/src/runtime/http-transport.ts
+++ b/src/runtime/http-transport.ts
@@ -1,6 +1,7 @@
 import {
   type Client,
   type FetchLike,
+  SdkErrorCode,
   SdkHttpError,
   SSEClientTransport,
   StreamableHTTPClientTransport,
@@ -32,6 +33,11 @@ interface ResolvedHttpTransportOptions {
 type HttpClientContextAttempt =
   | { context: ClientContext; nextDefinition?: undefined }
   | { context?: undefined; nextDefinition: ServerDefinition };
+
+export interface HttpClientFactory {
+  create(definition: ServerDefinition): Client;
+  createLegacy(definition: ServerDefinition): Client;
+}
 
 function extractTransportStatusCode(error: unknown): number | undefined {
   if (!error || typeof error !== 'object') return undefined;
@@ -123,6 +129,10 @@ function shouldAbortSseFallback(error: unknown): boolean {
   return isOAuthFlowError(error) || error instanceof OAuthTimeoutError;
 }
 
+function isEraNegotiationFailure(error: unknown): boolean {
+  return !!error && typeof error === 'object' && 'code' in error && error.code === SdkErrorCode.EraNegotiationFailed;
+}
+
 function maybePromoteHttpDefinition(
   definition: ServerDefinition,
   logger: Logger,
@@ -148,15 +158,22 @@ async function connectHttpTransport<TTransport extends OAuthCapableTransport>(
 }
 
 export async function createHttpClientContext(
-  client: Client,
   definition: ServerDefinition,
   logger: Logger,
   options: CreateClientContextOptions,
-  wrapRecordTransport: WrapRecordTransport
+  wrapRecordTransport: WrapRecordTransport,
+  clientFactory: HttpClientFactory
 ): Promise<ClientContext> {
   let activeDefinition = definition;
   while (true) {
-    const attempt = await attemptHttpClientContext(client, activeDefinition, logger, options, wrapRecordTransport);
+    const attempt = await attemptHttpClientContext(
+      clientFactory.create(activeDefinition),
+      activeDefinition,
+      logger,
+      options,
+      wrapRecordTransport,
+      clientFactory
+    );
     if (!attempt.nextDefinition) return attempt.context;
     activeDefinition = attempt.nextDefinition;
     options.onDefinitionPromoted?.(activeDefinition);
@@ -168,7 +185,8 @@ async function attemptHttpClientContext(
   activeDefinition: ServerDefinition,
   logger: Logger,
   options: CreateClientContextOptions,
-  wrapRecordTransport: WrapRecordTransport
+  wrapRecordTransport: WrapRecordTransport,
+  clientFactory: HttpClientFactory
 ): Promise<HttpClientContextAttempt> {
   const command = activeDefinition.command;
   if (command.kind !== 'http')
@@ -193,6 +211,10 @@ async function attemptHttpClientContext(
       ),
     };
   } catch (primaryError) {
+    if (isEraNegotiationFailure(primaryError)) {
+      await closeOAuthSession(oauthSession);
+      throw primaryError;
+    }
     if (shouldAbortSseFallback(primaryError)) {
       await closeOAuthSession(oauthSession);
       throw primaryError;
@@ -209,14 +231,15 @@ async function attemptHttpClientContext(
     }
     return {
       context: await connectSseFallbackTransport(
-        client,
+        clientFactory.createLegacy(activeDefinition),
         activeDefinition,
         command,
         transportOptions,
         oauthSession,
         logger,
         options,
-        wrapRecordTransport
+        wrapRecordTransport,
+        clientFactory
       ),
     };
   }
@@ -258,7 +281,8 @@ async function connectSseFallbackTransport(
   oauthSession: OAuthSession | undefined,
   logger: Logger,
   options: CreateClientContextOptions,
-  wrapRecordTransport: WrapRecordTransport
+  wrapRecordTransport: WrapRecordTransport,
+  clientFactory: HttpClientFactory
 ): Promise<ClientContext> {
   try {
     const transport = await connectHttpTransport(
@@ -281,7 +305,7 @@ async function connectSseFallbackTransport(
       const promoted = maybePromoteHttpDefinition(definition, logger, options);
       if (promoted) {
         options.onDefinitionPromoted?.(promoted);
-        return createHttpClientContext(client, promoted, logger, options, wrapRecordTransport);
+        return createHttpClientContext(promoted, logger, options, wrapRecordTransport, clientFactory);
       }
       if (definition.auth) throw sseError;
     }

--- a/src/runtime/record-transport.ts
+++ b/src/runtime/record-transport.ts
@@ -27,14 +27,12 @@ export class RecordTransport implements Transport {
   onclose?: Transport['onclose'];
   onerror?: Transport['onerror'];
   onmessage?: Transport['onmessage'];
-  sessionId?: string;
-  finishAuth?: (authorizationCode: string) => Promise<void>;
+  finishAuth?: (authorizationCode: string, iss?: string) => Promise<void>;
 
   private writes: Promise<void> = Promise.resolve();
   private closeRecorded = false;
 
   constructor(private readonly opts: RecordTransportOptions) {
-    this.sessionId = opts.inner.sessionId;
     // Preserve the SDK's structural stdio detection without making HTTP
     // recordings look stdio-shaped. This keeps probe timeout semantics and
     // still records the in-place server/discover exchange.
@@ -44,10 +42,19 @@ export class RecordTransport implements Transport {
         pid: { get: () => (opts.inner as { pid?: unknown }).pid },
       });
     }
-    const finishAuth = (opts.inner as { finishAuth?: (authorizationCode: string) => Promise<void> }).finishAuth;
+    const finishAuth = (opts.inner as { finishAuth?: (authorizationCode: string, iss?: string) => Promise<void> })
+      .finishAuth;
     if (finishAuth) {
-      this.finishAuth = (authorizationCode) => finishAuth.call(opts.inner, authorizationCode);
+      this.finishAuth = (authorizationCode, iss) => finishAuth.call(opts.inner, authorizationCode, iss);
     }
+  }
+
+  get hasPerRequestStream(): boolean | undefined {
+    return this.opts.inner.hasPerRequestStream;
+  }
+
+  get sessionId(): string | undefined {
+    return this.opts.inner.sessionId;
   }
 
   async start(): Promise<void> {
@@ -59,13 +66,12 @@ export class RecordTransport implements Transport {
     this.opts.inner.onerror = (error) => {
       this.onerror?.(error);
     };
-    this.opts.inner.onmessage = (message) => {
+    this.opts.inner.onmessage = (message, extra) => {
       void this.appendLine(this.withMeta(message, 'recv'));
-      this.onmessage?.(message);
+      this.onmessage?.(message, extra);
     };
     await this.appendLifecycle('start');
     await this.opts.inner.start();
-    this.sessionId = this.opts.inner.sessionId;
   }
 
   async send(message: JSONRPCMessage, options?: TransportSendOptions): Promise<void> {
@@ -81,6 +87,10 @@ export class RecordTransport implements Transport {
 
   setProtocolVersion(version: string): void {
     this.opts.inner.setProtocolVersion?.(version);
+  }
+
+  setSupportedProtocolVersions(versions: string[]): void {
+    this.opts.inner.setSupportedProtocolVersions?.(versions);
   }
 
   private async appendLifecycle(event: 'start' | 'close'): Promise<void> {

--- a/src/runtime/replay-transport.ts
+++ b/src/runtime/replay-transport.ts
@@ -12,7 +12,9 @@ interface ExpectedSend {
   readonly method: string;
   readonly params?: unknown;
   readonly expectsResponse: boolean;
-  readonly response?: JSONRPCMessage;
+  response?: JSONRPCMessage;
+  notificationsBeforeResponse?: JSONRPCMessage[];
+  notificationsAfterResponse?: JSONRPCMessage[];
 }
 
 type JsonRpcRecord = Record<string, unknown>;
@@ -55,7 +57,14 @@ export class ReplayTransport implements Transport {
         adaptInitializeResponse(request.method, expected.response, request.params),
         request.id
       );
-      queueMicrotask(() => this.onmessage?.(response));
+      const inbound = [
+        ...(expected.notificationsBeforeResponse ?? []),
+        response,
+        ...(expected.notificationsAfterResponse ?? []),
+      ];
+      queueMicrotask(() => {
+        for (const inboundMessage of inbound) this.onmessage?.(inboundMessage);
+      });
     }
   }
 
@@ -97,6 +106,8 @@ function readRecordedMessages(recordPath: string): RecordedMessage[] {
 function buildReplayQueue(messages: RecordedMessage[], server: string): ExpectedSend[] {
   const pendingRequests = new Map<string, ExpectedSend>();
   const expected: ExpectedSend[] = [];
+  let bufferedNotifications: JSONRPCMessage[] = [];
+  let lastResponse: ExpectedSend | undefined;
 
   for (const entry of messages) {
     if (entry._meta?.server !== server) {
@@ -123,6 +134,10 @@ function buildReplayQueue(messages: RecordedMessage[], server: string): Expected
       continue;
     }
     if (entry._meta.dir === 'recv') {
+      if (isInboundNotification(clean)) {
+        bufferedNotifications.push(clean);
+        continue;
+      }
       const responseId = responseIdOf(clean);
       if (responseId === undefined) {
         continue;
@@ -130,12 +145,24 @@ function buildReplayQueue(messages: RecordedMessage[], server: string): Expected
       const pending = pendingRequests.get(String(responseId));
       if (pending) {
         pendingRequests.delete(String(responseId));
-        (pending as { response?: JSONRPCMessage }).response = clean;
+        pending.notificationsBeforeResponse = bufferedNotifications;
+        bufferedNotifications = [];
+        pending.response = clean;
+        lastResponse = pending;
       }
     }
   }
 
+  if (lastResponse && bufferedNotifications.length > 0) {
+    lastResponse.notificationsAfterResponse = bufferedNotifications;
+  }
+
   return expected.filter((entry) => !entry.expectsResponse || entry.response);
+}
+
+function isInboundNotification(message: JSONRPCMessage): boolean {
+  const record = message as JsonRpcRecord;
+  return typeof record.method === 'string' && !('id' in record);
 }
 
 function stripMeta(message: RecordedMessage): JSONRPCMessage {

--- a/src/runtime/replay-transport.ts
+++ b/src/runtime/replay-transport.ts
@@ -18,6 +18,7 @@ interface ExpectedSend {
 type JsonRpcRecord = Record<string, unknown>;
 
 export class ReplayTransport implements Transport {
+  readonly hasPerRequestStream = undefined;
   onclose?: Transport['onclose'];
   onerror?: Transport['onerror'];
   onmessage?: Transport['onmessage'];

--- a/src/runtime/transport.ts
+++ b/src/runtime/transport.ts
@@ -98,14 +98,15 @@ function createClient(
 async function createReplayClientContext(
   definition: ServerDefinition,
   replayPath: string,
-  clientInfo: { name: string; version: string }
+  clientInfo: { name: string; version: string },
+  elicitationHandler?: ElicitationHandler
 ): Promise<ClientContext> {
   const transport = new ReplayTransport({ recordPath: replayPath, server: definition.name });
   // Pre-v2 captures start with initialize. Skip a probe those recordings
   // cannot satisfy; captures containing server/discover replay normally.
   const client = createClient(definition, clientInfo, {
     forceLegacy: transport.requiresLegacyNegotiation,
-    elicitationHandler: createNonInteractiveElicitationResponder().handler,
+    elicitationHandler: elicitationHandler ?? createNonInteractiveElicitationResponder().handler,
   });
   await client.connect(transport);
   return { client, transport, definition, oauthSession: undefined };
@@ -163,7 +164,7 @@ export async function createClientContext(
   options: CreateClientContextOptions = {}
 ): Promise<ClientContext> {
   if (options.replayPath && shouldUseModeForServer(definition, process.env.MCPORTER_REPLAY_SERVER)) {
-    return createReplayClientContext(definition, options.replayPath, clientInfo);
+    return createReplayClientContext(definition, options.replayPath, clientInfo, options.elicitationHandler);
   }
   const activeDefinition = await applyCachedAuthIfAvailable(definition, logger, options.allowCachedAuth);
 

--- a/src/runtime/transport.ts
+++ b/src/runtime/transport.ts
@@ -1,4 +1,10 @@
-import { Client, type ClientOptions, type Transport, type VersionNegotiationMode } from '@modelcontextprotocol/client';
+import {
+  Client,
+  type ClientOptions,
+  SdkErrorCode,
+  type Transport,
+  type VersionNegotiationMode,
+} from '@modelcontextprotocol/client';
 import { applyChromeDevtoolsCompat } from '../chrome-devtools-compat.js';
 import { rewriteChromeDevtoolsArgsForRelay } from '../chrome-devtools-relay.js';
 import type { ServerDefinition } from '../config.js';
@@ -51,6 +57,16 @@ function resolveNegotiationMode(definition: ServerDefinition): VersionNegotiatio
     default:
       return 'auto';
   }
+}
+
+function shouldRetryStdioAsLegacy(error: unknown, definition: ServerDefinition): boolean {
+  return (
+    resolveNegotiationMode(definition) === 'auto' &&
+    !!error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    error.code === SdkErrorCode.EraNegotiationFailed
+  );
 }
 
 function createClient(
@@ -146,12 +162,32 @@ export async function createClientContext(
 
   return withEnvOverrides(activeDefinition.env, async () => {
     if (activeDefinition.command.kind === 'stdio') {
-      return createStdioClientContext(
-        createClient(activeDefinition, clientInfo, { stdio: true, elicitationHandler: options.elicitationHandler }),
-        activeDefinition as ServerDefinition & { command: Extract<ServerDefinition['command'], { kind: 'stdio' }> },
-        logger,
-        options
-      );
+      const stdioDefinition = activeDefinition as ServerDefinition & {
+        command: Extract<ServerDefinition['command'], { kind: 'stdio' }>;
+      };
+      try {
+        return await createStdioClientContext(
+          createClient(stdioDefinition, clientInfo, { stdio: true, elicitationHandler: options.elicitationHandler }),
+          stdioDefinition,
+          logger,
+          options
+        );
+      } catch (error) {
+        if (!shouldRetryStdioAsLegacy(error, stdioDefinition)) throw error;
+        logger.info(
+          `Retrying '${stdioDefinition.name}' in legacy mode after its stdio process exited during version negotiation.`
+        );
+        return createStdioClientContext(
+          createClient(stdioDefinition, clientInfo, {
+            stdio: true,
+            forceLegacy: true,
+            elicitationHandler: options.elicitationHandler,
+          }),
+          stdioDefinition,
+          logger,
+          options
+        );
+      }
     }
     const httpClientFactory: HttpClientFactory = {
       create: (httpDefinition) =>

--- a/src/runtime/transport.ts
+++ b/src/runtime/transport.ts
@@ -11,7 +11,7 @@ import {
   type ElicitationHandler,
   registerElicitationHandler,
 } from './elicitation.js';
-import { createHttpClientContext } from './http-transport.js';
+import { createHttpClientContext, type HttpClientFactory } from './http-transport.js';
 import { RecordTransport } from './record-transport.js';
 import { ReplayTransport } from './replay-transport.js';
 import { McporterStdioTransport } from './stdio-transport.js';
@@ -153,12 +153,15 @@ export async function createClientContext(
         options
       );
     }
-    return createHttpClientContext(
-      createClient(activeDefinition, clientInfo, { elicitationHandler: options.elicitationHandler }),
-      activeDefinition,
-      logger,
-      options,
-      wrapRecordTransport
-    );
+    const httpClientFactory: HttpClientFactory = {
+      create: (httpDefinition) =>
+        createClient(httpDefinition, clientInfo, { elicitationHandler: options.elicitationHandler }),
+      createLegacy: (httpDefinition) =>
+        createClient(httpDefinition, clientInfo, {
+          forceLegacy: true,
+          elicitationHandler: options.elicitationHandler,
+        }),
+    };
+    return createHttpClientContext(activeDefinition, logger, options, wrapRecordTransport, httpClientFactory);
   });
 }

--- a/src/runtime/transport.ts
+++ b/src/runtime/transport.ts
@@ -1,6 +1,7 @@
 import {
   Client,
   type ClientOptions,
+  DEFAULT_REQUEST_TIMEOUT_MSEC,
   SdkErrorCode,
   type Transport,
   type VersionNegotiationMode,
@@ -46,7 +47,13 @@ const wrapRecordTransport: WrapRecordTransport = <TTransport extends Transport>(
 };
 
 const LIST_MAX_PAGES = 100;
-const STDIO_PROBE_TIMEOUT_MS = 3_000;
+
+function resolveStdioProbeTimeoutMs(): number {
+  const raw = process.env.MCPORTER_STDIO_PROBE_TIMEOUT_MS;
+  if (!raw || !/^[1-9]\d*$/.test(raw)) return DEFAULT_REQUEST_TIMEOUT_MSEC;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : DEFAULT_REQUEST_TIMEOUT_MSEC;
+}
 
 function resolveNegotiationMode(definition: ServerDefinition): VersionNegotiationMode {
   switch (definition.protocolVersion) {
@@ -80,7 +87,7 @@ function createClient(
     listMaxPages: LIST_MAX_PAGES,
     versionNegotiation: {
       mode,
-      ...(options.stdio && mode !== 'legacy' ? { probe: { timeoutMs: STDIO_PROBE_TIMEOUT_MS } } : {}),
+      ...(options.stdio && mode !== 'legacy' ? { probe: { timeoutMs: resolveStdioProbeTimeoutMs() } } : {}),
     },
   };
   const client = new Client(clientInfo, clientOptions);

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -35,6 +35,13 @@ interface ServedServer {
   readonly definition: ServerDefinition;
 }
 
+interface RuntimeToolDefinition {
+  readonly name: string;
+  readonly description?: string;
+  readonly inputSchema?: unknown;
+  readonly outputSchema?: unknown;
+}
+
 const TOOL_SEPARATOR = '__';
 const DEFAULT_OBJECT_SCHEMA = { type: 'object' } as const;
 export const DEFAULT_SERVE_HTTP_HOST = '127.0.0.1';
@@ -130,26 +137,28 @@ export function createBridgeServer(options: ServeOptions): McpServer {
         : 'MCPorter bridge exposing daemon-managed MCP servers. Tool names are namespaced as server__tool.',
     }
   );
+  const advertisedOutputSchemas = new Map<string, Tool['outputSchema']>();
+  const listRuntimeTools = (serverName: string) =>
+    options.runtime.listTools(serverName, {
+      includeSchema: true,
+      autoAuthorize: true,
+    }) as Promise<RuntimeToolDefinition[]>;
 
   server.server.setRequestHandler('tools/list', async () => {
     const tools: Tool[] = [];
     for (const served of servedServers) {
-      const listed = (await options.runtime.listTools(served.name, {
-        includeSchema: true,
-        autoAuthorize: true,
-      })) as Array<{
-        name: string;
-        description?: string;
-        inputSchema?: unknown;
-        outputSchema?: unknown;
-      }>;
+      const listed = await listRuntimeTools(served.name);
 
       for (const tool of listed) {
+        const name = bare ? tool.name : encodeToolName(served.name, tool.name);
+        const outputSchema = normalizeOutputSchema(tool.outputSchema);
+        if (outputSchema) advertisedOutputSchemas.set(name, outputSchema);
+        else advertisedOutputSchemas.delete(name);
         tools.push({
-          name: bare ? tool.name : encodeToolName(served.name, tool.name),
+          name,
           description: bare ? tool.description : describeTool(served.name, tool.description),
           inputSchema: normalizeInputSchema(tool.inputSchema),
-          outputSchema: normalizeOutputSchema(tool.outputSchema),
+          outputSchema,
         });
       }
     }
@@ -166,7 +175,13 @@ export function createBridgeServer(options: ServeOptions): McpServer {
     const result = await options.runtime.callTool(target.server, target.tool, {
       args: request.params.arguments,
     });
-    return result as CallToolResult;
+    let outputSchema = advertisedOutputSchemas.get(request.params.name);
+    if (!outputSchema) {
+      const definition = (await listRuntimeTools(target.server)).find((tool) => tool.name === target.tool);
+      outputSchema = normalizeOutputSchema(definition?.outputSchema);
+      if (outputSchema) advertisedOutputSchemas.set(request.params.name, outputSchema);
+    }
+    return server.server.projectCallToolResult(result as CallToolResult, outputSchema);
   });
 
   return server;
@@ -292,15 +307,14 @@ function normalizeInputSchema(schema: unknown): Tool['inputSchema'] {
 }
 
 function normalizeOutputSchema(schema: unknown): Tool['outputSchema'] {
-  if (isObjectSchema(schema)) {
-    return schema;
-  }
-  return undefined;
+  return isSchemaRecord(schema) ? (schema as Tool['outputSchema']) : undefined;
 }
 
 function isObjectSchema(schema: unknown): schema is Tool['inputSchema'] {
-  if (!schema || typeof schema !== 'object') {
-    return false;
-  }
+  if (!isSchemaRecord(schema)) return false;
   return (schema as { type?: unknown }).type === 'object';
+}
+
+function isSchemaRecord(schema: unknown): schema is Record<string, unknown> {
+  return !!schema && typeof schema === 'object' && !Array.isArray(schema);
 }

--- a/tests/record-replay.test.ts
+++ b/tests/record-replay.test.ts
@@ -1,13 +1,19 @@
 import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import type { Transport, TransportSendOptions } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { describe, expect, it, vi } from 'vitest';
+import type { ServerDefinition } from '../src/config.js';
 import { createRuntime, MCPORTER_VERSION } from '../src/runtime.js';
 import { RecordTransport, type RecordedMessage } from '../src/runtime/record-transport.js';
 import { ReplayTransport } from '../src/runtime/replay-transport.js';
+
+const TSX_CLI = createRequire(import.meta.url).resolve('tsx/cli');
+const MODERN_FIXTURE = fileURLToPath(new URL('./servers/modern/server.ts', import.meta.url));
 
 class StubTransport implements Transport {
   onclose?: Transport['onclose'];
@@ -450,6 +456,66 @@ describe('record/replay transports', () => {
       await fs.rm(tempHome, { recursive: true, force: true });
     }
   });
+
+  it('replays an accepted modern MRTR recording with the caller elicitation handler', async () => {
+    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-replay-mrtr-'));
+    const session = 'accepted-mrtr';
+    const definition: ServerDefinition = {
+      name: 'modern',
+      command: {
+        kind: 'stdio',
+        command: process.execPath,
+        args: [TSX_CLI, MODERN_FIXTURE, '--stdio'],
+        cwd: process.cwd(),
+      },
+      source: { kind: 'local', path: MODERN_FIXTURE },
+    };
+    const acceptingHandler = vi.fn(async () => ({
+      action: 'accept' as const,
+      content: { confirm: true },
+    }));
+    const originalEnvironment = {
+      HOME: process.env.HOME,
+      USERPROFILE: process.env.USERPROFILE,
+      MCPORTER_RECORD: process.env.MCPORTER_RECORD,
+      MCPORTER_REPLAY: process.env.MCPORTER_REPLAY,
+    };
+
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+    process.env.MCPORTER_RECORD = session;
+    delete process.env.MCPORTER_REPLAY;
+
+    try {
+      const recordingRuntime = await createRuntime({ servers: [definition], elicitationHandler: acceptingHandler });
+      try {
+        await expect(
+          recordingRuntime.callTool('modern', 'confirm_delete', { args: { target: 'recorded-item' } })
+        ).resolves.toMatchObject({ content: [{ type: 'text', text: 'deleted recorded-item' }] });
+      } finally {
+        await recordingRuntime.close();
+      }
+
+      delete process.env.MCPORTER_RECORD;
+      process.env.MCPORTER_REPLAY = session;
+      const replayRuntime = await createRuntime({ servers: [definition], elicitationHandler: acceptingHandler });
+      try {
+        await expect(
+          replayRuntime.callTool('modern', 'confirm_delete', { args: { target: 'recorded-item' } })
+        ).resolves.toMatchObject({ content: [{ type: 'text', text: 'deleted recorded-item' }] });
+      } finally {
+        await replayRuntime.close();
+      }
+
+      expect(acceptingHandler).toHaveBeenCalledTimes(2);
+    } finally {
+      for (const [key, value] of Object.entries(originalEnvironment)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      await fs.rm(tempHome, { recursive: true, force: true });
+    }
+  }, 15_000);
 
   it('keeps multi-server streams separated by metadata server', async () => {
     const recordPath = await writeRecording([

--- a/tests/record-replay.test.ts
+++ b/tests/record-replay.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import type { Transport, TransportSendOptions } from '@modelcontextprotocol/sdk/shared/transport.js';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createRuntime, MCPORTER_VERSION } from '../src/runtime.js';
 import { RecordTransport, type RecordedMessage } from '../src/runtime/record-transport.js';
 import { ReplayTransport } from '../src/runtime/replay-transport.js';
@@ -116,6 +116,53 @@ describe('record/replay transports', () => {
     const stdioShaped = transport as RecordTransport & { pid: number; stderr: EventTarget };
     expect(stdioShaped.pid).toBe(12345);
     expect(stdioShaped.stderr).toBe(stderr);
+  });
+
+  it('mirrors the wrapped v2 transport capability surface and message metadata', async () => {
+    const inner = new StubTransport() as StubTransport & {
+      hasPerRequestStream: boolean;
+      sessionId?: string;
+      setProtocolVersion: (version: string) => void;
+      setSupportedProtocolVersions: (versions: string[]) => void;
+      finishAuth: (authorizationCode: string, iss?: string) => Promise<void>;
+    };
+    inner.hasPerRequestStream = true;
+    inner.sessionId = 'initial-session';
+    inner.setProtocolVersion = vi.fn();
+    inner.setSupportedProtocolVersions = vi.fn();
+    inner.finishAuth = vi.fn(async () => {});
+    const transport = new RecordTransport({
+      inner,
+      recordPath: await tempRecordingPath(),
+      server: 'linear',
+    });
+    const receivedExtra: unknown[] = [];
+    transport.onmessage = (_message, extra) => receivedExtra.push(extra);
+
+    expect(transport.hasPerRequestStream).toBe(true);
+    expect(transport.sessionId).toBe('initial-session');
+    inner.sessionId = 'updated-session';
+    expect(transport.sessionId).toBe('updated-session');
+
+    await transport.start();
+    const extra = { request: new Request('https://example.test/mcp') };
+    inner.onmessage?.({ jsonrpc: '2.0', method: 'notifications/test' } as JSONRPCMessage, extra as never);
+    transport.setProtocolVersion('2026-07-28');
+    transport.setSupportedProtocolVersions(['2026-07-28', '2025-11-25']);
+    await transport.finishAuth?.('authorization-code', 'https://issuer.example');
+
+    expect(receivedExtra).toEqual([extra]);
+    expect(inner.setProtocolVersion).toHaveBeenCalledWith('2026-07-28');
+    expect(inner.setSupportedProtocolVersions).toHaveBeenCalledWith(['2026-07-28', '2025-11-25']);
+    expect(inner.finishAuth).toHaveBeenCalledWith('authorization-code', 'https://issuer.example');
+    await transport.close();
+  });
+
+  it('keeps replay transport on a shared in-memory channel', async () => {
+    const recordPath = await writeRecording([]);
+    const transport = new ReplayTransport({ recordPath, server: 'linear' });
+
+    expect(transport.hasPerRequestStream).toBeUndefined();
   });
 
   it('replays matching requests by method and params using the active request id', async () => {

--- a/tests/record-replay.test.ts
+++ b/tests/record-replay.test.ts
@@ -198,6 +198,42 @@ describe('record/replay transports', () => {
     ]);
   });
 
+  it('replays inbound progress notifications before the recorded response', async () => {
+    const recordPath = await writeRecording([
+      send('linear', 1, 'tools/call', { name: 'long_task', arguments: {} }),
+      recvNotification('linear', 'notifications/progress', {
+        progressToken: 'task-1',
+        progress: 1,
+        total: 1,
+      }),
+      recv('linear', 1, { content: [{ type: 'text', text: 'done' }] }),
+    ]);
+    const transport = new ReplayTransport({ recordPath, server: 'linear' });
+    const received: JSONRPCMessage[] = [];
+    transport.onmessage = (message) => received.push(message);
+
+    await transport.send({
+      jsonrpc: '2.0',
+      id: 99,
+      method: 'tools/call',
+      params: { name: 'long_task', arguments: {} },
+    });
+    await Promise.resolve();
+
+    expect(received).toEqual([
+      {
+        jsonrpc: '2.0',
+        method: 'notifications/progress',
+        params: { progressToken: 'task-1', progress: 1, total: 1 },
+      },
+      {
+        jsonrpc: '2.0',
+        id: 99,
+        result: { content: [{ type: 'text', text: 'done' }] },
+      },
+    ]);
+  });
+
   it('detects legacy recordings and matches server/discover probes by method', async () => {
     const legacyPath = await writeRecording([
       send('linear', 1, 'initialize', { protocolVersion: '2025-11-25' }),
@@ -618,5 +654,14 @@ function notification(server: string, method: string): RecordedMessage {
     jsonrpc: '2.0',
     method,
     _meta: { dir: 'send', server, ts: '2026-05-16T00:00:00.000Z' },
+  } as RecordedMessage;
+}
+
+function recvNotification(server: string, method: string, params: unknown): RecordedMessage {
+  return {
+    jsonrpc: '2.0',
+    method,
+    params,
+    _meta: { dir: 'recv', server, ts: '2026-05-16T00:00:00.000Z' },
   } as RecordedMessage;
 }

--- a/tests/runtime-compose.test.ts
+++ b/tests/runtime-compose.test.ts
@@ -441,6 +441,40 @@ describe('mcporter composability', () => {
     }
   });
 
+  it('stops automatic resource pagination when the server repeats a cursor', async () => {
+    mocks.listResourcesMock
+      .mockResolvedValueOnce({
+        resources: [{ uri: 'memo://one', name: 'One' }],
+        nextCursor: 'same-page',
+      })
+      .mockResolvedValueOnce({
+        resources: [{ uri: 'memo://two', name: 'Two' }],
+        nextCursor: 'same-page',
+      });
+    const runtime = await createRuntime({
+      servers: [
+        {
+          name: 'resources',
+          command: { kind: 'http' as const, url: new URL('https://resources.example.com/mcp') },
+        },
+      ],
+    });
+
+    try {
+      await expect(runtime.listResources('resources')).resolves.toEqual({
+        resources: [
+          { uri: 'memo://one', name: 'One' },
+          { uri: 'memo://two', name: 'Two' },
+        ],
+        nextCursor: 'same-page',
+      });
+      expect(mocks.listResourcesMock).toHaveBeenCalledTimes(2);
+      expect(mocks.listResourcesMock).toHaveBeenNthCalledWith(2, { cursor: 'same-page' });
+    } finally {
+      await runtime.close();
+    }
+  });
+
   it('uses disableOAuth on cold callTool/listTools helper connections', async () => {
     const runtime = await createRuntime({
       servers: [

--- a/tests/runtime-transport.test.ts
+++ b/tests/runtime-transport.test.ts
@@ -115,7 +115,7 @@ describe('createClientContext (HTTP)', () => {
     expect(negotiation?.probe).toBeUndefined();
   });
 
-  it('caps in-place stdio probes at three seconds', async () => {
+  it('uses the SDK default timeout for in-place stdio probes', async () => {
     const definition: ServerDefinition = {
       name: 'stdio-auto',
       command: { kind: 'stdio', command: 'node', args: ['unused.js'], cwd: '/tmp' },
@@ -128,8 +128,29 @@ describe('createClientContext (HTTP)', () => {
         _versionNegotiation?: { probe?: { timeoutMs?: number } };
       }
     )._versionNegotiation;
-    expect(negotiation?.probe?.timeoutMs).toBe(3000);
+    expect(negotiation?.probe?.timeoutMs).toBe(60_000);
     expect(context.transport).toBeInstanceOf(StdioClientTransport);
+  });
+
+  it('accepts an environment override for the stdio probe timeout', async () => {
+    const definition: ServerDefinition = {
+      name: 'stdio-auto',
+      command: { kind: 'stdio', command: 'node', args: ['unused.js'], cwd: '/tmp' },
+    };
+    vi.stubEnv('MCPORTER_STDIO_PROBE_TIMEOUT_MS', '12345');
+    vi.spyOn(Client.prototype, 'connect').mockResolvedValueOnce(undefined);
+
+    try {
+      const context = await createClientContext(definition, logger, clientInfo);
+      const negotiation = (
+        context.client as unknown as {
+          _versionNegotiation?: { probe?: { timeoutMs?: number } };
+        }
+      )._versionNegotiation;
+      expect(negotiation?.probe?.timeoutMs).toBe(12_345);
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it('falls back to SSE when primary connect fails', async () => {
@@ -706,4 +727,26 @@ describe('createClientContext (stdio negotiation)', () => {
       await context.client.close();
     }
   });
+
+  it('waits longer than three seconds for a slow modern discovery response', async () => {
+    const baseDefinition = stdioDefinition('modern');
+    if (baseDefinition.command.kind !== 'stdio') throw new Error('Expected stdio fixture definition.');
+    const definition: ServerDefinition = {
+      ...baseDefinition,
+      command: {
+        ...baseDefinition.command,
+        args: [...(baseDefinition.command.args ?? []), '3200'],
+      },
+    };
+
+    const context = await createClientContext(definition, logger, clientInfo);
+    try {
+      expect(context.client.getProtocolEra()).toBe('modern');
+      await expect(context.client.listTools()).resolves.toMatchObject({
+        tools: [expect.objectContaining({ name: 'modern_ping' })],
+      });
+    } finally {
+      await context.client.close();
+    }
+  }, 10_000);
 });

--- a/tests/runtime-transport.test.ts
+++ b/tests/runtime-transport.test.ts
@@ -7,6 +7,7 @@ import {
   StreamableHTTPClientTransport,
 } from '@modelcontextprotocol/client';
 import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
+import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -54,6 +55,7 @@ import {
 } from './helpers/runtime-test-helpers.js';
 
 const logger = createLogger();
+const STDIO_NEGOTIATION_FIXTURE = fileURLToPath(new URL('./servers/stdio-negotiation.mjs', import.meta.url));
 
 beforeEach(() => {
   resetLogger(logger);
@@ -665,5 +667,43 @@ describe('createClientContext (HTTP)', () => {
     expect(createOAuthSessionSpy).toHaveBeenCalledTimes(1);
     expect(clientConnect).toHaveBeenCalledTimes(1);
     await context.transport.close();
+  });
+});
+
+describe('createClientContext (stdio negotiation)', () => {
+  function stdioDefinition(mode: 'legacy-exit' | 'modern'): ServerDefinition {
+    return {
+      name: `stdio-${mode}`,
+      command: {
+        kind: 'stdio',
+        command: process.execPath,
+        args: [STDIO_NEGOTIATION_FIXTURE, mode],
+        cwd: process.cwd(),
+      },
+    };
+  }
+
+  it('retries with a fresh legacy process when the discovery probe kills the first process', async () => {
+    const context = await createClientContext(stdioDefinition('legacy-exit'), logger, clientInfo);
+    try {
+      expect(context.client.getProtocolEra()).toBe('legacy');
+      await expect(context.client.listTools()).resolves.toMatchObject({
+        tools: [expect.objectContaining({ name: 'legacy_ping' })],
+      });
+    } finally {
+      await context.client.close();
+    }
+  });
+
+  it('keeps a modern stdio server on the discovered modern connection', async () => {
+    const context = await createClientContext(stdioDefinition('modern'), logger, clientInfo);
+    try {
+      expect(context.client.getProtocolEra()).toBe('modern');
+      await expect(context.client.listTools()).resolves.toMatchObject({
+        tools: [expect.objectContaining({ name: 'modern_ping' })],
+      });
+    } finally {
+      await context.client.close();
+    }
   });
 });

--- a/tests/runtime-transport.test.ts
+++ b/tests/runtime-transport.test.ts
@@ -1,5 +1,6 @@
 import {
   Client,
+  SdkError,
   SdkErrorCode,
   SdkHttpError,
   SSEClientTransport,
@@ -146,6 +147,66 @@ describe('createClientContext (HTTP)', () => {
 
     expect(context.transport).toBeInstanceOf(SSEClientTransport);
     expect(clientConnect).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses a newly created legacy client for the SSE fallback', async () => {
+    const definition = stubHttpDefinition('https://example.com/legacy-sse');
+    const connectedClients: Client[] = [];
+
+    mocks.connectWithAuth
+      .mockImplementationOnce(async (client, transport) => {
+        connectedClients.push(client);
+        expect(transport).toBeInstanceOf(StreamableHTTPClientTransport);
+        throw new Error('streamable transport unavailable');
+      })
+      .mockImplementationOnce(async (client, transport) => {
+        connectedClients.push(client);
+        expect(transport).toBeInstanceOf(SSEClientTransport);
+        return transport;
+      });
+
+    const context = await createClientContext(definition, logger, clientInfo, { maxOAuthAttempts: 0 });
+    const fallbackNegotiation = (connectedClients[1] as unknown as { _versionNegotiation?: { mode?: unknown } })
+      ._versionNegotiation;
+
+    expect(connectedClients).toHaveLength(2);
+    expect(connectedClients[1]).not.toBe(connectedClients[0]);
+    expect(fallbackNegotiation?.mode).toBe('legacy');
+    expect(context.client).toBe(connectedClients[1]);
+  });
+
+  it.each([
+    [
+      'SdkError',
+      new SdkError(
+        SdkErrorCode.EraNegotiationFailed,
+        'Version negotiation failed: the server did not offer pinned protocol version 2026-07-28 (no fallback in pin mode)'
+      ),
+    ],
+    [
+      'SdkHttpError',
+      new SdkHttpError(
+        SdkErrorCode.EraNegotiationFailed,
+        'Version negotiation failed: the server did not offer pinned protocol version 2026-07-28 (no fallback in pin mode)',
+        { status: 400 }
+      ),
+    ],
+  ])('preserves pinned negotiation failures from %s without trying SSE', async (_kind, negotiationError) => {
+    const definition: ServerDefinition = {
+      ...stubHttpDefinition('https://example.com/legacy-only'),
+      protocolVersion: '2026-07-28',
+    };
+    const clientConnect = vi
+      .spyOn(Client.prototype, 'connect')
+      .mockRejectedValueOnce(negotiationError)
+      .mockRejectedValueOnce(new Error('SSE error: Non-200 status code (405)'));
+
+    await expect(createClientContext(definition, logger, clientInfo, { maxOAuthAttempts: 0 })).rejects.toBe(
+      negotiationError
+    );
+
+    expect(clientConnect).toHaveBeenCalledTimes(1);
+    expect(clientConnect.mock.calls[0]?.[0]).toBeInstanceOf(StreamableHTTPClientTransport);
   });
 
   it('does not fall back to SSE after the OAuth flow fails', async () => {

--- a/tests/serve.test.ts
+++ b/tests/serve.test.ts
@@ -145,6 +145,63 @@ describe('mcporter serve bridge', () => {
     await bridge.close();
   });
 
+  it('preserves and projects primitive tool outputs for legacy clients', async () => {
+    const runtime = primitiveOutputRuntime();
+    const bridge = createBridgeServer({ runtime, definitions, servers: ['alpha'] });
+    const client = new Client({ name: 'legacy-primitive-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    try {
+      await Promise.all([bridge.connect(serverTransport), client.connect(clientTransport)]);
+      await expect(client.listTools()).resolves.toMatchObject({
+        tools: [
+          {
+            name: 'alpha__primitive',
+            outputSchema: {
+              type: 'object',
+              properties: { result: { type: 'number' } },
+              required: ['result'],
+            },
+          },
+        ],
+      });
+      await expect(client.callTool({ name: 'alpha__primitive', arguments: {} })).resolves.toMatchObject({
+        content: [{ type: 'text', text: '42' }],
+        structuredContent: { result: 42 },
+      });
+    } finally {
+      await client.close().catch(() => {});
+      await bridge.close().catch(() => {});
+    }
+  });
+
+  it('preserves and projects primitive tool outputs for modern clients', async () => {
+    const runtime = primitiveOutputRuntime();
+    const httpServer = await serveHttp({ runtime, definitions, servers: ['alpha'], port: 0 });
+    const address = httpServer.address();
+    if (!address || typeof address !== 'object') throw new Error('Expected a listening HTTP server.');
+    const client = new V2Client(
+      { name: 'modern-primitive-client', version: '1.0.0' },
+      { versionNegotiation: { mode: { pin: '2026-07-28' } } }
+    );
+    const transport = new V2StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${address.port}/mcp`));
+
+    try {
+      await client.connect(transport);
+      expect(client.getProtocolEra()).toBe('modern');
+      await expect(client.listTools()).resolves.toMatchObject({
+        tools: [{ name: 'alpha__primitive', outputSchema: { type: 'number' } }],
+      });
+      await expect(client.callTool({ name: 'alpha__primitive', arguments: {} })).resolves.toMatchObject({
+        content: [{ type: 'text', text: '42' }],
+        structuredContent: 42,
+      });
+    } finally {
+      await client.close().catch(() => {});
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    }
+  });
+
   it('routes bridged keep-alive tool traffic through the daemon runtime wrapper', async () => {
     const baseRuntime = {
       listServers: () => definitions.map((definition) => definition.name),
@@ -441,3 +498,16 @@ describe('mcporter serve bridge', () => {
     }
   });
 });
+
+function primitiveOutputRuntime() {
+  return {
+    listTools: vi.fn().mockResolvedValue([
+      {
+        name: 'primitive',
+        inputSchema: { type: 'object', properties: {} },
+        outputSchema: { type: 'number' },
+      },
+    ]),
+    callTool: vi.fn().mockResolvedValue({ structuredContent: 42 }),
+  };
+}

--- a/tests/servers/stdio-negotiation.mjs
+++ b/tests/servers/stdio-negotiation.mjs
@@ -1,6 +1,7 @@
 import { createInterface } from 'node:readline';
 
 const mode = process.argv[2];
+const discoveryDelayMs = Number(process.argv[3] ?? 0);
 if (mode !== 'legacy-exit' && mode !== 'modern') {
   throw new Error("Expected negotiation fixture mode 'legacy-exit' or 'modern'.");
 }
@@ -16,10 +17,12 @@ input.on('line', (line) => {
     if (mode === 'legacy-exit') {
       process.exit(0);
     }
-    respond(message.id, {
-      supportedVersions: ['2026-07-28'],
-      capabilities: { tools: {} },
-    });
+    setTimeout(() => {
+      respond(message.id, {
+        supportedVersions: ['2026-07-28'],
+        capabilities: { tools: {} },
+      });
+    }, discoveryDelayMs);
     return;
   }
 

--- a/tests/servers/stdio-negotiation.mjs
+++ b/tests/servers/stdio-negotiation.mjs
@@ -1,0 +1,46 @@
+import { createInterface } from 'node:readline';
+
+const mode = process.argv[2];
+if (mode !== 'legacy-exit' && mode !== 'modern') {
+  throw new Error("Expected negotiation fixture mode 'legacy-exit' or 'modern'.");
+}
+
+function respond(id, result) {
+  process.stdout.write(`${JSON.stringify({ jsonrpc: '2.0', id, result })}\n`);
+}
+
+const input = createInterface({ input: process.stdin });
+input.on('line', (line) => {
+  const message = JSON.parse(line);
+  if (message.method === 'server/discover') {
+    if (mode === 'legacy-exit') {
+      process.exit(0);
+    }
+    respond(message.id, {
+      supportedVersions: ['2026-07-28'],
+      capabilities: { tools: {} },
+    });
+    return;
+  }
+
+  if (message.method === 'initialize') {
+    respond(message.id, {
+      protocolVersion: message.params.protocolVersion,
+      capabilities: { tools: {} },
+      serverInfo: { name: 'stdio-negotiation-fixture', version: '1.0.0' },
+    });
+    return;
+  }
+
+  if (message.method === 'tools/list') {
+    respond(message.id, {
+      ...(mode === 'modern' ? { resultType: 'complete', ttlMs: 0, cacheScope: 'private' } : {}),
+      tools: [
+        {
+          name: mode === 'modern' ? 'modern_ping' : 'legacy_ping',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ],
+    });
+  }
+});


### PR DESCRIPTION
Fixes eight protocol/transport defects found by an adversarial review of the MCP 2.0 series (#254–#258) and by testing against 30+ public MCP servers in the wild. Every fix ships with a regression test that fails before and passes after.

**Negotiation**
- **SSE fallback no longer inherits modern negotiation.** SSE is a legacy-era transport, but the fallback reused the modern-negotiating client. Consequences: auto mode re-sent `server/discover` on the SSE attempt (breaking legacy SSE-only servers), and pin mode masked the SDK's accurate error behind a meaningless `SSE error: Non-200 status code (405)`. Verified in the wild: pinning `2026-07-28` at Context7 now reports *"the server did not offer pinned protocol version 2026-07-28 via server/discover (no fallback in pin mode)"*. The fallback site now builds a legacy client via a small `HttpClientFactory` seam rather than threading flags.
- **stdio auto-negotiation can now recover from strict legacy servers.** Because `McporterStdioTransport` subclasses the SDK transport, the probe runs in-place on the only process; a legacy server that exits on any pre-`initialize` request left nothing to fall back to. Auto mode now retries once with a fresh legacy process. Modern servers keep the single-spawn fast path.
- **stdio probe timeout raised from 3s to the SDK default (60s)**, configurable via `MCPORTER_STDIO_PROBE_TIMEOUT_MS`. The old 3s budget included process cold-start and misclassified slow modern servers as legacy.

**Record/replay**
- `RecordTransport` now mirrors the wrapped transport's full capability surface. It was dropping `hasPerRequestStream`, so the v2 client never attached `requestSignal` and on timeout emitted the *removed* `notifications/cancelled` while the HTTP request kept running.
- Replay honors the caller's elicitation handler instead of force-installing a decline responder, so recordings whose MRTR round was accepted can actually replay.
- Recorded inbound notifications (progress, logging, list-changed) are re-emitted in order instead of being silently dropped.

**Bridge & pagination**
- The dual-era bridge preserves non-object output schemas and projects results per era via the SDK's own `projectCallToolResult`. Previously `outputSchema: {type:"number"}` was dropped on both eras and a v1 client's call failed `-32602 expected record, received number`.
- Resource pagination detects a repeated/non-advancing cursor instead of issuing 100 requests and appending the same page 99 times.

Proof: `pnpm check` clean; 955 passed / 3 skipped; autoreview clean (0.96). Re-verified against live servers across all four eras (2025-03-26 → 2026-07-28) with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
