### PR TITLE
fix(cli): survive duplicate tool names from a server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### CLI
 
+- Keep listing and calling usable when a server advertises the same tool name twice or two names that map to one proxy method.
 - Follow `resources/list` cursors automatically so paginated MCP resources are returned in full.
 - Raise Node's untouched Happy-Eyeballs connect-attempt timeout from 250 ms to 1500 ms while preserving explicit user overrides.
 - Keep replay recordings usable across MCP protocol-version and mcporter client-version changes.

--- a/src/cli/generate/tools.ts
+++ b/src/cli/generate/tools.ts
@@ -52,23 +52,32 @@ export function buildToolMetadata(tool: ServerToolInfo): ToolMetadata {
 
 export function buildToolMetadataList(
   tools: ServerToolInfo[],
-  options: { readonly sort?: boolean } = {}
+  options: { readonly sort?: boolean; readonly onCollision?: 'throw' | 'skip' } = {}
 ): ToolMetadata[] {
   const result = tools.map((tool) => buildToolMetadata(tool));
   if (options.sort !== false) {
     result.sort((left, right) => left.tool.name.localeCompare(right.tool.name));
   }
   const methods = new Map<string, string>();
+  const kept: ToolMetadata[] = [];
   for (const entry of result) {
     const previous = methods.get(entry.methodName);
-    if (previous) {
-      throw new Error(
-        `Generated proxy method collision '${entry.methodName}' for tools '${previous}' and '${entry.tool.name}'.`
-      );
+    if (previous !== undefined) {
+      // Servers in the wild re-advertise the same tool name; that is not a real
+      // conflict, so drop the repeat regardless of collision policy. Distinct
+      // names mapping to one method is ambiguous and still fails codegen.
+      if (previous === entry.tool.name) continue;
+      if (options.onCollision !== 'skip') {
+        throw new Error(
+          `Generated proxy method collision '${entry.methodName}' for tools '${previous}' and '${entry.tool.name}'.`
+        );
+      }
+      continue;
     }
     methods.set(entry.methodName, entry.tool.name);
+    kept.push(entry);
   }
-  return result;
+  return kept;
 }
 
 export function buildEmbeddedSchemaMap(tools: ToolMetadata[]): Record<string, unknown> {

--- a/src/cli/tool-cache.ts
+++ b/src/cli/tool-cache.ts
@@ -43,7 +43,9 @@ export async function loadToolMetadata(
   };
   const promise = runtime
     .listTools(serverName, listOptions)
-    .then((tools) => buildToolMetadataList(tools, { sort: false }))
+    // Listing and calling must survive a server whose tool names collide; only
+    // codegen needs to reject the ambiguity outright.
+    .then((tools) => buildToolMetadataList(tools, { sort: false, onCollision: 'skip' }))
     .catch((error) => {
       cache?.delete(key);
       throw error;

--- a/tests/generate-cli-helpers.test.ts
+++ b/tests/generate-cli-helpers.test.ts
@@ -55,6 +55,29 @@ describe('generate helpers', () => {
     ).toThrow(/Generated proxy method collision 'someTool'/);
   });
 
+  it('drops a repeated tool name instead of failing', () => {
+    // Observed in the wild: a server advertised the same tool twice, which made
+    // listing that server impossible.
+    const metadata = buildToolMetadataList([
+      { name: 'get_notifications', inputSchema: undefined, outputSchema: undefined },
+      { name: 'get_notifications', inputSchema: undefined, outputSchema: undefined },
+    ]);
+    expect(metadata).toHaveLength(1);
+    expect(metadata[0]?.tool.name).toBe('get_notifications');
+  });
+
+  it('skips ambiguous collisions when the caller opts out of throwing', () => {
+    const metadata = buildToolMetadataList(
+      [
+        { name: 'some-tool', inputSchema: undefined, outputSchema: undefined },
+        { name: 'some_tool', inputSchema: undefined, outputSchema: undefined },
+      ],
+      { onCollision: 'skip', sort: false }
+    );
+    expect(metadata).toHaveLength(1);
+    expect(metadata[0]?.tool.name).toBe('some-tool');
+  });
+
   it('extracts detailed option information', () => {
     const options = extractOptions(sampleTool);
     const first = options.find((option) => option.property === 'firstValue');


### PR DESCRIPTION
Found by testing mcporter against public MCP servers in the wild.

`https://game.spacemolt.com/mcp` advertises 213 tools and re-advertises one name (`get_notifications`) twice. mcporter threw `Generated proxy method collision`, which made `mcporter list` and every `call` against that server fail outright — a third-party server bug taking the client down with it.

A repeated *identical* name carries no ambiguity, so it is now dropped wherever it appears. Two *distinct* names mapping to one proxy method is genuinely ambiguous, so `generate-cli` still rejects it (emitting a CLI with a silently-shadowed method would be worse), while the read-only listing/calling path skips the duplicate rather than failing.

The server now lists all 212 distinct tools.

Proof: `pnpm check` clean; 957 passed / 3 skipped; verified against the live server before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
