### PR TITLE
release: 0.13.0 with MCP 2.0 headline, artifacts coverage, and compile-target normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,40 +1,45 @@
 # mcporter Changelog
 
-## [0.12.5] - Unreleased
+## [0.13.0] - 2026-08-02
+
+### MCP 2.0
+
+- Support MCP protocol revision `2026-07-28` — the stateless core, `server/discover` negotiation, per-request identity, and multi round-trip requests — while continuing to speak every legacy revision from `2024-10-07` to `2025-11-25`.
+- Negotiate each server automatically: probe with `server/discover`, fall back to the legacy `initialize` handshake, and keep stdio probing in-process instead of spawning a second server.
+- Add per-server `protocolVersion` / `protocol_version` overrides for `auto`, `legacy`, and pinned `2026-07-28` connections, surfaced by `mcporter list <server> --verbose`.
+- Bridge both generations at once through `mcporter serve`: a single endpoint answers 2026-07-28 and 2025-era clients, preserving primitive tool output schemas and projecting structured results per era.
+- Support interactive form and URL elicitation in terminals across legacy and 2026-07-28 multi-round-trip servers, with immediate declines and a terminal hint in headless or daemon-managed contexts.
+- Attribute elicitation prompts and public handler callbacks to their requesting server, and neutralize terminal control sequences in server-supplied prompt text.
+- Migrate the runtime and serve bridges to the MCP TypeScript SDK v2 client and server packages, keeping SDK v1 only as a legacy test fixture.
 
 ### CLI
 
-- Keep listing and calling usable when a server advertises the same tool name twice or two names that map to one proxy method.
-- Follow `resources/list` cursors automatically so paginated MCP resources are returned in full.
-- Raise Node's untouched Happy-Eyeballs connect-attempt timeout from 250 ms to 1500 ms while preserving explicit user overrides, including quoted `NODE_OPTIONS` values.
-- Keep replay recordings usable across MCP protocol-version and mcporter client-version changes.
-- Preserve protocol-version pins and supported snake_case config aliases when generating or regenerating standalone CLIs.
-- Support MCP protocol revision 2026-07-28 with automatic modern/legacy negotiation while preserving legacy server compatibility.
-- Support interactive form and URL elicitation in terminals across legacy and 2026-07-28 multi-round-trip servers, with immediate declines and a terminal hint in headless or daemon-managed contexts.
-- Attribute elicitation prompts and public handler callbacks to their requesting server, and neutralize terminal control sequences in server-supplied prompt text.
-- Close bridge subscription handlers before the HTTP listener so active `subscriptions/listen` streams cannot deadlock shutdown.
-- Restore bounded stdio process-tree teardown with pre-close PID capture, SIGTERM/SIGKILL escalation, and explicit stream destruction.
-- Cancel in-flight connection handshakes during `runtime.close()` instead of waiting for the full negotiation timeout.
-- Canonicalize decoded bridge server paths so percent-encoded aliases share one handler instead of allocating permanent duplicates.
 - Keep legacy SSE fallback on legacy negotiation and preserve pinned modern-version negotiation errors instead of masking them with a secondary SSE failure.
 - Recover legacy stdio servers that exit on modern discovery by retrying initialization once with a fresh legacy-mode process.
 - Use the SDK's 60-second stdio discovery timeout for slow-starting modern servers, configurable with `MCPORTER_STDIO_PROBE_TIMEOUT_MS`.
+- Keep listing and calling usable when a server advertises the same tool name twice or two names that map to one proxy method.
+- Follow `resources/list` cursors automatically so paginated MCP resources are returned in full, and stop when a server repeats its cursor instead of churning duplicate pages.
+- Raise Node's untouched Happy-Eyeballs connect-attempt timeout from 250 ms to 1500 ms while preserving explicit user overrides, including quoted `NODE_OPTIONS` values.
+- Restore bounded stdio process-tree teardown with pre-close PID capture, SIGTERM/SIGKILL escalation, and explicit stream destruction.
+- Cancel in-flight connection handshakes during `runtime.close()` instead of waiting for the full negotiation timeout.
+- Close bridge subscription handlers before the HTTP listener so active `subscriptions/listen` streams cannot deadlock shutdown.
+- Canonicalize decoded bridge server paths so percent-encoded aliases share one handler instead of allocating permanent duplicates.
+- Preserve protocol-version pins and supported snake_case config aliases when generating or regenerating standalone CLIs.
+- Normalize `--compile` bundle targets consistently instead of returning a platform-native path only when an extension was supplied.
+- Resolve bundled dependency roots for packages whose `package.json` is hidden behind export maps, avoiding an unnecessary npm fallback.
+
+### Record and replay
+
+- Keep replay recordings usable across MCP protocol-version and mcporter client-version changes.
 - Preserve transport capabilities and request metadata through recording wrappers so modern HTTP cancellation remains stream-based.
 - Replay accepted modern elicitation rounds with the caller's handler instead of unconditionally declining them.
