### PR TITLE
test(live): cross-era conformance against public MCP servers

### DIFF
--- a/tests/live/README.md
+++ b/tests/live/README.md
@@ -1,0 +1,34 @@
+# Live MCP tests
+
+Opt-in tests that hit real public MCP servers. They never run in the default gate because they
+depend on third-party uptime and network access.
+
+```bash
+MCP_LIVE_TESTS=1 pnpm exec vitest run tests/live
+```
+
+## Protocol-era conformance
+
+`protocol-era-conformance.test.ts` pins one representative public server per protocol revision
+mcporter must interoperate with, so a regression in version negotiation shows up against real
+implementations rather than only against the committed fixtures in `tests/servers/`.
+
+Survey of reachable no-auth public servers, 2026-08-02 (31 of 32 probed endpoints connected):
+
+| Revision   | Era    | Servers observed                                                                                                                                                      |
+| ---------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-07-28 | modern | Hugging Face, Cloudflare Docs/Blog/Demo Day, inference.sh, javadocs.dev                                                                                               |
+| 2025-11-25 | legacy | Context7, DeepWiki, Exa, Firecrawl, Clerk, CoinGecko, Twilio, Bun, Storyblok, Vue, Browserbase, Chargebee, Coinbase, Jina, Mapbox docs, svelte-llm, Cloudflare Agents |
+| 2025-06-18 | legacy | Microsoft Learn, Astro Docs, Svelte, Chakra UI, Oxylabs                                                                                                               |
+| 2025-03-26 | legacy | GitMCP, AWS Knowledge                                                                                                                                                 |
+
+Notes for whoever refreshes this list:
+
+- `javadocs.dev` is the most useful modern target: it advertises multiple supported versions and
+  returns a nonzero `ttlMs` with `cacheScope: "public"`, unlike the other modern servers which
+  return `ttlMs: 0` / `private`.
+- Hugging Face and Cloudflare expose `serverInfo` only under the `_meta`
+  `io.modelcontextprotocol/serverInfo` key; javadocs.dev also duplicates it top-level. A client
+  reading only the top-level field sees nothing on the former two.
+- Endpoints move. If a target starts failing, re-probe before assuming an mcporter regression —
+  several vendors have added auth to previously open endpoints.

