### PR TITLE
fix(daemon): make the socket timeout a liveness budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # mcporter Changelog
 
+## [0.13.1] - Unreleased
+
+### Daemon
+
+- Treat the daemon socket timeout as an idle liveness budget refreshed by progress frames, so interactive OAuth can outlive 30 seconds without restarting the daemon and opening a duplicate prompt. (PR #241, thanks @umutkeltek)
+- Keep daemon protocol v1 and v2 interoperable while returning daemon-owned operation timeouts as non-retryable errors. (PR #241, thanks @umutkeltek)
+
 ## [0.13.0] - 2026-08-02
 
 ### MCP 2.0

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -45,6 +45,8 @@ Eligible servers start the daemon automatically when a list or call needs them. 
 
 Daemon calls are non-interactive. If a server requests elicitation, the call is declined with a hint to use an ephemeral terminal call instead. See [protocols and interactive requests](protocols.md).
 
+The local socket timeout is an idle liveness budget rather than a cap on the whole operation. A current daemon emits progress frames while work is in flight, allowing interactive OAuth to run to its own deadline without causing a daemon restart or a duplicate browser prompt. Mixed versions remain compatible: a current client falls back to the previous flat deadline with an older daemon, while a current daemon sends the single-response format expected by older clients unless the caller explicitly opts into progress frames.
+
 ## Expose servers to another MCP client
 
 `mcporter serve` turns the daemon's keep-alive servers back into an MCP server:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -334,7 +334,7 @@ export async function runCli(argv: string[]): Promise<void> {
         return;
       }
       const { handleAuth: importedHandleAuth } = await import('./cli/auth-command.js');
-      await importedHandleAuth(runtime, resolvedArgs);
+      await importedHandleAuth(runtime, resolvedArgs, { oauthTimeoutMs: runtimeOptionsWithPath.oauthTimeoutMs });
       return;
     }
 
@@ -458,7 +458,7 @@ async function invokeAuthCommand(runtimeOptions: RuntimeOptions, args: string[])
   ]);
   const runtime = await createRuntime(runtimeOptions);
   try {
-    await importedHandleAuth(runtime, args);
+    await importedHandleAuth(runtime, args, { oauthTimeoutMs: runtimeOptions.oauthTimeoutMs });
   } finally {
     await runtime.close().catch(() => {});
   }