-- Preserve primitive tool output schemas through `mcporter serve` and project structured results correctly for both legacy and modern clients.
-- Stop resource pagination when a server repeats its cursor, returning the bounded partial result without duplicate-page churn.
 - Re-emit recorded progress, logging, and list-change notifications during replay in their recorded order relative to responses.
-
-### Config
-
-- Add per-server `protocolVersion` / `protocol_version` overrides for `auto`, `legacy`, and pinned `2026-07-28` connections.
-- Add per-server `oauthClientMetadataUrl` / `oauth_client_metadata_url` configuration for Client ID Metadata Documents, with SDK-managed DCR fallback.
 
 ### OAuth
 
-- Validate RFC 9207 authorization-response issuers before redeeming callback codes, with server-specific mismatch errors.
+- Validate RFC 9207 authorization-response issuers before redeeming callback codes, with server-specific mismatch errors, and preserve that validation while OAuth traffic is wrapped in recording mode.
 - Bind persisted tokens and client registrations to their authorization-server issuer across interactive and silent refresh flows, discarding mismatches before credentials are transmitted and stamping successful refreshes.
-- Preserve RFC 9207 authorization-response issuer validation while OAuth traffic is wrapped in recording mode.
+- Add per-server `oauthClientMetadataUrl` / `oauth_client_metadata_url` configuration for Client ID Metadata Documents, with SDK-managed DCR fallback.
 - Reject invalid Client ID Metadata Document configuration before binding the loopback OAuth callback listener.
 - Stop reflecting authorization-server callback errors into executable HTML or terminal-facing error messages.
 - Validate imported and persisted OAuth credential shapes so malformed issuer stamps trigger reauthorization instead of runtime crashes.
@@ -43,14 +48,16 @@
 
 - Export connection metadata and the named option/result types reachable through the package-root API.
 
+### Testing
+
+- Add committed MCP 2025-11-25 and 2026-07-28 fixture servers with end-to-end CLI and bridge coverage over stdio and Streamable HTTP.
+- Add an opt-in live conformance suite covering four protocol revisions against public servers, scheduled weekly rather than gating pull requests.
+- Enforce coverage thresholds in CI, publishing the summary and report from the Linux job.
+- Stop the test suite writing into the developer's real `~/.mcporter` by isolating `HOME` and every XDG root.
+
 ### Docs
 
 - Rewrite the README around a verified quick start and move protocol and daemon details into focused guides.
