### PR TITLE
test: scale Windows CI timing budgets from a shared helper

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,12 +13,13 @@ import { createInteractiveElicitationResponder } from './runtime/elicitation.js'
 
 export { parseCallArguments } from './cli/call-arguments.js';
 export { extractListFlags } from './cli/list-flags.js';
-export { resolveCallTimeout } from './cli/timeouts.js';
+export { resolveCallTimeout, STDOUT_FLUSH_TIMEOUT_MS } from './cli/timeouts.js';
+
+import { STDOUT_FLUSH_TIMEOUT_MS } from './cli/timeouts.js';
 
 configureAutoSelectFamilyAttemptTimeout();
 
 const FORCE_EXIT_GRACE_MS = 50;
-const STDOUT_FLUSH_TIMEOUT_MS = 2000;
 const DAEMON_FAST_PATH_SERVERS = new Set(['chrome-devtools', 'mobile-mcp', 'playwright']);
 
 function handleStdioError(error: Error): void {

--- a/src/cli/timeouts.ts
+++ b/src/cli/timeouts.ts
@@ -2,6 +2,12 @@ const DEFAULT_LIST_TIMEOUT_MS = 30_000;
 const DEFAULT_CALL_TIMEOUT_MS = 60_000;
 const POSITIVE_INTEGER_PATTERN = /^[1-9]\d*$/;
 
+// Deadline for the forced-exit path to flush stdout/stderr before calling
+// process.exit(). Lives here (a leaf module) rather than in cli.ts so tests can
+// derive their force-exit bounds from it without importing the CLI entrypoint,
+// which auto-runs main() on import.
+export const STDOUT_FLUSH_TIMEOUT_MS = 2000;
+
 export function parsePositiveInteger(raw: string | undefined): number | undefined {
   if (!raw || !POSITIVE_INTEGER_PATTERN.test(raw)) {
     return undefined;

--- a/src/daemon/host.ts
+++ b/src/daemon/host.ts
@@ -452,6 +452,9 @@ async function prepareSocket(socketPath: string): Promise<void> {
 
 export const __daemonHostInternals = {
   prepareSocket,
+  // Exposed so tests can derive their liveness bound from the real probe
+  // timeout instead of hardcoding a parallel constant.
+  DAEMON_PROBE_TIMEOUT_MS,
 };
 
 async function cleanupArtifacts(options: DaemonHostOptions): Promise<void> {

--- a/tests/cli-force-exit-behavior.integration.test.ts
+++ b/tests/cli-force-exit-behavior.integration.test.ts
@@ -7,6 +7,7 @@ import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { ensureDistBuilt } from './helpers/dist.js';
+import { budget } from './helpers/timing.js';
 
 const CLI_ENTRY = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
 const testRequire = createRequire(import.meta.url);
@@ -113,21 +114,29 @@ await server.connect(transport);
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
   });
 
-  it('preserves non-zero exit codes for MCP isError tool results', async () => {
-    const result = await runCli(['call', 'force-exit.fail'], configPath);
-    expect(result.code).toBe(1);
-    expect(result.stdout).toContain('expected failure');
-    expect(result.stderr).toBe('');
-  }, 20000);
+  it(
+    'preserves non-zero exit codes for MCP isError tool results',
+    async () => {
+      const result = await runCli(['call', 'force-exit.fail'], configPath);
+      expect(result.code).toBe(1);
+      expect(result.stdout).toContain('expected failure');
+      expect(result.stderr).toBe('');
+    },
+    budget(20_000)
+  );
 
-  it('does not truncate large JSON output when force exit is enabled', async () => {
-    const result = await runCli(['list', 'force-exit', '--schema', '--output', 'json'], configPath);
-    expect(result.code).toBe(0);
-    expect(result.stderr).toBe('');
-    expect(Buffer.byteLength(result.stdout)).toBeGreaterThan(8192);
+  it(
+    'does not truncate large JSON output when force exit is enabled',
+    async () => {
+      const result = await runCli(['list', 'force-exit', '--schema', '--output', 'json'], configPath);
+      expect(result.code).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(Buffer.byteLength(result.stdout)).toBeGreaterThan(8192);
 
-    const payload = JSON.parse(result.stdout) as { tools: Array<{ name: string }> };
-    expect(payload.tools).toHaveLength(65);
-    expect(payload.tools.at(-1)?.name).toBe('tool_63');
-  }, 20000);
+      const payload = JSON.parse(result.stdout) as { tools: Array<{ name: string }> };
+      expect(payload.tools).toHaveLength(65);
+      expect(payload.tools.at(-1)?.name).toBe('tool_63');
+    },
+    budget(20_000)
+  );
 });

--- a/tests/cli-http-selector.integration.test.ts
+++ b/tests/cli-http-selector.integration.test.ts
@@ -11,6 +11,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import express from 'express';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { ensureDistBuilt } from './helpers/dist.js';
+import { budget } from './helpers/timing.js';
 
 const CLI_ENTRY = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
 
@@ -23,7 +24,7 @@ function runCli(args: string[], configPath: string): Promise<{ stdout: string; s
         cwd: process.cwd(),
         env: { ...process.env, MCPORTER_NO_FORCE_EXIT: '1' },
         maxBuffer: 1024 * 1024,
-        timeout: 15_000,
+        timeout: budget(15_000),
       },
       (error, stdout, stderr) => {
         if (error) {
@@ -139,77 +140,81 @@ describe('mcporter HTTP selector CLI integration', () => {
     });
   });
 
-  it('routes configured and ad-hoc HTTP selectors to the intended literal tool names', async () => {
-    const cases: Array<{ args: string[]; configPath: string; expectedTool: string }> = [
-      {
-        args: ['call', 'xhs.check_login_status', '--output', 'json'],
-        configPath: configuredPath,
-        expectedTool: 'check_login_status',
-      },
-      {
-        args: ['call', 'xhs.check_login_status', '--http-url', baseUrl.href, '--allow-http', '--output', 'json'],
-        configPath: configuredPath,
-        expectedTool: 'check_login_status',
-      },
-      {
-        args: ['call', 'xhs.check_login_status', '--http-url', baseUrl.href, '--allow-http', '--output', 'json'],
-        configPath: emptyPath,
-        expectedTool: 'check_login_status',
-      },
-      {
-        args: [
-          'call',
-          'xhs.check_login_status',
-          '--http-url',
-          baseUrl.href,
-          '--allow-http',
-          '--name',
-          'xhs',
-          '--output',
-          'json',
-        ],
-        configPath: emptyPath,
-        expectedTool: 'check_login_status',
-      },
-      {
-        args: [
-          'call',
-          'xhs.selector_tool',
-          '--http-url',
-          baseUrl.href,
-          '--allow-http',
-          '--tool',
-          'check_login_status',
-          '--output',
-          'json',
-        ],
-        configPath: emptyPath,
-        expectedTool: 'check_login_status',
-      },
-      {
-        args: [
-          'call',
-          '--http-url',
-          baseUrl.href,
-          '--allow-http',
-          '--name',
-          'xhs',
-          '--tool',
-          'xhs.check_login_status',
-          '--output',
-          'json',
-        ],
-        configPath: emptyPath,
-        expectedTool: 'xhs.check_login_status',
-      },
-    ];
+  it(
+    'routes configured and ad-hoc HTTP selectors to the intended literal tool names',
+    async () => {
+      const cases: Array<{ args: string[]; configPath: string; expectedTool: string }> = [
+        {
+          args: ['call', 'xhs.check_login_status', '--output', 'json'],
+          configPath: configuredPath,
+          expectedTool: 'check_login_status',
+        },
+        {
+          args: ['call', 'xhs.check_login_status', '--http-url', baseUrl.href, '--allow-http', '--output', 'json'],
+          configPath: configuredPath,
+          expectedTool: 'check_login_status',
+        },
+        {
+          args: ['call', 'xhs.check_login_status', '--http-url', baseUrl.href, '--allow-http', '--output', 'json'],
+          configPath: emptyPath,
+          expectedTool: 'check_login_status',
+        },
+        {
+          args: [
+            'call',
+            'xhs.check_login_status',
+            '--http-url',
+            baseUrl.href,
+            '--allow-http',
+            '--name',
+            'xhs',
+            '--output',
+            'json',
+          ],
+          configPath: emptyPath,
+          expectedTool: 'check_login_status',
+        },
+        {
+          args: [
+            'call',
+            'xhs.selector_tool',
+            '--http-url',
+            baseUrl.href,
+            '--allow-http',
+            '--tool',
+            'check_login_status',
+            '--output',
+            'json',
+          ],
+          configPath: emptyPath,
+          expectedTool: 'check_login_status',
+        },
+        {
+          args: [
+            'call',
+            '--http-url',
+            baseUrl.href,
+            '--allow-http',
+            '--name',
+            'xhs',
+            '--tool',
+            'xhs.check_login_status',
+            '--output',
+            'json',
+          ],
+          configPath: emptyPath,
+          expectedTool: 'xhs.check_login_status',
+        },
+      ];
 
-    for (const testCase of cases) {
-      const result = await runCli(testCase.args, testCase.configPath);
-      expect(result.stderr).toBe('');
-      expect(JSON.parse(result.stdout)).toEqual({ loggedIn: true, observedTool: testCase.expectedTool });
-    }
+      for (const testCase of cases) {
+        const result = await runCli(testCase.args, testCase.configPath);
+        expect(result.stderr).toBe('');
+        expect(JSON.parse(result.stdout)).toEqual({ loggedIn: true, observedTool: testCase.expectedTool });
+      }
 
-    expect(observedToolNames).toEqual(cases.map((testCase) => testCase.expectedTool));
-  }, 30_000);
+      expect(observedToolNames).toEqual(cases.map((testCase) => testCase.expectedTool));
+    },
+    budget(30_000)
+  );
 });