@@ -647,6 +647,7 @@ function createDaemonOnlyRuntime(daemonClient: import('./daemon/client.js').Daem
         autoAuthorize: options?.autoAuthorize,
         allowCachedAuth: options?.allowCachedAuth,
         disableOAuth: options?.disableOAuth,
+        timeoutMs: options?.timeoutMs,
       })) as Awaited<ReturnType<Runtime['listTools']>>,
     callTool: (server, toolName, options) =>
       daemonClient.callTool({

--- a/src/cli/auth-command.ts
+++ b/src/cli/auth-command.ts
@@ -4,7 +4,7 @@ import type { OAuthAuthorizationRequest, OAuthSessionOptions } from '../oauth.js
 import { analyzeConnectionError } from '../error-classifier.js';
 import { clearOAuthCaches } from '../oauth-persistence.js';
 import type { Runtime } from '../runtime.js';
-import { isOAuthFlowError } from '../runtime/oauth.js';
+import { isOAuthFlowError, resolveOAuthTimeoutFromEnv } from '../runtime/oauth.js';
 import { renderAdhocServerHelpLines } from './adhoc-help.js';
 import type { EphemeralServerSpec } from './adhoc-server.js';
 import { extractEphemeralServerFlags } from './ephemeral-flags.js';
@@ -16,12 +16,17 @@ import { consumeOutputFormat } from './output-format.js';
 
 type BrowserSuppression = 'default' | 'no-browser';
 
+export interface AuthCommandOptions {
+  readonly oauthTimeoutMs?: number;
+}
+
 const TRUE_VALUES = new Set(['1', 'true', 'yes']);
 const FALSE_VALUES = new Set(['0', 'false', 'no']);
 
-export async function handleAuth(runtime: Runtime, args: string[]): Promise<void> {
+export async function handleAuth(runtime: Runtime, args: string[], options: AuthCommandOptions = {}): Promise<void> {
   const browserSuppression = consumeBrowserSuppression(args, process.env);
   const noBrowser = browserSuppression === 'no-browser';
+  const oauthTimeoutMs = options.oauthTimeoutMs ?? resolveOAuthTimeoutFromEnv();
   let authorizationOutputEmitted = false;
   const markAuthorizationOutputEmitted = () => {
     authorizationOutputEmitted = true;
@@ -84,6 +89,7 @@ export async function handleAuth(runtime: Runtime, args: string[]): Promise<void
       const tools = await withInfoLogsSuppressed(noBrowser, () =>
         runtime.listTools(target, {
           autoAuthorize: true,
+          timeoutMs: oauthTimeoutMs,
           ...(noBrowser
             ? {
                 oauthSessionOptions: buildNoBrowserOAuthOptions(format, markAuthorizationOutputEmitted),

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -6,6 +6,12 @@ import { withFileLock } from '../fs-json.js';
 import { isProcessRunning } from '../process-utils.js';
 import { collectConfigLayers, normalizeConfigLayers } from './config-layers.js';
 import { getDaemonMetadataPath, getDaemonSocketPath } from './paths.js';
+import {
+  DAEMON_PROTOCOL_VERSION,
+  DaemonFrameDecoder,
+  isDaemonProgressFrame,
+  resolveProgressInterval,
+} from './protocol.js';
 import { delay } from './request-utils.js';
 import type {
   CallToolParams,
@@ -36,6 +42,7 @@ export interface DaemonPaths {
 
 interface DaemonMetadata {
   readonly pid: number;
+  readonly protocolVersion?: number;
   readonly socketPath: string;
   readonly configPath: string;
   readonly configMtimeMs?: number | null;
@@ -71,7 +78,7 @@ export class DaemonClient {
   }
 
   async listTools(params: ListToolsParams): Promise<unknown> {
-    return this.invoke('listTools', params);
+    return this.invoke('listTools', params, params.timeoutMs);
   }
 
   async listResources(params: ListResourcesParams): Promise<unknown> {
@@ -260,15 +267,19 @@ export class DaemonClient {
   }
 
   private async sendRequest<T>(method: DaemonRequestMethod, params: unknown, timeoutOverrideMs?: number): Promise<T> {
+    const idleTimeoutMs = resolveDaemonTimeout(timeoutOverrideMs);
     const request: DaemonRequest = {
       id: randomUUID(),
       method,
       params,
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
+      progressIntervalMs: resolveProgressInterval(idleTimeoutMs),
     };
     const payload = JSON.stringify(request);
-    const timeoutMs = resolveDaemonTimeout(timeoutOverrideMs);
-    const response = await new Promise<string>((resolve, reject) => {
+    const parsed = await new Promise<DaemonResponse<T>>((resolve, reject) => {
       const socket = net.createConnection(this.socketPath);
+      const decoder = new DaemonFrameDecoder();
+      let response: DaemonResponse<T> | undefined;
       let settled = false;
       const finishReject = (error: Error): void => {
         if (settled) {
@@ -277,23 +288,31 @@ export class DaemonClient {
         settled = true;
         reject(error);
       };
-      const finishResolve = (value: string): void => {
+      const finishResolve = (value: DaemonResponse<T>): void => {
         if (settled) {
           return;
         }
         settled = true;
         resolve(value);
       };
-      socket.setTimeout(timeoutMs, () => {
-        // If the daemon doesn't answer in time we treat it as a transport error, destroy the socket,
-        // and let invoke() restart the daemon so hung keep-alive servers get a fresh start.
-        socket.destroy(
-          Object.assign(new Error('Daemon request timed out.'), {
-            code: 'ETIMEDOUT',
-          })
-        );
+      socket.setTimeout(idleTimeoutMs);
+      socket.on('timeout', () => {
+        // Progress makes this an idle budget. Silence remains a transport failure and keeps the
+        // existing restart-and-retry recovery for a genuinely wedged daemon.
+        socket.destroy(transportError('Daemon request timed out.', 'ETIMEDOUT'));
       });
-      let buffer = '';
+      const consume = (frames: ReturnType<DaemonFrameDecoder['push']>): void => {
+        for (const frame of frames) {
+          if (isDaemonProgressFrame(frame)) {
+            if (frame.id === request.id) {
+              socket.setTimeout(idleTimeoutMs);
+            }
+            continue;
+          }
+          response = frame as DaemonResponse<T>;
+          socket.setTimeout(0);
+        }
+      };
       socket.on('connect', () => {
         socket.write(payload, (error) => {
           if (error) {
@@ -303,27 +322,24 @@ export class DaemonClient {
         });
       });
       socket.on('data', (chunk) => {
-        buffer += chunk.toString();
+        consume(decoder.push(chunk.toString()));
       });
-      socket.on('end', () => finishResolve(buffer));
+      socket.on('end', () => {
+        consume(decoder.flush());
+        if (response) {
+          finishResolve(response);
+          return;
+        }
+        finishReject(
+          decoder.malformed
+            ? transportError('Failed to parse daemon response.', 'ECONNRESET')
+            : transportError('Empty daemon response.', 'ECONNRESET')
+        );
+      });
       socket.on('error', (error) => {
         finishReject(error as Error);
       });
     });
-    const trimmed = response.trim();
-    if (!trimmed) {
-      const error = new Error('Empty daemon response.');
-      (error as NodeJS.ErrnoException).code = 'ECONNRESET';
-      throw error;
-    }
-    let parsed: DaemonResponse<T>;
-    try {
-      parsed = JSON.parse(trimmed) as DaemonResponse<T>;
-    } catch {
-      const parseError = new Error('Failed to parse daemon response.');
-      (parseError as NodeJS.ErrnoException).code = 'ECONNRESET';
-      throw parseError;
-    }
     for (const notice of parsed.notices ?? []) {
       console.warn(`[mcporter] ${notice}`);
     }
@@ -334,6 +350,12 @@ export class DaemonClient {
     }
     return parsed.result as T;
   }
+}
+
+function transportError(message: string, code: string): Error {
+  const error = new Error(message);
+  (error as NodeJS.ErrnoException).code = code;
+  return error;
 }
 
 function deriveConfigKey(configPath: string): string {

--- a/src/daemon/host.ts
+++ b/src/daemon/host.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_REQUEST_TIMEOUT_MSEC, SdkErrorCode } from '@modelcontextprotocol/client';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
@@ -10,6 +11,8 @@ import { configureAutoSelectFamilyAttemptTimeout } from '../network-family-autos
 import { isProcessRunning } from '../process-utils.js';
 import { createRuntime, type Runtime } from '../runtime.js';
 import { createNonInteractiveElicitationResponder, NON_INTERACTIVE_ELICITATION_HINT } from '../runtime/elicitation.js';
+import { OAuthTimeoutError, resolveOAuthTimeoutFromEnv } from '../runtime/oauth.js';
+import { raceWithTimeout } from '../runtime/utils.js';
 import { collectConfigLayers, normalizeConfigLayers, statConfigMtime } from './config-layers.js';
 import { hashDaemonDefinitions } from './definition-hash.js';
 import {
@@ -20,15 +23,19 @@ import {
   logEvent,
   shouldLogServer,
 } from './log-context.js';
-import type {
-  CallToolParams,
-  CloseServerParams,
-  DaemonRequest,
-  DaemonResponse,
-  ListResourcesParams,
-  ListToolsParams,
-  ReadResourceParams,
-  StatusResult,
+import {
+  DAEMON_OPERATION_TIMEOUT_CODE,
+  DAEMON_PROGRESS_INTERVAL_MS,
+  DAEMON_PROTOCOL_VERSION,
+  encodeDaemonFrame,
+  type DaemonRequest,
+  type DaemonResponse,
+  type CallToolParams,
+  type CloseServerParams,
+  type ListResourcesParams,
+  type ListToolsParams,
+  type ReadResourceParams,
+  type StatusResult,
 } from './protocol.js';
 import {
   buildErrorResponse,
@@ -168,6 +175,7 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
           configPath: options.configPath,
           configLayers,
           socketPath: options.socketPath,
+          protocolVersion: DAEMON_PROTOCOL_VERSION,
           startedAt,
           logPath: options.logPath ?? null,
           configMtimeMs,
@@ -218,6 +226,7 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
     });
     await writeJsonFile(options.metadataPath, {
       pid: process.pid,
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
       socketPath: options.socketPath,
       configPath: options.configPath,
       configLayers,
@@ -287,6 +296,7 @@ function metadataFromStatus(
   fallbackConfigLayers: Array<{ path: string; mtimeMs: number | null }>
 ): {
   pid: number;
+  protocolVersion?: number;
   socketPath: string;
   configPath: string;
   configLayers?: StatusResult['configLayers'];
@@ -297,6 +307,7 @@ function metadataFromStatus(
 } {
   return {
     pid: status.pid,
+    protocolVersion: status.protocolVersion,
     socketPath: status.socketPath,
     configPath: status.configPath,
     configLayers: status.configLayers && status.configLayers.length > 0 ? status.configLayers : fallbackConfigLayers,
@@ -475,6 +486,7 @@ async function handleSocketRequest(
     configLayers: Array<{ path: string; mtimeMs: number | null }>;
     configMtimeMs: number | null;
     socketPath: string;
+    protocolVersion?: number;
     startedAt: number;
     logPath: string | null;
     definitionHash?: string;
@@ -483,16 +495,23 @@ async function handleSocketRequest(
   shutdown: () => Promise<void>,
   preParsedRequest?: DaemonRequest
 ): Promise<void> {
-  const { response, shouldShutdown } = await processRequestWithNotices(
-    rawPayload,
-    runtime,
-    managedServers,
-    activity,
-    metadata,
-    logContext,
-    preParsedRequest
-  );
-  socket.write(JSON.stringify(response), () => {
+  const stopProgress = startProgressFrames(socket, preParsedRequest);
+  let response: DaemonResponse;
+  let shouldShutdown: boolean;
+  try {
+    ({ response, shouldShutdown } = await processRequestWithNotices(
+      rawPayload,
+      runtime,
+      managedServers,
+      activity,
+      metadata,
+      logContext,
+      preParsedRequest
+    ));
+  } finally {
+    stopProgress();
+  }
+  socket.write(encodeDaemonFrame(response), () => {
     socket.end(() => {
       if (shouldShutdown) {
         void shutdown();
@@ -501,11 +520,54 @@ async function handleSocketRequest(
   });
 }
 
+function startProgressFrames(socket: net.Socket, request?: DaemonRequest): () => void {
+  // Protocol v1 clients parse the entire socket as one JSON value. Only clients
+  // that explicitly advertise v2 may receive additional newline-delimited frames.
+  if (
+    request?.protocolVersion !== DAEMON_PROTOCOL_VERSION ||
+    typeof request.progressIntervalMs !== 'number' ||
+    !Number.isFinite(request.progressIntervalMs) ||
+    request.progressIntervalMs <= 0
+  ) {
+    return () => {};
+  }
+  const intervalMs = Math.min(request.progressIntervalMs, DAEMON_PROGRESS_INTERVAL_MS);
+  const emit = (): void => {
+    if (!socket.destroyed && !socket.writableEnded) {
+      socket.write(encodeDaemonFrame({ type: 'progress', id: request.id }));
+    }
+  };
+  emit();
+  const timer = setInterval(emit, intervalMs);
+  timer.unref();
+  return () => clearInterval(timer);
+}
+
 function normalizeDaemonDisableOAuth(value: boolean | undefined): boolean {
   // Daemon messages are independent requests. Omission means the caller did
   // not request OAuth suppression, so a previous --no-oauth pooled transport
   // must not make later ordinary calls inherit the no-OAuth posture.
   return value === true;
+}
+
+function operationCeilingMs(requestTimeoutMs?: number): number {
+  const requestPhase =
+    typeof requestTimeoutMs === 'number' && Number.isFinite(requestTimeoutMs) && requestTimeoutMs > 0
+      ? requestTimeoutMs
+      : DEFAULT_REQUEST_TIMEOUT_MSEC;
+  return resolveOAuthTimeoutFromEnv() + requestPhase;
+}
+
+function daemonRuntimeErrorCode(error: unknown): string {
+  const errorCode = error && typeof error === 'object' ? (error as { code?: unknown }).code : undefined;
+  if (
+    error instanceof OAuthTimeoutError ||
+    errorCode === SdkErrorCode.RequestTimeout ||
+    (error instanceof Error && error.message === 'Timeout')
+  ) {
+    return DAEMON_OPERATION_TIMEOUT_CODE;
+  }
+  return 'runtime_error';
 }
 
 async function processRequestWithNotices(
@@ -532,6 +594,7 @@ async function processRequest(
     configLayers: Array<{ path: string; mtimeMs: number | null }>;
     configMtimeMs: number | null;
     socketPath: string;
+    protocolVersion?: number;
     startedAt: number;
     logPath: string | null;
     definitionHash?: string;
@@ -570,11 +633,14 @@ async function processRequest(
           logEvent(logContext, `callTool start server=${params.server} tool=${params.tool}`);
         }
         try {
-          const result = await runtime.callTool(params.server, params.tool, {
-            args: params.args ?? {},
-            timeoutMs: params.timeoutMs,
-            disableOAuth: normalizeDaemonDisableOAuth(params.disableOAuth),
-          });
+          const result = await raceWithTimeout(
+            runtime.callTool(params.server, params.tool, {
+              args: params.args ?? {},
+              timeoutMs: params.timeoutMs,
+              disableOAuth: normalizeDaemonDisableOAuth(params.disableOAuth),
+            }),
+            operationCeilingMs(params.timeoutMs)
+          );
           markActivity(params.server, activity);
           if (loggable) {
             logEvent(logContext, `callTool success server=${params.server} tool=${params.tool}`);
@@ -597,12 +663,16 @@ async function processRequest(
           logEvent(logContext, `listTools start server=${params.server}`);
         }
         try {
-          const result = await runtime.listTools(params.server, {
-            includeSchema: params.includeSchema,
-            autoAuthorize: resolveDaemonListToolsAutoAuthorize(params, definition),
-            allowCachedAuth: params.allowCachedAuth ?? true,
-            disableOAuth: normalizeDaemonDisableOAuth(params.disableOAuth),
-          });
+          const result = await raceWithTimeout(
+            runtime.listTools(params.server, {
+              includeSchema: params.includeSchema,
+              autoAuthorize: resolveDaemonListToolsAutoAuthorize(params, definition),
+              allowCachedAuth: params.allowCachedAuth ?? true,
+              disableOAuth: normalizeDaemonDisableOAuth(params.disableOAuth),
+              timeoutMs: params.timeoutMs,
+            }),
+            operationCeilingMs(params.timeoutMs)
+          );
           markActivity(params.server, activity);
           if (loggable) {
             logEvent(logContext, `listTools success server=${params.server}`);
@@ -624,11 +694,14 @@ async function processRequest(
           logEvent(logContext, `listResources start server=${params.server}`);
         }
         try {
-          const result = await runtime.listResources(params.server, {
-            ...params.params,
-            allowCachedAuth: params.allowCachedAuth,
-            disableOAuth: normalizeDaemonDisableOAuth(params.disableOAuth),
-          });
+          const result = await raceWithTimeout(
+            runtime.listResources(params.server, {
+              ...params.params,
+              allowCachedAuth: params.allowCachedAuth,
+              disableOAuth: normalizeDaemonDisableOAuth(params.disableOAuth),
+            }),
+            operationCeilingMs()
+          );
           markActivity(params.server, activity);
           if (loggable) {
             logEvent(logContext, `listResources success server=${params.server}`);
@@ -650,10 +723,13 @@ async function processRequest(
           logEvent(logContext, `readResource start server=${params.server} uri=${params.uri}`);
         }
         try {
-          const result = await runtime.readResource(params.server, params.uri, {
-            allowCachedAuth: params.allowCachedAuth,
-            disableOAuth: normalizeDaemonDisableOAuth(params.disableOAuth),
-          });
+          const result = await raceWithTimeout(
+            runtime.readResource(params.server, params.uri, {
+              allowCachedAuth: params.allowCachedAuth,
+              disableOAuth: normalizeDaemonDisableOAuth(params.disableOAuth),
+            }),
+            operationCeilingMs()
+          );
           markActivity(params.server, activity);
           if (loggable) {
             logEvent(logContext, `readResource success server=${params.server}`);
@@ -675,7 +751,7 @@ async function processRequest(
           logEvent(logContext, `closeServer start server=${params.server}`);
         }
         try {
-          await runtime.close(params.server);
+          await raceWithTimeout(runtime.close(params.server), operationCeilingMs());
           activity.set(params.server, { connected: false });
           if (loggable) {
             logEvent(logContext, `closeServer success server=${params.server}`);
@@ -695,6 +771,7 @@ async function processRequest(
       case 'status': {
         const result: StatusResult = {
           pid: process.pid,
+          protocolVersion: metadata.protocolVersion ?? DAEMON_PROTOCOL_VERSION,
           startedAt: metadata.startedAt,
           configPath: metadata.configPath,
           configLayers: metadata.configLayers,
@@ -728,7 +805,7 @@ async function processRequest(
     }
   } catch (error) {
     return {
-      response: buildErrorResponse(id, 'runtime_error', error),
+      response: buildErrorResponse(id, daemonRuntimeErrorCode(error), error),
       shouldShutdown: false,
     };
   }
@@ -769,5 +846,32 @@ export async function __testProcessRequest(
     metadata,
     logContext,
     preParsedRequest
+  );
+}
+
+export async function __testHandleSocketRequest(
+  socket: net.Socket,
+  request: DaemonRequest,
+  runtime: Runtime,
+  managedServers: Map<string, ServerDefinition>,
+  metadata: {
+    configPath: string;
+    configLayers: Array<{ path: string; mtimeMs: number | null }>;
+    configMtimeMs: number | null;
+    socketPath: string;
+    startedAt: number;
+    logPath: string | null;
+  }
+): Promise<void> {
+  await handleSocketRequest(
+    JSON.stringify(request),
+    socket,
+    runtime,
+    managedServers,
+    new Map(),
+    { ...metadata, protocolVersion: DAEMON_PROTOCOL_VERSION },
+    createLogContext({ enabled: false, logAllServers: false, servers: new Set() }),
+    async () => {},
+    request
   );
 }

--- a/src/daemon/protocol.ts
+++ b/src/daemon/protocol.ts
@@ -1,3 +1,14 @@
+export const DAEMON_PROTOCOL_VERSION = 2;
+export const DAEMON_OPERATION_TIMEOUT_CODE = 'operation_timeout';
+export const DAEMON_PROGRESS_INTERVAL_MS = 250;
+
+export function resolveProgressInterval(idleTimeoutMs: number): number {
+  if (!Number.isFinite(idleTimeoutMs) || idleTimeoutMs <= 0) {
+    return DAEMON_PROGRESS_INTERVAL_MS;
+  }
+  return Math.min(DAEMON_PROGRESS_INTERVAL_MS, Math.max(1, Math.floor(idleTimeoutMs / 3)));
+}
+
 export type DaemonRequestMethod =
   | 'callTool'
   | 'listTools'
@@ -11,6 +22,9 @@ export interface DaemonRequest<T extends DaemonRequestMethod = DaemonRequestMeth
   readonly id: string;
   readonly method: T;
   readonly params: P;
+  /** Protocol v2 clients opt in to progress frames by sending both fields. */
+  readonly protocolVersion?: number;
+  readonly progressIntervalMs?: number;
 }
 
 export interface DaemonResponse<T = unknown> {
@@ -22,6 +36,64 @@ export interface DaemonResponse<T = unknown> {
     readonly message: string;
     readonly code?: string;
   };
+}
+
+export interface DaemonProgressFrame {
+  readonly type: 'progress';
+  readonly id: string;
+}
+
+export type DaemonFrame<T = unknown> = DaemonProgressFrame | DaemonResponse<T>;
+
+export function isDaemonProgressFrame(frame: DaemonFrame): frame is DaemonProgressFrame {
+  return (frame as DaemonProgressFrame).type === 'progress';
+}
+
+export function encodeDaemonFrame(frame: DaemonFrame): string {
+  return `${JSON.stringify(frame)}\n`;
+}
+
+export class DaemonFrameDecoder {
+  private buffer = '';
+  private sawMalformedLine = false;
+
+  push(chunk: string): DaemonFrame[] {
+    this.buffer += chunk;
+    const frames: DaemonFrame[] = [];
+    let newlineIndex = this.buffer.indexOf('\n');
+    while (newlineIndex !== -1) {
+      const line = this.buffer.slice(0, newlineIndex);
+      this.buffer = this.buffer.slice(newlineIndex + 1);
+      this.collect(line, frames);
+      newlineIndex = this.buffer.indexOf('\n');
+    }
+    return frames;
+  }
+
+  /** Flushes a final bare frame written by a protocol-v1 daemon. */
+  flush(): DaemonFrame[] {
+    const remainder = this.buffer;
+    this.buffer = '';
+    const frames: DaemonFrame[] = [];
+    this.collect(remainder, frames);
+    return frames;
+  }
+
+  get malformed(): boolean {
+    return this.sawMalformedLine;
+  }
+
+  private collect(line: string, frames: DaemonFrame[]): void {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return;
+    }
+    try {
+      frames.push(JSON.parse(trimmed) as DaemonFrame);
+    } catch {
+      this.sawMalformedLine = true;
+    }
+  }
 }
 
 export interface CallToolParams {
@@ -38,6 +110,7 @@ export interface ListToolsParams {
   readonly autoAuthorize?: boolean;
   readonly allowCachedAuth?: boolean;
   readonly disableOAuth?: boolean;
+  readonly timeoutMs?: number;
 }
 
 export interface ListResourcesParams {
@@ -60,6 +133,8 @@ export interface CloseServerParams {
 
 export interface StatusResult {
   readonly pid: number;
+  /** Absent on daemons predating progress framing. */
+  readonly protocolVersion?: number;
   readonly startedAt: number;
   readonly configPath: string;
   readonly configMtimeMs?: number | null;

--- a/src/daemon/runtime-wrapper.ts
+++ b/src/daemon/runtime-wrapper.ts
@@ -11,6 +11,7 @@ import type {
   Runtime,
 } from '../runtime.js';
 import type { DaemonClient } from './client.js';
+import { DAEMON_OPERATION_TIMEOUT_CODE } from './protocol.js';
 
 interface KeepAliveRuntimeOptions {
   readonly daemonClient: DaemonClient | null;
@@ -70,6 +71,7 @@ class KeepAliveRuntime implements Runtime {
           autoAuthorize: options?.autoAuthorize,
           allowCachedAuth: options?.allowCachedAuth ?? true,
           disableOAuth: options?.disableOAuth,
+          timeoutMs: options?.timeoutMs,
         })
       )) as Awaited<ReturnType<Runtime['listTools']>>;
     }
@@ -177,6 +179,9 @@ const NON_FATAL_CODES = new Set([ErrorCode.InvalidRequest, ErrorCode.MethodNotFo
 
 function shouldRestartDaemonServer(error: unknown): boolean {
   if (!error) {
+    return false;
+  }
+  if (typeof error === 'object' && (error as { code?: unknown }).code === DAEMON_OPERATION_TIMEOUT_CODE) {
     return false;
   }
   // Restarting cannot repair a missing or rejected credential, and replaying the

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -68,6 +68,8 @@ export interface ListToolsOptions {
    * headless callers that need cached-token-only behavior.
    */
   readonly disableOAuth?: boolean;
+  /** Per-request and interactive OAuth timeout in milliseconds. */
+  readonly timeoutMs?: number;
 }
 
 export type ListResourcesOptions = Partial<ListResourcesRequest['params']> & {
@@ -84,6 +86,7 @@ export interface ReadResourceOptions {
 
 export interface ConnectOptions {
   readonly maxOAuthAttempts?: number;
+  readonly oauthTimeoutMs?: number;
   readonly skipCache?: boolean;
   readonly allowCachedAuth?: boolean;
   readonly oauthSessionOptions?: OAuthSessionOptions;
@@ -253,17 +256,23 @@ class McpRuntime implements Runtime {
       true
     );
     const useLegacyNoAuthorize = !autoAuthorize && disableOAuth !== true;
+    const timeoutMs = normalizeTimeout(options.timeoutMs);
     const context = await this.connect(server, {
       maxOAuthAttempts: useLegacyNoAuthorize ? 0 : undefined,
       skipCache: useLegacyNoAuthorize,
       allowCachedAuth,
       oauthSessionOptions: options.oauthSessionOptions,
       disableOAuth,
+      oauthTimeoutMs: timeoutMs,
     });
     let closeError: unknown;
     let tools: ServerToolInfo[] = [];
     try {
-      const response = await context.client.listTools();
+      const listPromise = context.client.listTools(
+        undefined,
+        timeoutMs ? { timeout: timeoutMs, resetTimeoutOnProgress: true, maxTotalTimeout: timeoutMs } : undefined
+      );
+      const response = timeoutMs ? await raceWithTimeout(listPromise, timeoutMs) : await listPromise;
       tools = (response.tools ?? []).map((tool) => ({
         name: tool.name,
         description: tool.description ?? undefined,

--- a/src/runtime/connection-cache.ts
+++ b/src/runtime/connection-cache.ts
@@ -299,7 +299,7 @@ export class RuntimeConnectionCache {
     const contextRef: { current?: ClientContext } = {};
     let contextPromise = createClientContext(definition, this.logger, this.clientInfo, {
       maxOAuthAttempts: options.maxOAuthAttempts,
-      oauthTimeoutMs: this.oauthTimeoutMs,
+      oauthTimeoutMs: options.oauthTimeoutMs ?? this.oauthTimeoutMs,
       onDefinitionPromoted: (promoted) => {
         if (
           this.serverGeneration(normalized) === generation &&

--- a/tests/cli-auth-stdio.test.ts
+++ b/tests/cli-auth-stdio.test.ts
@@ -67,7 +67,7 @@ describe('CLI auth helper and validation behavior', () => {
 
     await handleAuth(runtimeFor(definition, listTools), ['linear', '--reset']);
 
-    expect(listTools).toHaveBeenCalledWith('linear', { autoAuthorize: true });
+    expect(listTools).toHaveBeenCalledWith('linear', { autoAuthorize: true, timeoutMs: 300_000 });
   });
 
   it('rejects missing targets and incomplete browser aliases', async () => {
@@ -91,6 +91,6 @@ describe('CLI auth helper and validation behavior', () => {
 
     await handleAuth(runtimeFor(definition, listTools), ['linear']);
 
-    expect(listTools).toHaveBeenCalledWith('linear', { autoAuthorize: true });
+    expect(listTools).toHaveBeenCalledWith('linear', { autoAuthorize: true, timeoutMs: 300_000 });
   });
 });

--- a/tests/cli-auth.test.ts
+++ b/tests/cli-auth.test.ts
@@ -34,7 +34,7 @@ describe('mcporter auth ad-hoc support', () => {
 
     await handleAuth(runtime, ['--http-url', 'https://mcp.deepwiki.com/sse']);
 
-    expect(listTools).toHaveBeenCalledWith('mcp-deepwiki-com-sse', { autoAuthorize: true });
+    expect(listTools).toHaveBeenCalledWith('mcp-deepwiki-com-sse', { autoAuthorize: true, timeoutMs: 300_000 });
   });
 
   it('accepts bare URLs as the auth target', async () => {
@@ -43,7 +43,7 @@ describe('mcporter auth ad-hoc support', () => {
 
     await handleAuth(runtime, ['https://mcp.supabase.com/mcp']);
 
-    expect(listTools).toHaveBeenCalledWith('mcp-supabase-com-mcp', { autoAuthorize: true });
+    expect(listTools).toHaveBeenCalledWith('mcp-supabase-com-mcp', { autoAuthorize: true, timeoutMs: 300_000 });
   });
 
   it('reuses configured servers when auth target is a URL', async () => {
@@ -64,7 +64,7 @@ describe('mcporter auth ad-hoc support', () => {
 
     await handleAuth(runtime, ['https://mcp.vercel.com']);
 
-    expect(listTools).toHaveBeenCalledWith('vercel', { autoAuthorize: true });
+    expect(listTools).toHaveBeenCalledWith('vercel', { autoAuthorize: true, timeoutMs: 300_000 });
     expect(registerDefinition).not.toHaveBeenCalled();
   });
 

--- a/tests/cli-entrypoint-coverage.test.ts
+++ b/tests/cli-entrypoint-coverage.test.ts
@@ -174,7 +174,11 @@ describe('CLI entrypoint dispatch coverage', () => {
 
     await runCli([command]);
 
-    expect(handler).toHaveBeenCalledWith(expect.any(Object), []);
+    if (command === 'auth') {
+      expect(handler).toHaveBeenCalledWith(expect.any(Object), [], { oauthTimeoutMs: undefined });
+    } else {
+      expect(handler).toHaveBeenCalledWith(expect.any(Object), []);
+    }
     expect(mocks.close).toHaveBeenCalled();
   });
 
@@ -277,7 +281,7 @@ describe('CLI entrypoint dispatch coverage', () => {
 
     await runCli(['config', 'auth', 'demo']);
 
-    expect(mocks.handleAuth).toHaveBeenCalledWith(expect.any(Object), ['demo']);
+    expect(mocks.handleAuth).toHaveBeenCalledWith(expect.any(Object), ['demo'], { oauthTimeoutMs: undefined });
     expect(mocks.close).toHaveBeenCalledOnce();
   });
 

--- a/tests/cli-oauth-timeout-flag.test.ts
+++ b/tests/cli-oauth-timeout-flag.test.ts
@@ -52,6 +52,43 @@ describe('mcporter --oauth-timeout flag', () => {
     createRuntimeSpy.mockRestore();
   });
 
+  it('uses the override for the interactive auth request', async () => {
+    const definition = {
+      name: 'fake',
+      description: 'Fake HTTP server',
+      command: { kind: 'http' as const, url: new URL('https://example.com/mcp') },
+    };
+    const listTools = vi.fn(async () => []);
+    const runtimeStub = {
+      listServers: vi.fn(() => [definition.name]),
+      getDefinitions: vi.fn(() => [definition]),
+      getDefinition: vi.fn(() => definition),
+      registerDefinition: vi.fn(),
+      listTools,
+      callTool: vi.fn(),
+      listResources: vi.fn(),
+      readResource: vi.fn(),
+      connect: vi.fn(),
+      close: vi.fn(async () => {}),
+    } as Runtime;
+    const runtimeModule = await import('../src/runtime.js');
+    const createRuntime = vi.spyOn(runtimeModule, 'createRuntime').mockResolvedValue(runtimeStub);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const previousNoForce = process.env.MCPORTER_NO_FORCE_EXIT;
+    process.env.MCPORTER_NO_FORCE_EXIT = '1';
+    try {
+      const { runCli } = await import('../src/cli.js');
+      await runCli(['--oauth-timeout', '600000', 'auth', 'fake']);
+    } finally {
+      if (previousNoForce === undefined) delete process.env.MCPORTER_NO_FORCE_EXIT;
+      else process.env.MCPORTER_NO_FORCE_EXIT = previousNoForce;
+      log.mockRestore();
+      createRuntime.mockRestore();
+    }
+
+    expect(listTools).toHaveBeenCalledWith('fake', expect.objectContaining({ timeoutMs: 600_000 }));
+  });
+
   it('rejects malformed --oauth-timeout values', async () => {
     const { runCli } = await import('../src/cli.js');
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/daemon-client-timeout.test.ts
+++ b/tests/daemon-client-timeout.test.ts
@@ -148,6 +148,17 @@ describe('DaemonClient timeouts', () => {
     expect(callRecord?.timeout).toBe(12_345);
   });
 
+  it('honors per-listTools timeout overrides', async () => {
+    const configPath = 'mcporter.config.json';
+    await writeFreshMetadata(configPath);
+    const client = new DaemonClient({ configPath, configExplicit: true });
+    await client.listTools({ server: 'foo', timeoutMs: 300_000 });
+    const statusRecord = timeoutRecords.find((entry) => entry.method === 'status');
+    const listRecord = timeoutRecords.find((entry) => entry.method === 'listTools');
+    expect(statusRecord?.timeout).toBe(300_000);
+    expect(listRecord?.timeout).toBe(300_000);
+  });
+
   it('clamps daemon status preflight timeout for tiny per-call timeouts', async () => {
     const configPath = 'mcporter.config.json';
     await writeFreshMetadata(configPath);

--- a/tests/daemon-host.test.ts
+++ b/tests/daemon-host.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../src/daemon/host.js';
 import type { DaemonRequest, DaemonResponse, StatusResult } from '../src/daemon/protocol.js';
 import type { Runtime } from '../src/runtime.js';
+import { OAuthTimeoutError } from '../src/runtime/oauth.js';
 
 const describeUnixSocket = process.platform === 'win32' ? describe.skip : describe;
 
@@ -72,6 +73,7 @@ describe('daemon host request handling', () => {
       autoAuthorize: undefined,
       allowCachedAuth: true,
       disableOAuth: false,
+      timeoutMs: undefined,
     });
   });
 
@@ -90,6 +92,7 @@ describe('daemon host request handling', () => {
       autoAuthorize: undefined,
       allowCachedAuth: true,
       disableOAuth: false,
+      timeoutMs: undefined,
     });
   });
 
@@ -108,6 +111,7 @@ describe('daemon host request handling', () => {
       autoAuthorize: false,
       allowCachedAuth: true,
       disableOAuth: false,
+      timeoutMs: undefined,
     });
   });
 
@@ -138,6 +142,7 @@ describe('daemon host request handling', () => {
       autoAuthorize: undefined,
       allowCachedAuth: true,
       disableOAuth: true,
+      timeoutMs: undefined,
     });
   });
 
@@ -156,7 +161,65 @@ describe('daemon host request handling', () => {
       autoAuthorize: undefined,
       allowCachedAuth: false,
       disableOAuth: false,
+      timeoutMs: undefined,
     });
+  });
+
+  it('returns a non-retryable operation timeout when OAuth reaches its deadline', async () => {
+    const runtime = createRuntimeDouble();
+    vi.mocked(runtime.listTools).mockRejectedValue(new OAuthTimeoutError('oauth', 5_000));
+
+    const result = await __testProcessRequest(
+      '',
+      runtime as unknown as Runtime,
+      createManagedServers(),
+      new Map(),
+      metadata,
+      logContext,
+      {
+        id: 'oauth-timeout',
+        method: 'listTools',
+        params: { server: 'oauth', timeoutMs: 5_000 },
+      }
+    );
+
+    expect(result.response).toMatchObject({
+      id: 'oauth-timeout',
+      ok: false,
+      error: { code: 'operation_timeout' },
+    });
+  });
+
+  it('bounds an operation even when its runtime promise never settles', async () => {
+    const previousOAuthTimeout = process.env.MCPORTER_OAUTH_TIMEOUT_MS;
+    process.env.MCPORTER_OAUTH_TIMEOUT_MS = '10';
+    vi.useFakeTimers();
+    try {
+      const runtime = createRuntimeDouble();
+      vi.mocked(runtime.listTools).mockImplementation(() => new Promise(() => {}));
+      const pending = __testProcessRequest(
+        '',
+        runtime as unknown as Runtime,
+        createManagedServers(),
+        new Map(),
+        metadata,
+        logContext,
+        {
+          id: 'wedged-operation',
+          method: 'listTools',
+          params: { server: 'oauth', timeoutMs: 5 },
+        }
+      );
+
+      await vi.advanceTimersByTimeAsync(15);
+      await expect(pending).resolves.toMatchObject({
+        response: { ok: false, error: { code: 'operation_timeout' } },
+      });
+    } finally {
+      vi.useRealTimers();
+      if (previousOAuthTimeout === undefined) delete process.env.MCPORTER_OAUTH_TIMEOUT_MS;
+      else process.env.MCPORTER_OAUTH_TIMEOUT_MS = previousOAuthTimeout;
+    }
   });
 
   it('dispatches resource, close, status, stop, and malformed requests with observable state', async () => {

--- a/tests/daemon-liveness.test.ts
+++ b/tests/daemon-liveness.test.ts
@@ -1,0 +1,228 @@
+import fs from 'node:fs/promises';
+import net from 'node:net';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ServerDefinition } from '../src/config.js';
+import { DaemonClient } from '../src/daemon/client.js';
+import { __testHandleSocketRequest } from '../src/daemon/host.js';
+import {
+  DAEMON_PROTOCOL_VERSION,
+  DaemonFrameDecoder,
+  encodeDaemonFrame,
+  type DaemonRequest,
+} from '../src/daemon/protocol.js';
+import type { Runtime } from '../src/runtime.js';
+import { makeShortTempDir } from './fixtures/test-helpers.js';
+
+const describeUnixSocket = process.platform === 'win32' ? describe.skip : describe;
+
+describe('daemon frame protocol', () => {
+  it('decodes split and coalesced frames and reports malformed lines', () => {
+    const decoder = new DaemonFrameDecoder();
+    const progress = encodeDaemonFrame({ type: 'progress', id: 'one' });
+    const response = encodeDaemonFrame({ id: 'one', ok: true, result: ['done'] });
+
+    expect(decoder.push(progress.slice(0, 8))).toEqual([]);
+    expect(decoder.push(`${progress.slice(8)}not-json\n${response.slice(0, -1)}`)).toEqual([
+      { type: 'progress', id: 'one' },
+    ]);
+    expect(decoder.flush()).toEqual([{ id: 'one', ok: true, result: ['done'] }]);
+    expect(decoder.malformed).toBe(true);
+  });
+});
+
+describeUnixSocket('daemon socket liveness', () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+  });
+
+  it('keeps a request alive past its flat deadline while progress arrives', async () => {
+    const idleTimeoutMs = 60;
+    const operationMs = 240;
+    const listTools = vi.fn(async () => {
+      await delay(operationMs);
+      return [{ name: 'authorized' }];
+    });
+    const served = await serveSocket(async (socket, request) => {
+      await __testHandleSocketRequest(
+        socket,
+        request,
+        { listTools } as unknown as Runtime,
+        managedServers(),
+        metadata(served.socketPath)
+      );
+    });
+    cleanups.push(served.close);
+    const client = clientForSocket(served.socketPath);
+
+    const startedAt = Date.now();
+    const result = await sendRequest(client, 'listTools', { server: 'oauth' }, idleTimeoutMs);
+
+    expect(result).toEqual([{ name: 'authorized' }]);
+    expect(Date.now() - startedAt).toBeGreaterThan(idleTimeoutMs * 3);
+    expect(listTools).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys a genuinely silent daemon socket at the idle deadline', async () => {
+    let observedClose!: () => void;
+    const closed = new Promise<void>((resolve) => {
+      observedClose = resolve;
+    });
+    const served = await serveSocket(async (socket) => {
+      socket.once('close', () => observedClose());
+    });
+    cleanups.push(served.close);
+    const client = clientForSocket(served.socketPath);
+
+    await expect(
+      Promise.race([
+        sendRequest(client, 'listTools', { server: 'oauth' }, 50),
+        delay(200).then(() => {
+          throw new Error('silent daemon socket was not torn down');
+        }),
+      ])
+    ).rejects.toMatchObject({ code: 'ETIMEDOUT' });
+    await expect(Promise.race([closed, delay(200).then(() => 'still-open')])).resolves.toBeUndefined();
+  });
+
+  it('accepts a bare v1 response and retains the flat fallback deadline', async () => {
+    let receivedRequest: DaemonRequest | undefined;
+    const served = await serveSocket(async (socket, request) => {
+      receivedRequest = request;
+      await delay(30);
+      socket.end(JSON.stringify({ id: request.id, ok: true, result: 'legacy' }));
+    });
+    cleanups.push(served.close);
+    const client = clientForSocket(served.socketPath);
+
+    await expect(sendRequest(client, 'status', {}, 100)).resolves.toBe('legacy');
+    expect(receivedRequest).toMatchObject({
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
+      progressIntervalMs: expect.any(Number),
+    });
+  });
+
+  it('sends one old-parser-safe response when a v1 client does not opt into progress', async () => {
+    const served = await serveSocket(async (socket, request) => {
+      await __testHandleSocketRequest(
+        socket,
+        request,
+        { listTools: vi.fn().mockResolvedValue([{ name: 'legacy-client' }]) } as unknown as Runtime,
+        managedServers(),
+        metadata(served.socketPath)
+      );
+    });
+    cleanups.push(served.close);
+
+    const payload = await rawRequest(served.socketPath, {
+      id: 'v1-client',
+      method: 'listTools',
+      params: { server: 'oauth' },
+    });
+
+    expect(JSON.parse(payload.trim())).toEqual({
+      id: 'v1-client',
+      ok: true,
+      result: [{ name: 'legacy-client' }],
+    });
+    expect(payload.trim().split('\n')).toHaveLength(1);
+  });
+});
+
+async function serveSocket(
+  handler: (socket: net.Socket, request: DaemonRequest) => Promise<void>
+): Promise<{ socketPath: string; close: () => Promise<void> }> {
+  const tmpDir = await makeShortTempDir('daemon-live');
+  const socketPath = path.join(tmpDir, 'd.sock');
+  const openSockets = new Set<net.Socket>();
+  const server = net.createServer((socket) => {
+    openSockets.add(socket);
+    socket.once('close', () => openSockets.delete(socket));
+    socket.once('error', () => {});
+    let buffer = '';
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString();
+      try {
+        const request = JSON.parse(buffer) as DaemonRequest;
+        socket.removeAllListeners('data');
+        void handler(socket, request).catch((error) => socket.destroy(error as Error));
+      } catch {
+        // Wait for the rest of the request.
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  return {
+    socketPath,
+    close: async () => {
+      for (const socket of openSockets) socket.destroy();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function clientForSocket(socketPath: string): DaemonClient {
+  const client = new DaemonClient({ configPath: '/unused/config.json', configExplicit: true });
+  (client as unknown as { socketPath: string }).socketPath = socketPath;
+  return client;
+}
+
+function sendRequest(
+  client: DaemonClient,
+  method: 'listTools' | 'status',
+  params: unknown,
+  timeoutMs: number
+): Promise<unknown> {
+  return (
+    client as unknown as {
+      sendRequest(method: 'listTools' | 'status', params: unknown, timeoutMs: number): Promise<unknown>;
+    }
+  ).sendRequest(method, params, timeoutMs);
+}
+
+function rawRequest(socketPath: string, request: DaemonRequest): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(socketPath);
+    let response = '';
+    socket.once('connect', () => socket.write(JSON.stringify(request)));
+    socket.on('data', (chunk) => (response += chunk.toString()));
+    socket.once('end', () => resolve(response));
+    socket.once('error', reject);
+  });
+}
+
+function managedServers(): Map<string, ServerDefinition> {
+  return new Map([
+    [
+      'oauth',
+      {
+        name: 'oauth',
+        command: { kind: 'http', url: new URL('https://example.test/mcp') },
+      } as ServerDefinition,
+    ],
+  ]);
+}
+
+function metadata(socketPath: string) {
+  return {
+    configPath: '/tmp/config.json',
+    configLayers: [],
+    configMtimeMs: null,
+    socketPath,
+    startedAt: Date.now(),
+    logPath: null,
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/keep-alive-runtime.test.ts
+++ b/tests/keep-alive-runtime.test.ts
@@ -113,6 +113,7 @@ describe('createKeepAliveRuntime', () => {
       autoAuthorize: undefined,
       allowCachedAuth: true,
       disableOAuth: undefined,
+      timeoutMs: undefined,
     });
 
     await keepAliveRuntime.listTools('alpha', { allowCachedAuth: false });
@@ -122,6 +123,7 @@ describe('createKeepAliveRuntime', () => {
       autoAuthorize: undefined,
       allowCachedAuth: false,
       disableOAuth: undefined,
+      timeoutMs: undefined,
     });
 
     await keepAliveRuntime.listResources('alpha', { cursor: '1' });
@@ -182,6 +184,7 @@ describe('createKeepAliveRuntime', () => {
       autoAuthorize: undefined,
       allowCachedAuth: true,
       disableOAuth: true,
+      timeoutMs: undefined,
     });
 
     await keepAliveRuntime.listResources('alpha', { cursor: '1', disableOAuth: true });
@@ -299,6 +302,26 @@ describe('createKeepAliveRuntime', () => {
 
     await expect(keepAliveRuntime.callTool('alpha', 'ping', {})).rejects.toThrow(/unauthorized/i);
     expect(daemon.callTool).toHaveBeenCalledTimes(1);
+    expect(daemon.closeServer).not.toHaveBeenCalled();
+  });
+
+  it('does not restart or replay daemon operation timeouts', async () => {
+    const runtime = new FakeRuntime(definitions);
+    const timeout = Object.assign(new Error('OAuth authorization timed out'), { code: 'operation_timeout' });
+    const daemon = {
+      callTool: vi.fn(),
+      closeServer: vi.fn().mockResolvedValue(undefined),
+      listTools: vi.fn().mockRejectedValue(timeout),
+      listResources: vi.fn(),
+      readResource: vi.fn(),
+    };
+    const keepAliveRuntime = createKeepAliveRuntime(runtime as unknown as Runtime, {
+      daemonClient: daemon as never,
+      keepAliveServers: new Set(['alpha']),
+    });
+
+    await expect(keepAliveRuntime.listTools('alpha', { timeoutMs: 5_000 })).rejects.toThrow('timed out');
+    expect(daemon.listTools).toHaveBeenCalledTimes(1);
     expect(daemon.closeServer).not.toHaveBeenCalled();
   });
 });

--- a/tests/runtime-listtools-timeout.test.ts
+++ b/tests/runtime-listtools-timeout.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRuntime } from '../src/runtime.js';
+
+describe('runtime listTools timeouts', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('forwards the deadline to OAuth connection setup and the MCP request', async () => {
+    const runtime = await createRuntime({ servers: [] });
+    const listTools = vi.fn().mockResolvedValue({ tools: [{ name: 'one' }] });
+    type ClientContext = Awaited<ReturnType<typeof runtime.connect>>;
+    const context = {
+      client: { listTools },
+      transport: { close: vi.fn().mockResolvedValue(undefined) },
+      definition: {
+        name: 'temp',
+        command: { kind: 'stdio', command: 'node', args: [], cwd: process.cwd() },
+      },
+    } as unknown as ClientContext;
+    const connect = vi.spyOn(runtime, 'connect').mockResolvedValue(context);
+
+    await expect(runtime.listTools('temp', { timeoutMs: 5_000 })).resolves.toEqual([{ name: 'one' }]);
+
+    expect(connect).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ oauthTimeoutMs: 5_000 }));
+    expect(listTools).toHaveBeenCalledWith(undefined, {
+      timeout: 5_000,
+      resetTimeoutOnProgress: true,
+      maxTotalTimeout: 5_000,
+    });
+  });
+
+  it('preserves the SDK defaults when no timeout is supplied', async () => {
+    const runtime = await createRuntime({ servers: [] });
+    const listTools = vi.fn().mockResolvedValue({ tools: [] });
+    type ClientContext = Awaited<ReturnType<typeof runtime.connect>>;
+    vi.spyOn(runtime, 'connect').mockResolvedValue({
+      client: { listTools },
+      transport: { close: vi.fn().mockResolvedValue(undefined) },
+      definition: { name: 'temp' },
+    } as unknown as ClientContext);
+
+    await runtime.listTools('temp');
+
+    expect(listTools).toHaveBeenCalledWith(undefined, undefined);
+  });
+});


### PR DESCRIPTION
Reimplements the design from #241 by @umutkeltek, which could not be rebased after the SDK v2 migration rewrote the daemon, runtime and CLI underneath it. Commits carry `Co-authored-by: Umut Keltek`.

## The bug, confirmed on 0.13.0

`listTools` reaches `invoke()` with no timeout, so it falls back to a flat `DEFAULT_DAEMON_TIMEOUT_MS` of 30s on the daemon socket. The daemon-side handler meanwhile calls `runtime.listTools(...)` with `autoAuthorize`, which can open a browser and wait up to `DEFAULT_OAUTH_CODE_TIMEOUT_MS` — 300s — for consent. Nothing in the daemon protocol proved liveness in between.

So a user who spends more than 30 seconds at the consent screen trips the client deadline, `invoke()` classifies it as a transport error, restarts the daemon and re-sends — producing exactly the second OAuth prompt #241 set out to eliminate.

The predecessor `resolveOperationSocketBudget` (`2 * timeoutMs + 5s`) is gone, but the flat 30s that replaced it is the same mistake in simpler clothing: a deadline encoding an assumption about how long legitimate work takes.

## The fix

The socket deadline becomes an **idle** budget rather than an operation budget:

- The daemon emits `progress` frames at a bounded interval while a request is in flight, so a working daemon proves it is alive.
- The client treats each frame as proof of life; a genuinely silent daemon still trips the deadline, is destroyed, and is restarted exactly as before.
- The real operation deadline is enforced daemon-side and returned as a **non-retryable** timeout, so a slow operation is never replayed into a duplicate prompt.
- Frames are decoded incrementally, so split and coalesced writes parse correctly.

**Version skew is explicit in both directions**, since a daemon started by an older build can outlive it: a new client talking to an old daemon sees no progress frames and retains the flat deadline; an old client never receives progress at all, because emission requires an explicit v2 opt-in, so it still reads exactly one JSON response.

## Verification

Mutation-checked rather than assumed — suppressing the daemon's progress emission fails precisely the test that claims to prove liveness (`Daemon request timed out`), and restoring it passes. Worth noting one subtlety found while verifying: Node's `socket.setTimeout` is an inactivity timer, so incoming progress data resets it natively; the explicit re-arm in the client is redundant belt-and-braces, and the real mechanism is the daemon writing at all.

Also proven: a silent daemon is still torn down, a v1 client receives old-parser-safe output, and removing the no-retry handling replays the request twice.

Black-box CLI check: a 100 ms socket budget survived 880 ms and 986 ms operations.

`pnpm check` clean, 1,277 tests passing, coverage 91.55% statements. Closes #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