--- a/tests/live/protocol-era-conformance.test.ts
+++ b/tests/live/protocol-era-conformance.test.ts
@@ -1,0 +1,100 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+// Cross-era conformance against real public MCP servers. Opt-in: these hit the
+// network and depend on third-party uptime, so they never run in the default gate.
+// Run with: MCP_LIVE_TESTS=1 pnpm exec vitest run tests/live/protocol-era-conformance.test.ts
+
+const LIVE_FLAG = process.env.MCP_LIVE_TESTS === '1';
+const execFileAsync = promisify(execFile);
+
+interface EraTarget {
+  readonly name: string;
+  readonly url: string;
+  /** Protocol revision this server negotiated when the matrix was last refreshed. */
+  readonly expectedVersion: string;
+  readonly expectedEra: 'modern' | 'legacy';
+}
+
+// One representative server per protocol revision mcporter must interoperate with.
+// Verified reachable 2026-08-02; see tests/live/README.md for the full survey.
+const ERA_TARGETS: readonly EraTarget[] = [
+  { name: 'javadocs', url: 'https://www.javadocs.dev/mcp', expectedVersion: '2026-07-28', expectedEra: 'modern' },
+  { name: 'hf', url: 'https://huggingface.co/mcp', expectedVersion: '2026-07-28', expectedEra: 'modern' },
+  { name: 'cfdocs', url: 'https://docs.mcp.cloudflare.com/mcp', expectedVersion: '2026-07-28', expectedEra: 'modern' },
+  { name: 'context7', url: 'https://mcp.context7.com/mcp', expectedVersion: '2025-11-25', expectedEra: 'legacy' },
+  { name: 'mslearn', url: 'https://learn.microsoft.com/api/mcp', expectedVersion: '2025-06-18', expectedEra: 'legacy' },
+  { name: 'gitmcp', url: 'https://gitmcp.io/docs', expectedVersion: '2025-03-26', expectedEra: 'legacy' },
+];
+
+let configPath: string;
+let tempDir: string;
+
+async function runCli(args: readonly string[]): Promise<string> {
+  const result = await execFileAsync('node', ['dist/cli.js', ...args], {
+    env: { ...process.env, MCPORTER_CONFIG: configPath },
+    timeout: 60_000,
+  }).catch((error: unknown) => {
+    const failure = error as { stdout?: string; stderr?: string };
+    return { stdout: failure.stdout ?? '', stderr: failure.stderr ?? '' };
+  });
+  return `${result.stdout}\n${result.stderr}`;
+}
+
+beforeAll(async () => {
+  if (!LIVE_FLAG) return;
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-live-era-'));
+  configPath = path.join(tempDir, 'mcporter.json');
+  const mcpServers: Record<string, { url: string; protocolVersion?: string }> = {};
+  for (const target of ERA_TARGETS) mcpServers[target.name] = { url: target.url };
+  // Override coverage: pinning and forcing legacy must both be honored.
+  mcpServers['hf-pinned'] = { url: 'https://huggingface.co/mcp', protocolVersion: '2026-07-28' };
+  mcpServers['hf-legacy'] = { url: 'https://huggingface.co/mcp', protocolVersion: 'legacy' };
+  await fs.writeFile(configPath, JSON.stringify({ mcpServers }, null, 2));
+});
+
+afterAll(async () => {
+  if (tempDir) await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+describe.skipIf(!LIVE_FLAG)('live protocol-era conformance', () => {
+  for (const target of ERA_TARGETS) {
+    it(`negotiates ${target.expectedVersion} with ${target.name}`, async () => {
+      const output = await runCli(['list', target.name, '--verbose']);
+      // A third-party outage should read as a skip-worthy failure, not a silent pass.
+      expect(output).toContain('Protocol:');
+      expect(output).toContain(`${target.expectedVersion} (${target.expectedEra})`);
+    }, 90_000);
+  }
+
+  it('honors an explicit modern pin', async () => {
+    const output = await runCli(['list', 'hf-pinned', '--verbose']);
+    expect(output).toContain('2026-07-28 (modern)');
+  }, 90_000);
+
+  it('honors an explicit legacy override against a modern server', async () => {
+    const output = await runCli(['list', 'hf-legacy', '--verbose']);
+    expect(output).toContain('(legacy)');
+    expect(output).not.toContain('2026-07-28');
+  }, 90_000);
+
+  it('calls a tool on a modern (2026-07-28) server', async () => {
+    const output = await runCli([
+      'call',
+      'javadocs.get_latest_version',
+      'groupId=com.google.guava',
+      'artifactId=guava',
+    ]);
+    // Guava publishes -jre/-android qualified versions; assert the shape, not a pinned value.
+    expect(output).toMatch(/\d+\.\d+/);
+  }, 90_000);
+
+  it('calls a tool on a legacy server', async () => {
+    const output = await runCli(['call', 'context7.resolve-library-id', 'query=testing', 'libraryName=vitest']);
+    expect(output.toLowerCase()).toContain('vitest');
+  }, 90_000);
+});


### PR DESCRIPTION
Turns the ad-hoc wild-server validation done during the MCP 2.0 work into repeatable infrastructure.

`tests/live/protocol-era-conformance.test.ts` pins one representative public server per protocol revision mcporter must interoperate with, plus pin/legacy override coverage and a real tool call on each era. Opt-in like the existing live tests (`MCP_LIVE_TESTS=1`), so the default gate stays network-free.

Covered revisions, all verified reachable 2026-08-02: **2026-07-28** (javadocs.dev, Hugging Face, Cloudflare Docs), **2025-11-25** (Context7), **2025-06-18** (Microsoft Learn), **2025-03-26** (GitMCP).

`tests/live/README.md` records the wider survey — 31 of 32 probed public endpoints connected — and two interop notes worth keeping: javadocs.dev is the only modern server observed returning a nonzero `ttlMs` with `cacheScope: "public"`, and Hugging Face and Cloudflare expose `serverInfo` *only* under the `_meta` `io.modelcontextprotocol/serverInfo` key, so a client reading the top-level field sees nothing.

This exists because the committed fixtures can only test what we thought to implement; these tests catch drift against real implementations.

Proof: 10 tests passing against live servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