--- a/tests/cli-idle-sse.integration.test.ts
+++ b/tests/cli-idle-sse.integration.test.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { budget } from './helpers/timing.js';
 
 const CLI_ENTRY = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
 const SINGLE_CONNECTION_FETCH = String.raw`
@@ -69,7 +70,7 @@ function runCli(args: string[], configPath: string, preloadPath: string): Promis
           NODE_OPTIONS: `--import=${pathToFileURL(preloadPath).href}`,
         },
         maxBuffer: 1024 * 1024,
-        timeout: 10_000,
+        timeout: budget(10_000),
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/tests/cli-stdout-pipe-truncation.integration.test.ts
+++ b/tests/cli-stdout-pipe-truncation.integration.test.ts
@@ -6,7 +6,9 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { STDOUT_FLUSH_TIMEOUT_MS } from '../src/cli/timeouts.js';
 import { ensureDistBuilt } from './helpers/dist.js';
+import { budget } from './helpers/timing.js';
 
 const CLI_ENTRY = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
 const testRequire = createRequire(import.meta.url);
@@ -16,6 +18,16 @@ const STDIO_SERVER_MODULE = pathToFileURL(testRequire.resolve('@modelcontextprot
 // Payload comfortably larger than the OS pipe buffer (~64KB) so that a forced
 // exit which does not wait for stdout to drain would truncate the output.
 const LARGE_TEXT_BYTES = 200_000;
+
+// The "consumer never reads" test must terminate via the CLI's stdout flush
+// fallback deadline rather than hanging. Derive the bounds from the real
+// STDOUT_FLUSH_TIMEOUT_MS so the assertion tracks the budget it polices: the
+// process should exit shortly after one flush deadline, and must never take so
+// long that it looks hung. Scale by platform — process teardown is far slower
+// on Windows.
+const FLUSH_DEADLINE_MS = STDOUT_FLUSH_TIMEOUT_MS;
+const FORCE_EXIT_UPPER_MS = budget(FLUSH_DEADLINE_MS * 4);
+const FORCE_EXIT_TEST_TIMEOUT_MS = budget(FLUSH_DEADLINE_MS * 10);
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
@@ -176,28 +188,33 @@ await server.connect(transport);
     expect(pipeBytes).toBe(fileBytes);
   }, 30000);
 
-  it('still force-exits when stdout is piped to a consumer that never reads', async () => {
-    // A consumer that keeps stdout open but never reads fills the pipe buffer
-    // and blocks the drain callback. The fallback deadline must still terminate
-    // the process instead of hanging indefinitely.
-    const start = Date.now();
-    const child = spawn(
-      process.execPath,
-      [CLI_ENTRY, '--config', configPath, 'call', 'large-output.big', '--output', 'json'],
-      { cwd: process.cwd(), env: process.env, stdio: ['ignore', 'pipe', 'ignore'] }
-    );
-    // Intentionally never consume stdout so the OS pipe buffer stays full.
-    child.stdout.pause();
+  it(
+    'still force-exits when stdout is piped to a consumer that never reads',
+    async () => {
+      // A consumer that keeps stdout open but never reads fills the pipe buffer
+      // and blocks the drain callback. The fallback deadline must still terminate
+      // the process instead of hanging indefinitely.
+      const start = Date.now();
+      const child = spawn(
+        process.execPath,
+        [CLI_ENTRY, '--config', configPath, 'call', 'large-output.big', '--output', 'json'],
+        { cwd: process.cwd(), env: process.env, stdio: ['ignore', 'pipe', 'ignore'] }
+      );
+      // Intentionally never consume stdout so the OS pipe buffer stays full.
+      child.stdout.pause();
 
-    const code = await new Promise<number>((resolve) => {
-      child.on('exit', (exitCode) => resolve(exitCode ?? -1));
-    });
-    const elapsed = Date.now() - start;
+      const code = await new Promise<number>((resolve) => {
+        child.on('exit', (exitCode) => resolve(exitCode ?? -1));
+      });
+      const elapsed = Date.now() - start;
 
-    expect(code).toBe(0);
-    // Terminates via the fallback deadline (~2s) rather than hanging.
-    expect(elapsed).toBeLessThan(8000);
-  }, 20000);
+      expect(code).toBe(0);
+      // Terminates via the stdout flush fallback deadline rather than hanging;
+      // derived from STDOUT_FLUSH_TIMEOUT_MS above.
+      expect(elapsed).toBeLessThan(FORCE_EXIT_UPPER_MS);
+    },
+    FORCE_EXIT_TEST_TIMEOUT_MS
+  );
 
   it('does not crash when a piped consumer closes stdout early (EPIPE)', async () => {
     const command = [

--- a/tests/daemon-elicitation.test.ts
+++ b/tests/daemon-elicitation.test.ts
@@ -8,62 +8,67 @@ import { __testProcessRequest, loadDaemonRuntimeState } from '../src/daemon/host
 import type { DaemonResponse } from '../src/daemon/protocol.js';
 import { NON_INTERACTIVE_ELICITATION_HINT } from '../src/runtime/elicitation.js';
 import { makeShortTempDir } from './fixtures/test-helpers.js';
+import { budget } from './helpers/timing.js';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 const MODERN_SERVER = path.join(REPO_ROOT, 'tests', 'servers', 'modern', 'server.ts');
 const TSX_CLI = createRequire(import.meta.url).resolve('tsx/cli');
 
 describe('daemon elicitation', () => {
-  it('returns an actionable CLI notice when a keep-alive call declines elicitation', async () => {
-    const tempDir = await makeShortTempDir('daemon-elicitation');
-    const configPath = path.join(tempDir, 'mcporter.json');
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        mcpServers: {
-          modern: {
-            command: process.execPath,
-            args: [TSX_CLI, MODERN_SERVER, '--stdio'],
-            lifecycle: 'keep-alive',
-            protocolVersion: '2026-07-28',
+  it(
+    'returns an actionable CLI notice when a keep-alive call declines elicitation',
+    async () => {
+      const tempDir = await makeShortTempDir('daemon-elicitation');
+      const configPath = path.join(tempDir, 'mcporter.json');
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            modern: {
+              command: process.execPath,
+              args: [TSX_CLI, MODERN_SERVER, '--stdio'],
+              lifecycle: 'keep-alive',
+              protocolVersion: '2026-07-28',
+            },
           },
-        },
-        imports: [],
-      }),
-      'utf8'
-    );
-
-    const { runtime } = await loadDaemonRuntimeState({ configPath });
-    try {
-      const definition = runtime.getDefinition('modern');
-      const result = await __testProcessRequest(
-        '',
-        runtime,
-        new Map<string, ServerDefinition>([['modern', definition]]),
-        new Map(),
-        {
-          configPath,
-          configLayers: [],
-          configMtimeMs: null,
-          socketPath: path.join(tempDir, 'daemon.sock'),
-          startedAt: Date.now(),
-          logPath: null,
-        },
-        { enabled: false, logAllServers: false, servers: new Set() },
-        {
-          id: 'elicitation-call',
-          method: 'callTool',
-          params: { server: 'modern', tool: 'confirm_delete', args: { target: 'fixture-item' } },
-        }
+          imports: [],
+        }),
+        'utf8'
       );
-      const response = result.response as DaemonResponse & { notices?: string[] };
 
-      expect(response.ok).toBe(true);
-      expect(response.notices).toEqual([NON_INTERACTIVE_ELICITATION_HINT]);
-      expect(JSON.stringify(response.result)).toContain('delete declined');
-    } finally {
-      await runtime.close().catch(() => {});
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
-  }, 20_000);
+      const { runtime } = await loadDaemonRuntimeState({ configPath });
+      try {
+        const definition = runtime.getDefinition('modern');
+        const result = await __testProcessRequest(
+          '',
+          runtime,
+          new Map<string, ServerDefinition>([['modern', definition]]),
+          new Map(),
+          {
+            configPath,
+            configLayers: [],
+            configMtimeMs: null,
+            socketPath: path.join(tempDir, 'daemon.sock'),
+            startedAt: Date.now(),
+            logPath: null,
+          },
+          { enabled: false, logAllServers: false, servers: new Set() },
+          {
+            id: 'elicitation-call',
+            method: 'callTool',
+            params: { server: 'modern', tool: 'confirm_delete', args: { target: 'fixture-item' } },
+          }
+        );
+        const response = result.response as DaemonResponse & { notices?: string[] };
+
+        expect(response.ok).toBe(true);
+        expect(response.notices).toEqual([NON_INTERACTIVE_ELICITATION_HINT]);
+        expect(JSON.stringify(response.result)).toContain('delete declined');
+      } finally {
+        await runtime.close().catch(() => {});
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    },
+    budget(20_000)
+  );
 });

--- a/tests/daemon-host.test.ts
+++ b/tests/daemon-host.test.ts
@@ -587,14 +587,21 @@ describeUnixSocket('isDaemonResponding', () => {
     expect(await isDaemonResponding(p)).toBe(true);
   });
 
-  it('returns false when the socket accepts but never responds (hung daemon)', async () => {
-    const p = socketPath();
-    await listen(
-      net.createServer((socket) => socket.pause()),
-      p
-    );
-    expect(await isDaemonResponding(p)).toBe(false);
-  }, 5_000);
+  it(
+    'returns false when the socket accepts but never responds (hung daemon)',
+    async () => {
+      const p = socketPath();
+      await listen(
+        net.createServer((socket) => socket.pause()),
+        p
+      );
+      expect(await isDaemonResponding(p)).toBe(false);
+      // isDaemonResponding must give up after its internal probe timeout
+      // (DAEMON_PROBE_TIMEOUT_MS) rather than hang on the paused socket. Derive
+      // the test budget from that constant so it tracks the timeout it exercises.
+    },
+    __daemonHostInternals.DAEMON_PROBE_TIMEOUT_MS * 2 + 1_000
+  );
 
   it('returns false when status reports a different socket (foreign listener)', async () => {
     const p = socketPath();

--- a/tests/daemon.integration.test.ts
+++ b/tests/daemon.integration.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { ensureDistBuilt } from './helpers/dist.js';
+import { budget } from './helpers/timing.js';
 
 const CLI_ENTRY = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
 const testRequire = createRequire(import.meta.url);
@@ -79,14 +80,16 @@ function parseCliJson(output: string): { instanceId: string; count: number } {
 }
 
 describeDaemon('daemon keep-alive integration', () => {
-  it('reuses stdio servers across mcporter invocations', async () => {
-    await ensureDistBuilt(CLI_ENTRY);
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-e2e-'));
-    const scriptPath = path.join(tempDir, 'daemon-server.mjs');
-    const configPath = path.join(tempDir, 'mcporter.daemon.json');
-    const launchLogPath = path.join(tempDir, 'launches.log');
+  it(
+    'reuses stdio servers across mcporter invocations',
+    async () => {
+      await ensureDistBuilt(CLI_ENTRY);
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-e2e-'));
+      const scriptPath = path.join(tempDir, 'daemon-server.mjs');
+      const configPath = path.join(tempDir, 'mcporter.daemon.json');
+      const launchLogPath = path.join(tempDir, 'launches.log');
 
-    const stdioServerSource = `import { randomUUID } from 'node:crypto';
+      const stdioServerSource = `import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import { McpServer } from '${MCP_SERVER_MODULE}';
 import { StdioServerTransport } from '${STDIO_SERVER_MODULE}';
@@ -123,71 +126,75 @@ await new Promise((resolve) => {
 });
 `;
 