-
-### Tooling / Dependencies
-
-- Migrate mcporter runtime and serve bridges to the MCP TypeScript SDK v2 client/server packages while retaining SDK v1 as a legacy test fixture.
-- Add committed MCP 2025-11-25 and 2026-07-28 fixture servers with end-to-end CLI and bridge coverage over stdio and Streamable HTTP.
 
 ## [0.12.4] - 2026-08-02
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcporter",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "description": "TypeScript runtime and CLI for connecting to configured Model Context Protocol servers.",
   "keywords": [
     "cli",

--- a/src/cli/generate/artifacts.ts
+++ b/src/cli/generate/artifacts.ts
@@ -349,15 +349,22 @@ function formatMcporterInstallSpec(installSpec: string): string {
 }
 
 function resolveDependencyDirectory(specifier: (typeof BUNDLED_DEPENDENCIES)[number]): string | undefined {
+  if (specifier === 'mcporter') {
+    return packageRoot;
+  }
   try {
-    if (specifier === 'mcporter') {
-      return packageRoot;
+    const entryPath = localRequire.resolve(specifier);
+    let candidate = path.dirname(entryPath);
+    while (candidate !== path.dirname(candidate)) {
+      if (fsSync.existsSync(path.join(candidate, 'package.json'))) {
+        return candidate;
+      }
+      candidate = path.dirname(candidate);
     }
-    const pkgPath = localRequire.resolve(path.join(specifier, 'package.json'));
-    return path.dirname(pkgPath);
   } catch {
     return undefined;
   }
+  return undefined;
 }
 
 async function linkOrCopyDependency(sourceDir: string, targetDir: string): Promise<void> {
@@ -396,3 +403,21 @@ function resolveUniquePath(directory: string, baseName: string): string {
   }
   return attempt;
 }
+
+// Kept off the package export map: these hooks let tests drive platform-specific
+// filesystem and subprocess failures that cannot be induced portably through the CLI.
+export const artifactsTestHooks = {
+  buildEsmRequireBanner,
+  createLocalDependencyAliasPlugin,
+  ensureBundlerDeps,
+  findMissingBundlerDeps,
+  formatMcporterInstallSpec,
+  installPublishedBundlerDeps,
+  isExpectedNodeBuiltinWarning,
+  linkOrCopyDependency,
+  outputFormatForTarget,
+  resolveDependencyDirectory,
+  resolveLocalDependency,
+  resolveUniquePath,
+  sanitizeFileName,
+};

--- a/src/cli/generate/artifacts.ts
+++ b/src/cli/generate/artifacts.ts
@@ -197,7 +197,11 @@ export function resolveBundleTarget({
   }
   if (typeof compile === 'string') {
     const ext = path.extname(compile);
-    const base = ext ? path.join(path.dirname(compile), path.basename(compile, ext)) : compile;
+    // Normalize both arms: rebuilding through path.join only when an extension was
+    // present used to return a platform-native path for `dist/custom.bin` and the
+    // caller's verbatim string for `dist/custom`, so the same flag produced two
+    // separator styles on Windows.
+    const base = path.join(path.dirname(compile), path.basename(compile, ext));
     return `${base}.js`;
   }
   if (compile) {

--- a/tests/cli-generate-artifacts-rolldown-unavailable.test.ts
+++ b/tests/cli-generate-artifacts-rolldown-unavailable.test.ts
@@ -1,0 +1,58 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => {
+  vi.doUnmock('rolldown');
+  vi.resetModules();
+});
+
+describe('unavailable Rolldown', () => {
+  it('adds an actionable message to module loading errors', async () => {
+    vi.doMock('rolldown', () => {
+      throw new Error('fixture module load failure');
+    });
+    const { bundleOutput } = await import('../src/cli/generate/artifacts.js');
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-rolldown-unavailable-'));
+    try {
+      await expect(
+        bundleOutput({
+          sourcePath: path.join(tempDir, 'entry.ts'),
+          targetPath: path.join(tempDir, 'bundle.js'),
+          runtimeKind: 'node',
+          minify: false,
+          bundler: 'rolldown',
+        })
+      ).rejects.toThrow(
+        'Rolldown bundling is unavailable in this build of mcporter; rerun with --bundler bun or install mcporter via npm'
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('wraps non-Error module loading failures', async () => {
+    vi.doMock('rolldown', () => {
+      throw 'fixture string failure';
+    });
+    const { bundleOutput } = await import('../src/cli/generate/artifacts.js');
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-rolldown-unavailable-'));
+    try {
+      await expect(
+        bundleOutput({
+          sourcePath: path.join(tempDir, 'entry.ts'),
+          targetPath: path.join(tempDir, 'bundle.js'),
+          runtimeKind: 'bun',
+          minify: false,
+          bundler: 'rolldown',
+        })
+      ).rejects.toMatchObject({
+        message: expect.stringContaining('Rolldown bundling is unavailable in this build of mcporter'),
+        cause: 'fixture string failure',
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli-generate-artifacts.test.ts
+++ b/tests/cli-generate-artifacts.test.ts
@@ -461,14 +461,16 @@ describe('resolveBundleTarget', () => {
     expect(resolveBundleTarget({ bundle: 'dist/custom.js', compile: 'dist/custom', outputPath: 'source.ts' })).toBe(
       'dist/custom.js'
     );
-    // A --compile target WITH an extension is rebuilt through path.join, so it
-    // picks up the platform separator; one WITHOUT an extension is passed through
-    // untouched and keeps whatever separator the caller wrote. The two therefore
-    // differ on Windows.
-    expect(resolveBundleTarget({ compile: 'dist/custom.bin', outputPath: 'source.ts' })).toBe(
-      `${path.join('dist', 'custom')}.js`
-    );
-    expect(resolveBundleTarget({ compile: 'dist/custom', outputPath: 'source.ts' })).toBe('dist/custom.js');
+    // Both --compile forms must agree, with or without a supplied extension. The
+    // arms used to diverge only on Windows (path.join there yields a backslash
+    // while the extensionless arm returned the caller's string verbatim), so this
+    // invariant is trivially true on POSIX and is really enforced by Windows CI.
+    const distCustomJs = `${path.join('dist', 'custom')}.js`;
+    const withExtension = resolveBundleTarget({ compile: 'dist/custom.bin', outputPath: 'source.ts' });
+    const withoutExtension = resolveBundleTarget({ compile: 'dist/custom', outputPath: 'source.ts' });
+    expect(withExtension).toBe(distCustomJs);
+    expect(withoutExtension).toBe(distCustomJs);
+    expect(withoutExtension).toBe(withExtension);
     expect(resolveBundleTarget({ compile: true, outputPath: 'dist/source.ts' })).toMatch(
       /tmp[/\\]mcporter-cli-bundles[/\\]source-\d+\.bundle\.js$/
     );

--- a/tests/cli-generate-artifacts.test.ts
+++ b/tests/cli-generate-artifacts.test.ts
@@ -2,11 +2,34 @@ import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { bundleOutput, computeCompileTarget, resolveBundleTarget } from '../src/cli/generate/artifacts.js';
+import { MCPORTER_VERSION } from '../src/version.js';
+import {
+  artifactsTestHooks,
+  bundleOutput,
+  compileBundleWithBun,
+  computeCompileTarget,
+  resolveBundleTarget,
+} from '../src/cli/generate/artifacts.js';
 
 const TMP_PREFIX = path.join(os.tmpdir(), 'mcporter-artifacts-test-');
+const FAKE_BUN_PATH = fileURLToPath(new URL('./fixtures/fake-bun.mjs', import.meta.url));
+const FAKE_NPM_PATH = fileURLToPath(new URL('./fixtures/fake-npm.mjs', import.meta.url));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+async function readInvocationLog(logPath: string): Promise<Array<{ args: string[]; cwd: string }>> {
+  const contents = await fsPromises.readFile(logPath, 'utf8');
+  return contents
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line) as { args: string[]; cwd: string });
+}
 
 describe('bundleOutput', () => {
   it('resolves mcporter dependencies even without local node_modules', async () => {
@@ -27,6 +50,379 @@ describe('bundleOutput', () => {
     const stats = await fsPromises.stat(result);
     expect(stats.isFile()).toBe(true);
     await fsPromises.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('writes ESM output with the Node require banner', async () => {
+    const tempDir = await fsPromises.mkdtemp(TMP_PREFIX);
+    try {
+      const entryPath = path.join(tempDir, 'entry.ts');
+      await fsPromises.writeFile(entryPath, 'console.log("esm fixture");\n', 'utf8');
+
+      const result = await bundleOutput({
+        sourcePath: entryPath,
+        targetPath: path.join(tempDir, 'bundle.mjs'),
+        runtimeKind: 'node',
+        minify: true,
+        bundler: 'rolldown',
+      });
+
+      const contents = await fsPromises.readFile(result, 'utf8');
+      expect(contents).toContain('from"node:module"');
+      expect(contents).toContain('import.meta.url');
+      expect(contents).toContain('esm fixture');
+    } finally {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe.skipIf(process.platform === 'win32')('Bun artifact generation', () => {
+  beforeAll(async () => {
+    await fsPromises.chmod(FAKE_BUN_PATH, 0o755);
+  });
+
+  it.each([
+    { runtimeKind: 'node' as const, minify: false },
+    { runtimeKind: 'bun' as const, minify: true },
+  ])('bundles for $runtimeKind with minify=$minify', async ({ runtimeKind, minify }) => {
+    const tempDir = await fsPromises.mkdtemp(TMP_PREFIX);
+    const logPath = path.join(tempDir, 'bun.log');
+    vi.stubEnv('BUN_BIN', FAKE_BUN_PATH);
+    vi.stubEnv('FAKE_BUN_LOG', logPath);
+    try {
+      const entryPath = path.join(tempDir, 'entry.ts');
+      const targetPath = path.join(tempDir, 'nested', 'bundle.js');
+      await fsPromises.writeFile(entryPath, 'console.log("bun fixture");\n', 'utf8');
+
+      const result = await bundleOutput({
+        sourcePath: entryPath,
+        targetPath,
+        runtimeKind,
+        minify,
+        bundler: 'bun',
+      });
+
+      expect(result).toBe(path.resolve(targetPath));
+      expect(await fsPromises.readFile(result, 'utf8')).toContain('fake bun bundle');
+      expect((await fsPromises.stat(result)).mode & 0o111).not.toBe(0);
+      const invocations = await readInvocationLog(logPath);
+      expect(invocations[0]?.args).toEqual(['--version']);
+      const build = invocations.find((invocation) => invocation.args[0] === 'build');
+      expect(build?.args).toEqual([
+        'build',
+        expect.stringMatching(/[/\\]bundle-[^/\\]+[/\\]entry\.ts$/),
+        '--outfile',
+        path.resolve(targetPath),
+        '--target',
+        runtimeKind,
+        ...(minify ? ['--minify'] : []),
+      ]);
+      expect(build?.cwd).toMatch(/[/\\]bundle-[^/\\]+$/);
+      await expect(fsPromises.access(build?.cwd ?? '')).rejects.toThrow();
+    } finally {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('removes the staging directory when Bun bundling fails', async () => {
+    const tempDir = await fsPromises.mkdtemp(TMP_PREFIX);
+    const logPath = path.join(tempDir, 'bun.log');
+    vi.stubEnv('BUN_BIN', FAKE_BUN_PATH);
+    vi.stubEnv('FAKE_BUN_LOG', logPath);
+    vi.stubEnv('FAKE_BUN_FAIL', '1');
+    try {
+      const entryPath = path.join(tempDir, 'entry.ts');
+      await fsPromises.writeFile(entryPath, 'console.log("failure fixture");\n', 'utf8');
+
+      await expect(
+        bundleOutput({
+          sourcePath: entryPath,
+          targetPath: path.join(tempDir, 'bundle.js'),
+          runtimeKind: 'node',
+          minify: false,
+          bundler: 'bun',
+        })
+      ).rejects.toThrow('Command failed');
+
+      const build = (await readInvocationLog(logPath)).find((invocation) => invocation.args[0] === 'build');
+      expect(build).toBeDefined();
+      await expect(fsPromises.access(build?.cwd ?? '')).rejects.toThrow();
+    } finally {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('compiles a bundle and marks the result executable', async () => {
+    const tempDir = await fsPromises.mkdtemp(TMP_PREFIX);
+    const logPath = path.join(tempDir, 'bun.log');
+    vi.stubEnv('BUN_BIN', FAKE_BUN_PATH);
+    vi.stubEnv('FAKE_BUN_LOG', logPath);
+    try {
+      const bundlePath = path.join(tempDir, 'bundle.js');
+      const outputPath = path.join(tempDir, 'compiled-cli');
+      await fsPromises.writeFile(bundlePath, 'console.log("compile fixture");\n', 'utf8');
+
+      await compileBundleWithBun(bundlePath, outputPath);
+
+      expect(await fsPromises.readFile(outputPath, 'utf8')).toContain('fake compiled bun artifact');
+      expect((await fsPromises.stat(outputPath)).mode & 0o111).not.toBe(0);
+      const build = (await readInvocationLog(logPath)).find((invocation) => invocation.args[0] === 'build');
+      expect(build?.args).toEqual(['build', bundlePath, '--compile', '--outfile', outputPath]);
+    } finally {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('surfaces Bun compilation failures without creating an artifact', async () => {
+    const tempDir = await fsPromises.mkdtemp(TMP_PREFIX);
+    vi.stubEnv('BUN_BIN', FAKE_BUN_PATH);
+    vi.stubEnv('FAKE_BUN_FAIL', '1');
+    try {
+      const bundlePath = path.join(tempDir, 'bundle.js');
+      const outputPath = path.join(tempDir, 'compiled-cli');
+      await fsPromises.writeFile(bundlePath, 'console.log("compile fixture");\n', 'utf8');
+
+      await expect(compileBundleWithBun(bundlePath, outputPath)).rejects.toThrow('Command failed');
+      await expect(fsPromises.access(outputPath)).rejects.toThrow();
+    } finally {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('artifact implementation behavior', () => {
+  it('selects output formats from explicit extensions before runtime defaults', () => {
+    expect(artifactsTestHooks.outputFormatForTarget('bundle.mjs', 'node')).toBe('esm');
+    expect(artifactsTestHooks.outputFormatForTarget('bundle.cjs', 'bun')).toBe('cjs');
+    expect(artifactsTestHooks.outputFormatForTarget('bundle.js', 'bun')).toBe('esm');
+    expect(artifactsTestHooks.outputFormatForTarget('bundle.js', 'node')).toBe('cjs');
+    expect(artifactsTestHooks.buildEsmRequireBanner()).toContain('__mcporterCreateRequire(import.meta.url)');
+  });
+
+  it('recognizes only unresolved Node builtin warnings', () => {
+    expect(
+      artifactsTestHooks.isExpectedNodeBuiltinWarning({
+        code: 'UNRESOLVED_IMPORT',
+        message: 'Could not resolve "node:fs"',
+      })
+    ).toBe(true);
+    expect(
+      artifactsTestHooks.isExpectedNodeBuiltinWarning({
+        code: 'UNRESOLVED_IMPORT',
+        message: "Could not resolve 'left-pad'",
+      })
+    ).toBe(false);
+    expect(artifactsTestHooks.isExpectedNodeBuiltinWarning({ code: 'OTHER', message: 'node:fs' })).toBe(false);
+    expect(artifactsTestHooks.isExpectedNodeBuiltinWarning({})).toBe(false);
+  });
+
+  it('resolves local dependencies and aliases exact package specifiers', async () => {
+    const commanderPath = artifactsTestHooks.resolveLocalDependency('commander');
+    expect(commanderPath).toBeDefined();
+    expect(artifactsTestHooks.resolveLocalDependency('definitely-not-an-installed-package')).toBeUndefined();
+    const plugin = artifactsTestHooks.createLocalDependencyAliasPlugin(['commander']) as
+      | { name: string; resolveId: (source: string) => string | null }
+      | undefined;
+    expect(plugin?.name).toBe('mcporter-local-deps');
+    expect(plugin?.resolveId('commander')).toBe(commanderPath);
+    expect(plugin?.resolveId('commander/subpath')).toBeNull();
+    expect(artifactsTestHooks.createLocalDependencyAliasPlugin([])).toBeUndefined();
+  });
+
+  it('falls back cleanly when optional package metadata cannot be used', () => {
+    const originalReadFileSync = fs.readFileSync;
+    const readSpy = vi.spyOn(fs, 'readFileSync').mockImplementation((filePath, options) => {
+      if (String(filePath).endsWith(path.join('jsonc-parser', 'package.json'))) {
+        return '{}';
+      }
+      return originalReadFileSync(filePath, options as never);
+    });
+    expect(artifactsTestHooks.resolveLocalDependency('jsonc-parser')).toBeDefined();
+    readSpy.mockRestore();
+
+    const originalExistsSync = fs.existsSync;
+    vi.spyOn(fs, 'existsSync').mockImplementation((filePath) => {
+      if (String(filePath).includes(`${path.sep}jsonc-parser${path.sep}lib${path.sep}esm${path.sep}`)) {
+        return false;
+      }
+      return originalExistsSync(filePath);
+    });
+    expect(artifactsTestHooks.resolveLocalDependency('jsonc-parser')).toBeDefined();
+  });
+
+  it('finds and stages the generated CLI dependencies', async () => {
+    const tempDir = await fsPromises.mkdtemp(TMP_PREFIX);
+    try {
+      expect(await artifactsTestHooks.findMissingBundlerDeps(tempDir)).toEqual([
+        'commander',
+        'mcporter',
+        'jsonc-parser',
+      ]);
+      await artifactsTestHooks.ensureBundlerDeps(tempDir);
+      expect(await artifactsTestHooks.findMissingBundlerDeps(tempDir)).toEqual([]);
+      for (const dependency of ['commander', 'mcporter', 'jsonc-parser']) {
+        await expect(fsPromises.access(path.join(tempDir, 'node_modules', dependency, 'package.json'))).resolves.toBe(
+          undefined
+        );
+      }
+      expect(artifactsTestHooks.resolveDependencyDirectory('commander')).toBeDefined();
+      expect(path.resolve(artifactsTestHooks.resolveDependencyDirectory('mcporter') ?? '')).toBe(path.resolve('.'));
+      expect(
+        artifactsTestHooks.resolveDependencyDirectory(
+          'definitely-not-installed' as Parameters<typeof artifactsTestHooks.resolveDependencyDirectory>[0]
+        )
+      ).toBeUndefined();
+      expect(
+        artifactsTestHooks.resolveDependencyDirectory(
+          'fs' as Parameters<typeof artifactsTestHooks.resolveDependencyDirectory>[0]
+        )
+      ).toBeUndefined();
+    } finally {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('routes unresolved staged dependencies to the offline install guard', async () => {
+    const tempDir = await fsPromises.mkdtemp(TMP_PREFIX);
+    const originalExistsSync = fs.existsSync;
+    vi.spyOn(fs, 'existsSync').mockImplementation((filePath) => {
+      if (path.basename(String(filePath)) === 'package.json') {
+        return false;
+      }
+      return originalExistsSync(filePath);
+    });
+    vi.stubEnv('MCPORTER_BUNDLER_DEP_PACKAGE', '0.0.0-dev');
+    try {
+      await expect(artifactsTestHooks.ensureBundlerDeps(tempDir)).rejects.toThrow(
+        'Unable to resolve generated-CLI bundler dependencies'
+      );
+    } finally {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('links dependencies and tolerates existing or vanished targets', async () => {
+    const tempDir = await fsPromises.mkdtemp(TMP_PREFIX);
+    try {
+      const sourceDir = path.join(tempDir, 'source');
+      await fsPromises.mkdir(sourceDir);
+      await fsPromises.writeFile(path.join(sourceDir, 'fixture.txt'), 'linked', 'utf8');
+      const linkedTarget = path.join(tempDir, 'linked');
+      await artifactsTestHooks.linkOrCopyDependency(sourceDir, linkedTarget);
+      expect(await fsPromises.readFile(path.join(linkedTarget, 'fixture.txt'), 'utf8')).toBe('linked');
+
+      const existingTarget = path.join(tempDir, 'existing');
+      await fsPromises.mkdir(existingTarget);
+      await expect(artifactsTestHooks.linkOrCopyDependency(sourceDir, existingTarget)).resolves.toBeUndefined();
+      await expect(
+        artifactsTestHooks.linkOrCopyDependency(sourceDir, path.join(tempDir, 'missing-parent', 'target'))
+      ).resolves.toBeUndefined();
+    } finally {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('copies a dependency when directory symlinks are not permitted', async () => {
+    const tempDir = await fsPromises.mkdtemp(TMP_PREFIX);
+    try {
+      const sourceDir = path.join(tempDir, 'source');
+      const targetDir = path.join(tempDir, 'copied');
+      await fsPromises.mkdir(sourceDir);
+      await fsPromises.writeFile(path.join(sourceDir, 'fixture.txt'), 'copied', 'utf8');
+      vi.spyOn(fsPromises, 'symlink').mockRejectedValueOnce(
+        Object.assign(new Error('symlinks forbidden'), { code: 'EPERM' })
+      );
+
+      await artifactsTestHooks.linkOrCopyDependency(sourceDir, targetDir);
+
+      expect(await fsPromises.readFile(path.join(targetDir, 'fixture.txt'), 'utf8')).toBe('copied');
+      expect((await fsPromises.lstat(targetDir)).isSymbolicLink()).toBe(false);
+    } finally {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not hide unexpected dependency-linking errors', async () => {
+    vi.spyOn(fsPromises, 'symlink').mockRejectedValueOnce(Object.assign(new Error('disk failure'), { code: 'EIO' }));
+    await expect(artifactsTestHooks.linkOrCopyDependency('/source', '/target')).rejects.toThrow('disk failure');
+  });
+
+  it('sanitizes generated names and resolves collisions', async () => {
+    const tempDir = await fsPromises.mkdtemp(TMP_PREFIX);
+    try {
+      expect(artifactsTestHooks.sanitizeFileName('  My Fancy CLI!!  ')).toBe('my-fancy-cli');
+      expect(artifactsTestHooks.sanitizeFileName('!!!')).toBe('');
+      await fsPromises.writeFile(path.join(tempDir, 'tool'), '', 'utf8');
+      await fsPromises.writeFile(path.join(tempDir, 'tool-1'), '', 'utf8');
+      expect(artifactsTestHooks.resolveUniquePath(tempDir, 'tool')).toBe(path.join(tempDir, 'tool-2'));
+    } finally {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects dependency installation for unpublished development builds', async () => {
+    const tempDir = await fsPromises.mkdtemp(TMP_PREFIX);
+    vi.stubEnv('MCPORTER_BUNDLER_DEP_PACKAGE', '0.0.0-dev');
+    try {
+      await expect(artifactsTestHooks.installPublishedBundlerDeps(tempDir)).rejects.toThrow(
+        'Unable to resolve generated-CLI bundler dependencies'
+      );
+    } finally {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe.skipIf(process.platform === 'win32')('published dependency installation', () => {
+  async function prepareFakeNpm(tempDir: string): Promise<string> {
+    const binDir = path.join(tempDir, 'bin');
+    const npmPath = path.join(binDir, 'npm');
+    await fsPromises.mkdir(binDir);
+    await fsPromises.copyFile(FAKE_NPM_PATH, npmPath);
+    await fsPromises.chmod(npmPath, 0o755);
+    return binDir;
+  }
+
+  it('runs a no-script npm install for the selected published package', async () => {
+    const tempDir = await fsPromises.mkdtemp(TMP_PREFIX);
+    const logPath = path.join(tempDir, 'npm.log');
+    const binDir = await prepareFakeNpm(tempDir);
+    vi.stubEnv('PATH', `${binDir}${path.delimiter}${process.env.PATH ?? ''}`);
+    vi.stubEnv('FAKE_NPM_LOG', logPath);
+    vi.stubEnv('MCPORTER_BUNDLER_DEP_PACKAGE', 'file:mcporter-fixture.tgz');
+    try {
+      await artifactsTestHooks.installPublishedBundlerDeps(tempDir);
+
+      const manifest = JSON.parse(await fsPromises.readFile(path.join(tempDir, 'package.json'), 'utf8')) as {
+        dependencies: { mcporter: string };
+      };
+      expect(manifest.dependencies.mcporter).toBe('file:mcporter-fixture.tgz');
+      const normalizedTempDir = await fsPromises.realpath(tempDir);
+      expect(await readInvocationLog(logPath)).toEqual([
+        {
+          args: ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--min-release-age=0'],
+          cwd: normalizedTempDir,
+        },
+      ]);
+    } finally {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('adds package context to npm installation failures', async () => {
+    const tempDir = await fsPromises.mkdtemp(TMP_PREFIX);
+    const binDir = await prepareFakeNpm(tempDir);
+    vi.stubEnv('PATH', `${binDir}${path.delimiter}${process.env.PATH ?? ''}`);
+    vi.stubEnv('FAKE_NPM_FAIL', '1');
+    vi.stubEnv('MCPORTER_BUNDLER_DEP_PACKAGE', 'file:mcporter-fixture.tgz');
+    try {
+      await expect(artifactsTestHooks.installPublishedBundlerDeps(tempDir)).rejects.toThrow(
+        'Unable to install mcporter from file:mcporter-fixture.tgz dependencies'
+      );
+      expect(artifactsTestHooks.formatMcporterInstallSpec(MCPORTER_VERSION)).toBe(`mcporter@${MCPORTER_VERSION}`);
+    } finally {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -52,6 +448,10 @@ describe('computeCompileTarget', () => {
 
   it('honors an explicit compile target', () => {
     expect(computeCompileTarget('dist/custom-cli', '/tmp/bundle.js', 'ignored')).toBe('dist/custom-cli');
+  });
+
+  it('uses the generic CLI name when the server name has no filename characters', () => {
+    expect(path.basename(computeCompileTarget(true, '/tmp/bundle.js', '!!!'))).toMatch(/^mcporter-cli(?:-\d+)?$/);
   });
 });
 

--- a/tests/fixtures/fake-bun.mjs
+++ b/tests/fixtures/fake-bun.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const args = process.argv.slice(2);
+const logPath = process.env.FAKE_BUN_LOG;
+if (logPath) {
+  await fs.appendFile(logPath, `${JSON.stringify({ args, cwd: process.cwd() })}\n`, 'utf8');
+}
+
+if (args[0] === '--version') {
+  console.log('1.2.3-fake');
+  process.exit(0);
+}
+
+if (process.env.FAKE_BUN_FAIL === '1') {
+  console.error('fake bun build failure');
+  process.exit(1);
+}
+
+if (args[0] !== 'build') {
+  console.error(`unsupported fake bun command: ${args.join(' ')}`);
+  process.exit(2);
+}
+
+const outfileIndex = args.indexOf('--outfile');
+const outputPath = args[outfileIndex + 1];
+if (outfileIndex === -1 || !outputPath) {
+  console.error('fake bun requires --outfile');
+  process.exit(2);
+}
+
+await fs.mkdir(path.dirname(outputPath), { recursive: true });
+const compiled = args.includes('--compile');
+const content = compiled
+  ? '#!/usr/bin/env node\nconsole.log("fake compiled bun artifact");\n'
+  : '// fake bun bundle\nconsole.log("fake bundled artifact");\n';
+await fs.writeFile(outputPath, content, 'utf8');

--- a/tests/fixtures/fake-npm.mjs
+++ b/tests/fixtures/fake-npm.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+
+const logPath = process.env.FAKE_NPM_LOG;
+if (logPath) {
+  await fs.appendFile(logPath, `${JSON.stringify({ args: process.argv.slice(2), cwd: process.cwd() })}\n`, 'utf8');
+}
+
+if (process.env.FAKE_NPM_FAIL === '1') {
+  console.error('fake npm install failure');
+  process.exit(1);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,14 +34,14 @@ export default defineConfig({
       reporter: ['text-summary', 'json-summary', 'lcov'],
       // A ratchet, not a target. Calibrate against LINUX, where the CI coverage job
       // runs: the prior macOS-to-ubuntu deltas were 0.85/0.50/1.08/0.88 points.
-      // Current macOS coverage is 91.2/84.3/92.7/91.4, projecting to roughly
-      // 90.4/83.8/91.6/90.5 on ubuntu. These thresholds sit about 1 point below
+      // Current macOS coverage is 91.5/84.5/92.7/91.7, projecting to roughly
+      // 90.6/84.0/91.6/90.8 on ubuntu. These thresholds sit about 1 point below
       // that projection; raise them deliberately when coverage climbs.
       thresholds: {
-        statements: 89.4,
-        branches: 82.7,
-        functions: 90.5,
-        lines: 89.5,
+        statements: 89.6,
+        branches: 83.0,
+        functions: 90.6,
+        lines: 89.8,
       },
     },
   },


### PR DESCRIPTION
Closes out the MCP 2.0 work and cuts **0.13.0**.

## Coverage: the last platform-specific blind spot

`src/cli/generate/artifacts.ts` measured 83% on macOS but **48% on ubuntu** — the widest platform split in the repo, and it mattered because the coverage gate runs on ubuntu. The cause was straightforward once found: Bun is installed on the developer machine and absent on the Linux runner, so every Bun bundling and compile path was covered locally and never in CI.

The fix exploits the existing seam — `verifyBunAvailable()` resolves `process.env.BUN_BIN ?? 'bun'`, and all Bun work goes through `execFile(bunBin, …)`. A committed fake `bun` executable now drives version, build, compile, target, minify, failure, and staging-cleanup paths on any platform, with npm routed through a second fake so nothing is fetched.

`artifacts.ts`: **83.1% → 98.9% statements**, 64.0% → 93.2% branches. Repo-wide: 91.2% → **91.5% statements** (84.6% branches), 1,243 → 1,265 tests. Thresholds ratchet to 89.6 / 83.0 / 90.6 / 89.8.

That work also fixed a real bug: dependency-root discovery failed for packages whose `package.json` is hidden behind an export map, triggering an unnecessary npm fallback.

## `--compile` target normalization

`resolveBundleTarget` rebuilt the target through `path.join` only when the caller supplied an extension, so `dist/custom.bin` returned a platform-native path while `dist/custom` returned the caller's string verbatim — the same flag producing two separator styles on Windows. Both arms normalize now.

Worth noting for reviewers: the sole production caller already wraps the result in `path.resolve()`, so **no generated artifact path changes**. The divergence was only observable when calling the helper directly, as the tests did. The test now asserts the two forms agree; that invariant is trivially true on POSIX and is genuinely enforced by Windows CI.

## Release notes

The changelog's flat 32-bullet list is restructured so **MCP 2.0 leads**, followed by CLI, record/replay, OAuth, TypeScript API, testing, and docs. Version bumped to 0.13.0.

Verified: `pnpm check` clean, 1,265 tests passing, coverage gate green, autoreview clean (0.99).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
