### PR TITLE
fix(ci): resolve the default branch before the ancestry check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,11 @@ jobs:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin "$DEFAULT_BRANCH" --depth=1
+          # Fetch the default branch into its remote-tracking ref with full history:
+          # this job checks out the tag, so origin/<branch> does not otherwise exist,
+          # and --depth=1 cannot answer the ancestry question below.
+          git fetch --no-tags origin \
+            "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"
           release_sha="$(git rev-parse "$RELEASE_TAG^{commit}")"
           package_version="$(node -p "require('./package.json').version")"
           expected_tag="v$package_version"


### PR DESCRIPTION
The v0.13.0 release reached npm publication and failed the tag guard:

```
##[error]Tagged commit 49dcd3e7fffd5270b2dfcb554c3a0236fc8fe9fe is not contained in origin/main.
```

The commit is plainly on `main` — the guard couldn't see it. Two compounding causes in one line:

1. The job checks out `ref: <tag>`, so `refs/remotes/origin/main` never exists in that checkout.
2. It fetched the branch as `git fetch --no-tags origin "$DEFAULT_BRANCH" --depth=1`, which lands in `FETCH_HEAD` without creating the tracking ref — and a depth-1 fetch could not answer an ancestry question even if the ref did exist.

Now fetched as `+refs/heads/<branch>:refs/remotes/origin/<branch>` with full history, which is what `git merge-base --is-ancestor` actually requires.

The guard behaved correctly in the sense that mattered: it failed **before** publication, so nothing was half-released — npm is still on 0.12.4 and the published GitHub Release with its verified assets is untouched. Per `docs/RELEASE.md`, recovery is a manual **Release** dispatch with the same tag, which repeats every tag, main, native-proof, source-gate, npm and Homebrew check.

Verified with `actionlint` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