-    await fs.writeFile(scriptPath, stdioServerSource, 'utf8');
-    await fs.writeFile(
-      configPath,
-      JSON.stringify(
-        {
-          mcpServers: {
-            'daemon-e2e': {
-              description: 'E2E daemon test server',
-              command: 'node',
-              args: [scriptPath],
-              lifecycle: 'keep-alive',
+      await fs.writeFile(scriptPath, stdioServerSource, 'utf8');
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            mcpServers: {
+              'daemon-e2e': {
+                description: 'E2E daemon test server',
+                command: 'node',
+                args: [scriptPath],
+                lifecycle: 'keep-alive',
+              },
             },
           },
-        },
-        null,
-        2
-      ),
-      'utf8'
-    );
+          null,
+          2
+        ),
+        'utf8'
+      );
 
-    const logPath = path.join(tempDir, 'daemon.log');
-    const cliEnv = {
-      MCPORTER_DAEMON_LOG: '1',
-      MCPORTER_DAEMON_LOG_PATH: logPath,
-      MCPORTER_DAEMON_LOG_SERVERS: 'daemon-e2e',
-      MCPORTER_TEST_LAUNCH_LOG: launchLogPath,
-    };
-    const cli = (args: string[]) => runCli(args, configPath, cliEnv);
+      const logPath = path.join(tempDir, 'daemon.log');
+      const cliEnv = {
+        MCPORTER_DAEMON_LOG: '1',
+        MCPORTER_DAEMON_LOG_PATH: logPath,
+        MCPORTER_DAEMON_LOG_SERVERS: 'daemon-e2e',
+        MCPORTER_TEST_LAUNCH_LOG: launchLogPath,
+      };
+      const cli = (args: string[]) => runCli(args, configPath, cliEnv);
 
-    try {
-      await cli(['daemon', 'stop']);
+      try {
+        await cli(['daemon', 'stop']);
 
-      await cli(['list', 'daemon-e2e', '--json']);
-      await cli(['list', 'daemon-e2e', '--json']);
+        await cli(['list', 'daemon-e2e', '--json']);
+        await cli(['list', 'daemon-e2e', '--json']);
 
-      const first = await cli(['call', 'daemon-e2e.next_value', '--output', 'json']);
-      const firstResult = parseCliJson(first.stdout);
-      expect(firstResult.count).toBe(1);
+        const first = await cli(['call', 'daemon-e2e.next_value', '--output', 'json']);
+        const firstResult = parseCliJson(first.stdout);
+        expect(firstResult.count).toBe(1);
 
-      const second = await cli(['call', 'daemon-e2e.next_value', '--output', 'json']);
-      const secondResult = parseCliJson(second.stdout);
-      expect(secondResult.count).toBe(2);
-      expect(secondResult.instanceId).toBe(firstResult.instanceId);
+        const second = await cli(['call', 'daemon-e2e.next_value', '--output', 'json']);
+        const secondResult = parseCliJson(second.stdout);
+        expect(secondResult.count).toBe(2);
+        expect(secondResult.instanceId).toBe(firstResult.instanceId);
 
-      const launchLog = await readFileWithRetries(launchLogPath);
-      expect(launchLog.trim().split('\n')).toEqual([firstResult.instanceId]);
+        const launchLog = await readFileWithRetries(launchLogPath);
+        expect(launchLog.trim().split('\n')).toEqual([firstResult.instanceId]);
 
-      const logContents = await readFileWithRetries(logPath);
-      expect(logContents).toContain('listTools start server=daemon-e2e');
-      expect(logContents).toContain('listTools success server=daemon-e2e');
-      expect(logContents).toContain('callTool start server=daemon-e2e tool=next_value');
-      expect(logContents).toContain('callTool success server=daemon-e2e tool=next_value');
-    } finally {
-      await cli(['daemon', 'stop']).catch(() => {});
-      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
-    }
-  }, 40_000);
+        const logContents = await readFileWithRetries(logPath);
+        expect(logContents).toContain('listTools start server=daemon-e2e');
+        expect(logContents).toContain('listTools success server=daemon-e2e');
+        expect(logContents).toContain('callTool start server=daemon-e2e tool=next_value');
+        expect(logContents).toContain('callTool success server=daemon-e2e tool=next_value');
+      } finally {
+        await cli(['daemon', 'stop']).catch(() => {});
+        await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      }
+    },
+    budget(40_000)
+  );
 
