### PR TITLE
test(release): cover default runner path

### DIFF
--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -302,11 +302,12 @@ assert_fails env \
   "$ROOT/scripts/package-release.sh" "$TAG"
 [[ ! -e "$rejected_out" ]] || fail 'rejected notarization published release output'
 
-# The happy path exercises dual builds, signing/notary calls, packaging, provenance,
-# basename-only checksums, and the token-free exact-inventory verifier.
+# The happy path exercises the packager's default runner path, dual builds,
+# signing/notary calls, packaging, provenance, basename-only checksums, and the
+# token-free exact-inventory verifier.
 : >"$MOCK_LOG"
 release_out="$WORK/release-output"
-MCP_RUNNER=env \
+env -u MCP_RUNNER \
   MCPORTER_RELEASE_OUT_DIR="$release_out" \
   MAC_RELEASE_CODESIGN_IDENTITY="$EXPECTED_IDENTITY" \
   NOTARYTOOL_KEYCHAIN_PROFILE=mock-profile \


### PR DESCRIPTION
## Summary

- exercise the release packager happy path with MCP_RUNNER explicitly unset
- retain the override-based failure cases for fast, hermetic setup
- make a stale or missing default runner fail the release contract suite

## Proof

- ./scripts/test-release.sh
- mutation check: changed the default runner to a nonexistent path and confirmed the release contract test failed with exit 127
- pnpm check
- pnpm test
- autoreview clean with Codex gpt-5.6-sol