-  it('refuses duplicate binds when foreground starts race outside the client lock', async () => {
-    await ensureDistBuilt(CLI_ENTRY);
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-bind-'));
-    const scriptPath = path.join(tempDir, 'bind-server.mjs');
-    const configPath = path.join(tempDir, 'mcporter.bind.json');
+  it(
+    'refuses duplicate binds when foreground starts race outside the client lock',
+    async () => {
+      await ensureDistBuilt(CLI_ENTRY);
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-bind-'));
+      const scriptPath = path.join(tempDir, 'bind-server.mjs');
+      const configPath = path.join(tempDir, 'mcporter.bind.json');
 
-    const serverSource = `import { McpServer } from '${MCP_SERVER_MODULE}';
+      const serverSource = `import { McpServer } from '${MCP_SERVER_MODULE}';
 import { StdioServerTransport } from '${STDIO_SERVER_MODULE}';
 const server = new McpServer({ name: 'bind-e2e', version: '1.0.0' });
 server.registerTool('ping', { title: 'ping', description: 'ping', inputSchema: {} }, async () => ({
@@ -196,199 +203,13 @@ server.registerTool('ping', { title: 'ping', description: 'ping', inputSchema: {
 await server.connect(new StdioServerTransport());
 await new Promise(() => {});
 `;
-    await fs.writeFile(scriptPath, serverSource, 'utf8');
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        mcpServers: {
-          'bind-e2e': { description: 'bind race server', command: 'node', args: [scriptPath], lifecycle: 'keep-alive' },
-        },
-      }),
-      'utf8'
-    );
-
-    const children: ChildProcess[] = [];
-    try {
-      await runCli(['daemon', 'stop'], configPath).catch(() => {});
-      for (let i = 0; i < 4; i++) {
-        children.push(
-          spawn(process.execPath, [CLI_ENTRY, '--config', configPath, 'daemon', 'start', '--foreground'], {
-            env: { ...process.env, MCPORTER_NO_FORCE_EXIT: '1' },
-            stdio: 'ignore',
-          })
-        );
-      }
-      await new Promise((resolve) => setTimeout(resolve, 4_000));
-      const alive = children.filter((child) => child.exitCode === null && child.signalCode === null);
-      expect(alive).toHaveLength(1);
-    } finally {
-      for (const child of children) {
-        child.kill('SIGKILL');
-      }
-      await runCli(['daemon', 'stop'], configPath).catch(() => {});
-      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
-    }
-  }, 40_000);
-
-  it('repairs metadata when a live daemon owns the socket and metadata is missing', async () => {
-    await ensureDistBuilt(CLI_ENTRY);
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-meta-'));
-    const scriptPath = path.join(tempDir, 'meta-server.mjs');
-    const configPath = path.join(tempDir, 'mcporter.meta.json');
-    const metadataPath = path.join(tempDir, 'daemon.json');
-
-    const serverSource = `import { McpServer } from '${MCP_SERVER_MODULE}';
-import { StdioServerTransport } from '${STDIO_SERVER_MODULE}';
-const server = new McpServer({ name: 'meta-e2e', version: '1.0.0' });
-server.registerTool('ping', { title: 'ping', description: 'ping', inputSchema: {} }, async () => ({
-  content: [{ type: 'text', text: 'pong' }],
-}));
-await server.connect(new StdioServerTransport());
-await new Promise(() => {});
-`;
-    await fs.writeFile(scriptPath, serverSource, 'utf8');
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        mcpServers: {
-          'meta-e2e': { description: 'meta server', command: 'node', args: [scriptPath], lifecycle: 'keep-alive' },
-        },
-      }),
-      'utf8'
-    );
-
-    // Pin only the metadata path (not the socket, to stay under the unix socket length limit).
-    const env = { ...process.env, MCPORTER_NO_FORCE_EXIT: '1', MCPORTER_DAEMON_METADATA: metadataPath };
-    const children: ChildProcess[] = [];
-    const startForeground = (): ChildProcess => {
-      const child = spawn(process.execPath, [CLI_ENTRY, '--config', configPath, 'daemon', 'start', '--foreground'], {
-        env,
-        stdio: 'ignore',
-      });
-      children.push(child);
-      return child;
-    };
-
-    try {
-      const first = startForeground();
-      const firstPid = JSON.parse(await readFileWithRetries(metadataPath, 50)).pid as number;
-      expect(firstPid).toBe(first.pid);
-
-      await fs.rm(metadataPath, { force: true });
-
-      const replacement = startForeground();
-      await waitForExit(replacement);
-
-      const ownerPid = JSON.parse(await readFileWithRetries(metadataPath, 50)).pid as number;
-      expect(ownerPid).toBe(first.pid);
-      expect(first.exitCode).toBeNull();
-    } finally {
-      for (const child of children) {
-        child.kill('SIGKILL');
-      }
-      await runCli(['daemon', 'stop'], configPath, { MCPORTER_DAEMON_METADATA: metadataPath }).catch(() => {});
-      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
-    }
-  }, 40_000);
-
-  it('stops a live daemon with stale config before rebinding', async () => {
-    await ensureDistBuilt(CLI_ENTRY);
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-stale-'));
-    const scriptPath = path.join(tempDir, 'stale-server.mjs');
-    const configPath = path.join(tempDir, 'mcporter.stale.json');
-    const metadataPath = path.join(tempDir, 'daemon.json');
-
-    const serverSource = `import { McpServer } from '${MCP_SERVER_MODULE}';
-import { StdioServerTransport } from '${STDIO_SERVER_MODULE}';
-const server = new McpServer({ name: 'stale-e2e', version: '1.0.0' });
-server.registerTool('ping', { title: 'ping', description: 'ping', inputSchema: {} }, async () => ({
-  content: [{ type: 'text', text: 'pong' }],
-}));
-await server.connect(new StdioServerTransport());
-await new Promise(() => {});
-`;
-    await fs.writeFile(scriptPath, serverSource, 'utf8');
-    const writeConfig = async (description: string): Promise<void> => {
+      await fs.writeFile(scriptPath, serverSource, 'utf8');
       await fs.writeFile(
         configPath,
         JSON.stringify({
           mcpServers: {
-            'stale-e2e': { description, command: 'node', args: [scriptPath], lifecycle: 'keep-alive' },
-          },
-        }),
-        'utf8'
-      );
-    };
-    await writeConfig('stale server v1');
-
-    const env = { ...process.env, MCPORTER_NO_FORCE_EXIT: '1', MCPORTER_DAEMON_METADATA: metadataPath };
-    const children: ChildProcess[] = [];
-    const startForeground = (): ChildProcess => {
-      const child = spawn(process.execPath, [CLI_ENTRY, '--config', configPath, 'daemon', 'start', '--foreground'], {
-        env,
-        stdio: 'ignore',
-      });
-      children.push(child);
-      return child;
-    };
-
-    try {
-      const first = startForeground();
-      const firstPid = JSON.parse(await readFileWithRetries(metadataPath, 50)).pid as number;
-      expect(firstPid).toBe(first.pid);
-
-      await delay(20);
-      await writeConfig('stale server v2');
-      const staleConfigTime = new Date(Date.now() + 5_000);
-      await fs.utimes(configPath, staleConfigTime, staleConfigTime);
-
-      const replacement = startForeground();
-      await waitForExit(first);
-
-      const ownerPid = JSON.parse(await readFileWithRetries(metadataPath, 50)).pid as number;
-      expect(ownerPid).toBe(replacement.pid);
-      expect(replacement.exitCode).toBeNull();
-    } finally {
-      for (const child of children) {
-        child.kill('SIGKILL');
-      }
-      await runCli(['daemon', 'stop'], configPath, { MCPORTER_DAEMON_METADATA: metadataPath }).catch(() => {});
-      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
-    }
-  }, 40_000);
-
-  it('stops a live daemon when imported root definitions change', async () => {
-    await ensureDistBuilt(CLI_ENTRY);
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-root-'));
-    const scriptPath = path.join(tempDir, 'root-server.mjs');
-    const configPath = path.join(tempDir, 'mcporter.root.json');
-    const metadataPath = path.join(tempDir, 'daemon.json');
-    const socketPath = path.join(tempDir, 'daemon.sock');
-    const rootA = path.join(tempDir, 'root-a');
-    const rootB = path.join(tempDir, 'root-b');
-    const fakeHome = path.join(tempDir, 'home');
-
-    const serverSource = `import { McpServer } from '${MCP_SERVER_MODULE}';
-import { StdioServerTransport } from '${STDIO_SERVER_MODULE}';
-const server = new McpServer({ name: 'root-e2e', version: '1.0.0' });
-server.registerTool('ping', { title: 'ping', description: 'ping', inputSchema: {} }, async () => ({
-  content: [{ type: 'text', text: 'pong' }],
-}));
-await server.connect(new StdioServerTransport());
-await new Promise(() => {});
-`;
-    await fs.writeFile(scriptPath, serverSource, 'utf8');
-    await fs.writeFile(configPath, JSON.stringify({ imports: ['cursor'], mcpServers: {} }), 'utf8');
-
-    const writeCursorImport = async (rootDir: string, name: string): Promise<void> => {
-      const importPath = path.join(rootDir, '.cursor', 'mcp.json');
-      await fs.mkdir(path.dirname(importPath), { recursive: true });
-      await fs.writeFile(
-        importPath,
-        JSON.stringify({
-          mcpServers: {
-            [name]: {
-              description: name,
+            'bind-e2e': {
+              description: 'bind race server',
               command: 'node',
               args: [scriptPath],
               lifecycle: 'keep-alive',
@@ -397,66 +218,273 @@ await new Promise(() => {});
         }),
         'utf8'
       );
-    };
-    await writeCursorImport(rootA, 'root-a-e2e');
-    await writeCursorImport(rootB, 'root-b-e2e');
 
-    const env = {
-      ...process.env,
-      MCPORTER_NO_FORCE_EXIT: '1',
-      MCPORTER_DAEMON_METADATA: metadataPath,
-      MCPORTER_DAEMON_SOCKET: socketPath,
-      MCPORTER_KEEPALIVE: '*',
-      HOME: fakeHome,
-      XDG_CONFIG_HOME: path.join(tempDir, 'xdg'),
-      APPDATA: path.join(tempDir, 'appdata'),
-    };
-    const children: ChildProcess[] = [];
-    const startForeground = (rootDir: string): ChildProcess => {
-      const child = spawn(
-        process.execPath,
-        [CLI_ENTRY, '--config', configPath, '--root', rootDir, 'daemon', 'start', '--foreground'],
-        {
+      const children: ChildProcess[] = [];
+      try {
+        await runCli(['daemon', 'stop'], configPath).catch(() => {});
+        for (let i = 0; i < 4; i++) {
+          children.push(
+            spawn(process.execPath, [CLI_ENTRY, '--config', configPath, 'daemon', 'start', '--foreground'], {
+              env: { ...process.env, MCPORTER_NO_FORCE_EXIT: '1' },
+              stdio: 'ignore',
+            })
+          );
+        }
+        // Give the racing foreground starts time to settle so exactly one wins the
+        // bind; a hang-catcher, so scale for slow platforms.
+        await new Promise((resolve) => setTimeout(resolve, budget(4_000)));
+        const alive = children.filter((child) => child.exitCode === null && child.signalCode === null);
+        expect(alive).toHaveLength(1);
+      } finally {
+        for (const child of children) {
+          child.kill('SIGKILL');
+        }
+        await runCli(['daemon', 'stop'], configPath).catch(() => {});
+        await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      }
+    },
+    budget(40_000)
+  );
+
+  it(
+    'repairs metadata when a live daemon owns the socket and metadata is missing',
+    async () => {
+      await ensureDistBuilt(CLI_ENTRY);
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-meta-'));
+      const scriptPath = path.join(tempDir, 'meta-server.mjs');
+      const configPath = path.join(tempDir, 'mcporter.meta.json');
+      const metadataPath = path.join(tempDir, 'daemon.json');
+
+      const serverSource = `import { McpServer } from '${MCP_SERVER_MODULE}';
+import { StdioServerTransport } from '${STDIO_SERVER_MODULE}';
+const server = new McpServer({ name: 'meta-e2e', version: '1.0.0' });
+server.registerTool('ping', { title: 'ping', description: 'ping', inputSchema: {} }, async () => ({
+  content: [{ type: 'text', text: 'pong' }],
+}));
+await server.connect(new StdioServerTransport());
+await new Promise(() => {});
+`;
+      await fs.writeFile(scriptPath, serverSource, 'utf8');
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          mcpServers: {
+            'meta-e2e': { description: 'meta server', command: 'node', args: [scriptPath], lifecycle: 'keep-alive' },
+          },
+        }),
+        'utf8'
+      );
+
+      // Pin only the metadata path (not the socket, to stay under the unix socket length limit).
+      const env = { ...process.env, MCPORTER_NO_FORCE_EXIT: '1', MCPORTER_DAEMON_METADATA: metadataPath };
+      const children: ChildProcess[] = [];
+      const startForeground = (): ChildProcess => {
+        const child = spawn(process.execPath, [CLI_ENTRY, '--config', configPath, 'daemon', 'start', '--foreground'], {
           env,
           stdio: 'ignore',
+        });
+        children.push(child);
+        return child;
+      };
+
+      try {
+        const first = startForeground();
+        const firstPid = JSON.parse(await readFileWithRetries(metadataPath, 50)).pid as number;
+        expect(firstPid).toBe(first.pid);
+
+        await fs.rm(metadataPath, { force: true });
+
+        const replacement = startForeground();
+        await waitForExit(replacement);
+
+        const ownerPid = JSON.parse(await readFileWithRetries(metadataPath, 50)).pid as number;
+        expect(ownerPid).toBe(first.pid);
+        expect(first.exitCode).toBeNull();
+      } finally {
+        for (const child of children) {
+          child.kill('SIGKILL');
         }
-      );
-      children.push(child);
-      return child;
-    };
-
-    try {
-      const first = startForeground(rootA);
-      const firstMetadata = JSON.parse(await readFileWithRetries(metadataPath, 50)) as {
-        pid: number;
-        definitionHash?: string;
-      };
-      expect(firstMetadata.pid).toBe(first.pid);
-      expect(typeof firstMetadata.definitionHash).toBe('string');
-
-      const replacement = startForeground(rootB);
-      await waitForExit(first);
-
-      const replacementMetadata = JSON.parse(await readFileWithRetries(metadataPath, 50)) as {
-        pid: number;
-        definitionHash?: string;
-      };
-      expect(replacementMetadata.pid).toBe(replacement.pid);
-      expect(replacementMetadata.definitionHash).not.toBe(firstMetadata.definitionHash);
-      expect(replacement.exitCode).toBeNull();
-    } finally {
-      for (const child of children) {
-        child.kill('SIGKILL');
+        await runCli(['daemon', 'stop'], configPath, { MCPORTER_DAEMON_METADATA: metadataPath }).catch(() => {});
+        await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
       }
-      await runCli(['daemon', 'stop'], configPath, {
+    },
+    budget(40_000)
+  );
+
+  it(
+    'stops a live daemon with stale config before rebinding',
+    async () => {
+      await ensureDistBuilt(CLI_ENTRY);
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-stale-'));
+      const scriptPath = path.join(tempDir, 'stale-server.mjs');
+      const configPath = path.join(tempDir, 'mcporter.stale.json');
+      const metadataPath = path.join(tempDir, 'daemon.json');
+
+      const serverSource = `import { McpServer } from '${MCP_SERVER_MODULE}';
+import { StdioServerTransport } from '${STDIO_SERVER_MODULE}';
+const server = new McpServer({ name: 'stale-e2e', version: '1.0.0' });
+server.registerTool('ping', { title: 'ping', description: 'ping', inputSchema: {} }, async () => ({
+  content: [{ type: 'text', text: 'pong' }],
+}));
+await server.connect(new StdioServerTransport());
+await new Promise(() => {});
+`;
+      await fs.writeFile(scriptPath, serverSource, 'utf8');
+      const writeConfig = async (description: string): Promise<void> => {
+        await fs.writeFile(
+          configPath,
+          JSON.stringify({
+            mcpServers: {
+              'stale-e2e': { description, command: 'node', args: [scriptPath], lifecycle: 'keep-alive' },
+            },
+          }),
+          'utf8'
+        );
+      };
+      await writeConfig('stale server v1');
+
+      const env = { ...process.env, MCPORTER_NO_FORCE_EXIT: '1', MCPORTER_DAEMON_METADATA: metadataPath };
+      const children: ChildProcess[] = [];
+      const startForeground = (): ChildProcess => {
+        const child = spawn(process.execPath, [CLI_ENTRY, '--config', configPath, 'daemon', 'start', '--foreground'], {
+          env,
+          stdio: 'ignore',
+        });
+        children.push(child);
+        return child;
+      };
+
+      try {
+        const first = startForeground();
+        const firstPid = JSON.parse(await readFileWithRetries(metadataPath, 50)).pid as number;
+        expect(firstPid).toBe(first.pid);
+
+        await delay(20);
+        await writeConfig('stale server v2');
+        const staleConfigTime = new Date(Date.now() + 5_000);
+        await fs.utimes(configPath, staleConfigTime, staleConfigTime);
+
+        const replacement = startForeground();
+        await waitForExit(first);
+
+        const ownerPid = JSON.parse(await readFileWithRetries(metadataPath, 50)).pid as number;
+        expect(ownerPid).toBe(replacement.pid);
+        expect(replacement.exitCode).toBeNull();
+      } finally {
+        for (const child of children) {
+          child.kill('SIGKILL');
+        }
+        await runCli(['daemon', 'stop'], configPath, { MCPORTER_DAEMON_METADATA: metadataPath }).catch(() => {});
+        await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      }
+    },
+    budget(40_000)
+  );
+
+  it(
+    'stops a live daemon when imported root definitions change',
+    async () => {
+      await ensureDistBuilt(CLI_ENTRY);
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-root-'));
+      const scriptPath = path.join(tempDir, 'root-server.mjs');
+      const configPath = path.join(tempDir, 'mcporter.root.json');
+      const metadataPath = path.join(tempDir, 'daemon.json');
+      const socketPath = path.join(tempDir, 'daemon.sock');
+      const rootA = path.join(tempDir, 'root-a');
+      const rootB = path.join(tempDir, 'root-b');
+      const fakeHome = path.join(tempDir, 'home');
+
+      const serverSource = `import { McpServer } from '${MCP_SERVER_MODULE}';
+import { StdioServerTransport } from '${STDIO_SERVER_MODULE}';
+const server = new McpServer({ name: 'root-e2e', version: '1.0.0' });
+server.registerTool('ping', { title: 'ping', description: 'ping', inputSchema: {} }, async () => ({
+  content: [{ type: 'text', text: 'pong' }],
+}));
+await server.connect(new StdioServerTransport());
+await new Promise(() => {});
+`;
+      await fs.writeFile(scriptPath, serverSource, 'utf8');
+      await fs.writeFile(configPath, JSON.stringify({ imports: ['cursor'], mcpServers: {} }), 'utf8');
+
+      const writeCursorImport = async (rootDir: string, name: string): Promise<void> => {
+        const importPath = path.join(rootDir, '.cursor', 'mcp.json');
+        await fs.mkdir(path.dirname(importPath), { recursive: true });
+        await fs.writeFile(
+          importPath,
+          JSON.stringify({
+            mcpServers: {
+              [name]: {
+                description: name,
+                command: 'node',
+                args: [scriptPath],
+                lifecycle: 'keep-alive',
+              },
+            },
+          }),
+          'utf8'
+        );
+      };
+      await writeCursorImport(rootA, 'root-a-e2e');
+      await writeCursorImport(rootB, 'root-b-e2e');
+
+      const env = {
+        ...process.env,
+        MCPORTER_NO_FORCE_EXIT: '1',
         MCPORTER_DAEMON_METADATA: metadataPath,
         MCPORTER_DAEMON_SOCKET: socketPath,
         MCPORTER_KEEPALIVE: '*',
         HOME: fakeHome,
         XDG_CONFIG_HOME: path.join(tempDir, 'xdg'),
         APPDATA: path.join(tempDir, 'appdata'),
-      }).catch(() => {});
-      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
-    }
-  }, 40_000);
+      };
+      const children: ChildProcess[] = [];
+      const startForeground = (rootDir: string): ChildProcess => {
+        const child = spawn(
+          process.execPath,
+          [CLI_ENTRY, '--config', configPath, '--root', rootDir, 'daemon', 'start', '--foreground'],
+          {
+            env,
+            stdio: 'ignore',
+          }
+        );
+        children.push(child);
+        return child;
+      };
+
+      try {
+        const first = startForeground(rootA);
+        const firstMetadata = JSON.parse(await readFileWithRetries(metadataPath, 50)) as {
+          pid: number;
+          definitionHash?: string;
+        };
+        expect(firstMetadata.pid).toBe(first.pid);
+        expect(typeof firstMetadata.definitionHash).toBe('string');
+
+        const replacement = startForeground(rootB);
+        await waitForExit(first);
+
+        const replacementMetadata = JSON.parse(await readFileWithRetries(metadataPath, 50)) as {
+          pid: number;
+          definitionHash?: string;
+        };
+        expect(replacementMetadata.pid).toBe(replacement.pid);
+        expect(replacementMetadata.definitionHash).not.toBe(firstMetadata.definitionHash);
+        expect(replacement.exitCode).toBeNull();
+      } finally {
+        for (const child of children) {
+          child.kill('SIGKILL');
+        }
+        await runCli(['daemon', 'stop'], configPath, {
+          MCPORTER_DAEMON_METADATA: metadataPath,
+          MCPORTER_DAEMON_SOCKET: socketPath,
+          MCPORTER_KEEPALIVE: '*',
+          HOME: fakeHome,
+          XDG_CONFIG_HOME: path.join(tempDir, 'xdg'),
+          APPDATA: path.join(tempDir, 'appdata'),
+        }).catch(() => {});
+        await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      }
+    },
+    budget(40_000)
+  );
 });

--- a/tests/e2e-fixture-servers.test.ts
+++ b/tests/e2e-fixture-servers.test.ts
@@ -14,13 +14,12 @@ import type { ServerDefinition } from '../src/config.js';
 import { waitForChildExit } from '../src/process-utils.js';
 import { createRuntime } from '../src/runtime.js';
 import { makeShortTempDir } from './fixtures/test-helpers.js';
+import { budget } from './helpers/timing.js';
 
 // These tests spawn the real CLI repeatedly, and Windows pays a far higher
 // process-startup cost: the same suite runs ~25s locally and ~100s on a Windows
-// runner. Scale the per-test budgets rather than tuning them one flake at a
-// time — they exist to catch hangs, not to measure machine speed.
-const CI_SLOWDOWN = process.platform === 'win32' ? 3 : 1;
-const budget = (ms: number): number => ms * CI_SLOWDOWN;
+// runner. The per-test budgets use the shared `budget()` helper, which scales
+// by platform — they exist to catch hangs, not to measure machine speed.
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 const CLI_ENTRY = path.join(REPO_ROOT, 'dist', 'cli.js');
@@ -205,7 +204,9 @@ it(
 
       try {
         await client.callTool({ name: 'toggle_tool', arguments: {} });
-        await expect.poll(() => toolListChanges, { timeout: 2_000 }).toBeGreaterThan(0);
+        // Guards against a dropped list_changed notification; the poll fails if
+        // the notification never arrives, so scale the wait for slow platforms.
+        await expect.poll(() => toolListChanges, { timeout: budget(2_000) }).toBeGreaterThan(0);
         const refreshed = await client.listTools(undefined, { cacheMode: 'refresh' });
         expect(refreshed).toMatchObject({ ttlMs: 1_000, cacheScope: 'private' });
         expect(refreshed.tools.some((tool) => tool.name === 'runtime_tool')).toBe(!initiallyEnabled);
@@ -371,7 +372,7 @@ async function runCli(args: string[], configPath: string, env: NodeJS.ProcessEnv
     execFile(
       process.execPath,
       [CLI_ENTRY, '--config', configPath, ...args],
-      { cwd: REPO_ROOT, env, timeout: 20_000, maxBuffer: 5 * 1024 * 1024 },
+      { cwd: REPO_ROOT, env, timeout: budget(20_000), maxBuffer: 5 * 1024 * 1024 },
       (error, stdout, stderr) => {
         const code = error && typeof error.code === 'number' ? error.code : error ? 1 : 0;
         resolve({ stdout, stderr, exitCode: code });
@@ -387,7 +388,7 @@ function parseJson<T = Record<string, unknown>>(value: string): T {
 async function startHttpFixture(
   fixture: FixtureKind,
   serverPath: string,
-  readyTimeoutMs = 10_000
+  readyTimeoutMs = budget(10_000)
 ): Promise<RunningFixture> {
   const child = trackChild(
     spawn(process.execPath, [TSX_CLI, serverPath, '--http', '0'], {
@@ -437,7 +438,10 @@ async function startBridge(configPath: string, env: NodeJS.ProcessEnv): Promise<
   let captured = '';
   try {
     const url = await new Promise<string>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error(`mcporter serve did not become ready:\n${captured}`)), 15_000);
+      const timer = setTimeout(
+        () => reject(new Error(`mcporter serve did not become ready:\n${captured}`)),
+        budget(15_000)
+      );
       child.stderr?.on('data', (chunk: string) => {
         captured += chunk;
         const match = captured.match(/bridge (http:\/\/127\.0\.0\.1:\d+\/mcp)/);
@@ -467,10 +471,10 @@ async function stopChild(child: ChildProcess | undefined): Promise<void> {
   if (!child || child.exitCode !== null || child.signalCode !== null) return;
   child.kill('SIGTERM');
   try {
-    await waitForChildExit(child, 2_000);
+    await waitForChildExit(child, budget(2_000));
   } catch {
     child.kill('SIGKILL');
-    await waitForChildExit(child, 2_000).catch(() => {});
+    await waitForChildExit(child, budget(2_000)).catch(() => {});
   }
 }
 

--- a/tests/helpers/timing.ts
+++ b/tests/helpers/timing.ts
@@ -1,0 +1,17 @@
+// Shared platform scaling for test timing budgets.
+//
+// Windows CI runners are roughly 3-4x slower than macOS/Linux for this suite
+// (the same tests run ~25s locally and ~100s on a Windows runner), mostly due
+// to process-spawn and process-tree enumeration cost. Budgets that exist to
+// catch hangs — rather than to measure machine speed — should be expressed via
+// `budget()` so they scale by platform instead of being tuned one flake at a
+// time. Assertions that genuinely police real-time behavior (e.g. "close
+// settles promptly") should NOT use this helper; keep those fixed and document
+// them as real-time checks.
+export const CI_SLOWDOWN = process.platform === 'win32' ? 3 : 1;
+
+// Scale a millisecond budget that guards against hangs, so slow platforms get
+// proportionally more headroom. Pass the value you would use on a fast machine.
+export function budget(ms: number): number {
+  return ms * CI_SLOWDOWN;
+}

--- a/tests/record-replay.test.ts
+++ b/tests/record-replay.test.ts
@@ -12,6 +12,7 @@ import type { ServerDefinition } from '../src/config.js';
 import { createRuntime, MCPORTER_VERSION } from '../src/runtime.js';
 import { RecordTransport, type RecordedMessage } from '../src/runtime/record-transport.js';
 import { ReplayTransport } from '../src/runtime/replay-transport.js';
+import { budget } from './helpers/timing.js';
 
 const TSX_CLI = createRequire(import.meta.url).resolve('tsx/cli');
 const MODERN_FIXTURE = fileURLToPath(new URL('./servers/modern/server.ts', import.meta.url));
@@ -577,65 +578,69 @@ describe('record/replay transports', () => {
     }
   });
 
-  it('replays an accepted modern MRTR recording with the caller elicitation handler', async () => {
-    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-replay-mrtr-'));
-    const session = 'accepted-mrtr';
-    const definition: ServerDefinition = {
-      name: 'modern',
-      command: {
-        kind: 'stdio',
-        command: process.execPath,
-        args: [TSX_CLI, MODERN_FIXTURE, '--stdio'],
-        cwd: process.cwd(),
-      },
-      source: { kind: 'local', path: MODERN_FIXTURE },
-    };
-    const acceptingHandler = vi.fn(async () => ({
-      action: 'accept' as const,
-      content: { confirm: true },
-    }));
-    const originalEnvironment = {
-      HOME: process.env.HOME,
-      USERPROFILE: process.env.USERPROFILE,
-      MCPORTER_RECORD: process.env.MCPORTER_RECORD,
-      MCPORTER_REPLAY: process.env.MCPORTER_REPLAY,
-    };
+  it(
+    'replays an accepted modern MRTR recording with the caller elicitation handler',
+    async () => {
+      const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-replay-mrtr-'));
+      const session = 'accepted-mrtr';
+      const definition: ServerDefinition = {
+        name: 'modern',
+        command: {
+          kind: 'stdio',
+          command: process.execPath,
+          args: [TSX_CLI, MODERN_FIXTURE, '--stdio'],
+          cwd: process.cwd(),
+        },
+        source: { kind: 'local', path: MODERN_FIXTURE },
+      };
+      const acceptingHandler = vi.fn(async () => ({
+        action: 'accept' as const,
+        content: { confirm: true },
+      }));
+      const originalEnvironment = {
+        HOME: process.env.HOME,
+        USERPROFILE: process.env.USERPROFILE,
+        MCPORTER_RECORD: process.env.MCPORTER_RECORD,
+        MCPORTER_REPLAY: process.env.MCPORTER_REPLAY,
+      };
 
-    process.env.HOME = tempHome;
-    process.env.USERPROFILE = tempHome;
-    process.env.MCPORTER_RECORD = session;
-    delete process.env.MCPORTER_REPLAY;
+      process.env.HOME = tempHome;
+      process.env.USERPROFILE = tempHome;
+      process.env.MCPORTER_RECORD = session;
+      delete process.env.MCPORTER_REPLAY;
 
-    try {
-      const recordingRuntime = await createRuntime({ servers: [definition], elicitationHandler: acceptingHandler });
       try {
-        await expect(
-          recordingRuntime.callTool('modern', 'confirm_delete', { args: { target: 'recorded-item' } })
-        ).resolves.toMatchObject({ content: [{ type: 'text', text: 'deleted recorded-item' }] });
-      } finally {
-        await recordingRuntime.close();
-      }
+        const recordingRuntime = await createRuntime({ servers: [definition], elicitationHandler: acceptingHandler });
+        try {
+          await expect(
+            recordingRuntime.callTool('modern', 'confirm_delete', { args: { target: 'recorded-item' } })
+          ).resolves.toMatchObject({ content: [{ type: 'text', text: 'deleted recorded-item' }] });
+        } finally {
+          await recordingRuntime.close();
+        }
 
-      delete process.env.MCPORTER_RECORD;
-      process.env.MCPORTER_REPLAY = session;
-      const replayRuntime = await createRuntime({ servers: [definition], elicitationHandler: acceptingHandler });
-      try {
-        await expect(
-          replayRuntime.callTool('modern', 'confirm_delete', { args: { target: 'recorded-item' } })
-        ).resolves.toMatchObject({ content: [{ type: 'text', text: 'deleted recorded-item' }] });
-      } finally {
-        await replayRuntime.close();
-      }
+        delete process.env.MCPORTER_RECORD;
+        process.env.MCPORTER_REPLAY = session;
+        const replayRuntime = await createRuntime({ servers: [definition], elicitationHandler: acceptingHandler });
+        try {
+          await expect(
+            replayRuntime.callTool('modern', 'confirm_delete', { args: { target: 'recorded-item' } })
+          ).resolves.toMatchObject({ content: [{ type: 'text', text: 'deleted recorded-item' }] });
+        } finally {
+          await replayRuntime.close();
+        }
 
-      expect(acceptingHandler).toHaveBeenCalledTimes(2);
-    } finally {
-      for (const [key, value] of Object.entries(originalEnvironment)) {
-        if (value === undefined) delete process.env[key];
-        else process.env[key] = value;
+        expect(acceptingHandler).toHaveBeenCalledTimes(2);
+      } finally {
+        for (const [key, value] of Object.entries(originalEnvironment)) {
+          if (value === undefined) delete process.env[key];
+          else process.env[key] = value;
+        }
+        await fs.rm(tempHome, { recursive: true, force: true });
       }
-      await fs.rm(tempHome, { recursive: true, force: true });
-    }
-  }, 15_000);
+    },
+    budget(15_000)
+  );
 
   it('keeps multi-server streams separated by metadata server', async () => {
     const recordPath = await writeRecording([

--- a/tests/runtime-transport.test.ts
+++ b/tests/runtime-transport.test.ts
@@ -44,6 +44,7 @@ import type { ServerDefinition } from '../src/config.js';
 import * as oauthModule from '../src/oauth.js';
 import { markOAuthFlowError, markPostAuthConnectError } from '../src/runtime/oauth.js';
 import { createClientContext } from '../src/runtime/transport.js';
+import { budget } from './helpers/timing.js';
 import {
   clientInfo,
   createLogger,
@@ -728,25 +729,29 @@ describe('createClientContext (stdio negotiation)', () => {
     }
   });
 
-  it('waits longer than three seconds for a slow modern discovery response', async () => {
-    const baseDefinition = stdioDefinition('modern');
-    if (baseDefinition.command.kind !== 'stdio') throw new Error('Expected stdio fixture definition.');
-    const definition: ServerDefinition = {
-      ...baseDefinition,
-      command: {
-        ...baseDefinition.command,
-        args: [...(baseDefinition.command.args ?? []), '3200'],
-      },
-    };
+  it(
+    'waits longer than three seconds for a slow modern discovery response',
+    async () => {
+      const baseDefinition = stdioDefinition('modern');
+      if (baseDefinition.command.kind !== 'stdio') throw new Error('Expected stdio fixture definition.');
+      const definition: ServerDefinition = {
+        ...baseDefinition,
+        command: {
+          ...baseDefinition.command,
+          args: [...(baseDefinition.command.args ?? []), '3200'],
+        },
+      };
 
-    const context = await createClientContext(definition, logger, clientInfo);
-    try {
-      expect(context.client.getProtocolEra()).toBe('modern');
-      await expect(context.client.listTools()).resolves.toMatchObject({
-        tools: [expect.objectContaining({ name: 'modern_ping' })],
-      });
-    } finally {
-      await context.client.close();
-    }
-  }, 10_000);
+      const context = await createClientContext(definition, logger, clientInfo);
+      try {
+        expect(context.client.getProtocolEra()).toBe('modern');
+        await expect(context.client.listTools()).resolves.toMatchObject({
+          tools: [expect.objectContaining({ name: 'modern_ping' })],
+        });
+      } finally {
+        await context.client.close();
+      }
+    },
+    budget(10_000)
+  );
 });

--- a/tests/serve.test.ts
+++ b/tests/serve.test.ts
@@ -381,6 +381,11 @@ describe('mcporter serve bridge', () => {
         closePromise.then(() => true),
         new Promise<false>((resolve) => setTimeout(() => resolve(false), 750)),
       ]);
+      // This is a genuine real-time performance assertion, not a hang-catcher:
+      // server.close() must release active SSE listen streams and settle promptly
+      // rather than waiting out a request timeout. Deliberately NOT scaled by
+      // platform — closing an in-process HTTP server has no per-platform cost, so
+      // a fixed bound keeps the check meaningful everywhere.
       expect(closedPromptly).toBe(true);
     } finally {
       await subscription?.close().catch(() => {});

--- a/tests/stdio-servers.integration.test.ts
+++ b/tests/stdio-servers.integration.test.ts
@@ -6,6 +6,7 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { ensureDistBuilt } from './helpers/dist.js';
+import { budget } from './helpers/timing.js';
 
 const CLI_ENTRY = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
 
@@ -72,22 +73,26 @@ describe('stdio MCP servers (filesystem + memory)', () => {
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
   });
 
-  it('lists filesystem tools and reads files via stdio MCP', async () => {
-    const listResult = await runCli(['list', 'fs-test'], configPath);
-    expect(listResult.stdout).toContain('Filesystem MCP for stdio e2e tests');
-    const callResult = await runCli(
-      [
-        'call',
-        'fs-test.read_text_file',
-        '--output',
-        'json',
-        '--args',
-        JSON.stringify({ path: path.join(fsRoot, 'hello.txt') }),
-      ],
-      configPath
-    );
-    expect(callResult.stdout).toContain('hello from stdio mcp');
-  }, 20000);
+  it(
+    'lists filesystem tools and reads files via stdio MCP',
+    async () => {
+      const listResult = await runCli(['list', 'fs-test'], configPath);
+      expect(listResult.stdout).toContain('Filesystem MCP for stdio e2e tests');
+      const callResult = await runCli(
+        [
+          'call',
+          'fs-test.read_text_file',
+          '--output',
+          'json',
+          '--args',
+          JSON.stringify({ path: path.join(fsRoot, 'hello.txt') }),
+        ],
+        configPath
+      );
+      expect(callResult.stdout).toContain('hello from stdio mcp');
+    },
+    budget(20_000)
+  );
 
   const memoryTest = process.platform === 'win32' ? it.skip : it;
 


### PR DESCRIPTION
## Why

Windows CI runners run this suite ~3–4x slower than macOS/Linux (~25s locally, ~100s on a Windows runner), and several tests were calibrated with flat millisecond budgets on fast machines. After three Windows-only flakes surfaced in one session (`runtime-stdio-close`, `e2e-fixture-servers`, `runtime-inflight-close`), this does a systematic pass instead of tuning one flake at a time.

## What

Every hardcoded millisecond timeout / timing assertion in the suite was classified into one of three buckets and handled accordingly:

- **Shared helper** — new `tests/helpers/timing.ts` exports `CI_SLOWDOWN` (3× on Windows, 1× elsewhere) and `budget(ms)`. This is for *hang-catcher* budgets that exist to fail fast on a hang, not to measure machine speed. The helper's doc comment says so explicitly.
- **Derived from the real budget** — bounds now track the source constant they police:
  - The force-exit flush deadline `STDOUT_FLUSH_TIMEOUT_MS` was moved from `cli.ts` into the leaf module `cli/timeouts.ts` (and re-exported), so the truncation test imports it without triggering the CLI's auto-run-on-import.
  - The daemon liveness probe `DAEMON_PROBE_TIMEOUT_MS` is exposed via `__daemonHostInternals` and the hung-daemon test derives its budget from it.
  - The e2e `stopChild` teardown waits and readiness guards scale via `budget()`.
- **Hang-catchers scaled** — spawn-heavy per-test budgets and readiness guards across the e2e, daemon, and CLI integration suites now use `budget()`.
- **Genuine perf assertions kept fixed** — `serve.test.ts`'s 750ms close-promptness check and the in-flight close deadline stay fixed (closing an in-process HTTP server has no per-platform cost) and are documented as such.

## Proof

- The two non-trivial relaxed bounds were **mutation-checked**: breaking the force-exit fallback and breaking the daemon probe timeout each still fails the corresponding test, so the relaxed assertions retain their teeth.
- 134 tests across the 12 affected files pass locally; typecheck, oxlint, and oxfmt are clean.
- autoreview (codex, gpt-5.6-sol, high) clean; TruffleHog clean.

The formatting churn in the diff (e.g. `daemon.integration.test.ts`) is `oxfmt`'s mandated multiline `it(name, fn, timeout)` form whenever a trailing timeout arg is present — same reflow the earlier `f0bd0d8` commit accepted.

## Follow-up

Only a Windows CI run confirms the 3× factor is right. If it still flakes there, bump `CI_SLOWDOWN` rather than individual budgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
