### PR TITLE
docs(changelog): open 0.13.1 after the 0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # mcporter Changelog
 
+## [0.13.1] - Unreleased
+
 ## [0.13.0] - 2026-08-02
 
 ### MCP 2.0


### PR DESCRIPTION
Post-release closeout: 0.13.0 is published on npm, GitHub, and Homebrew, so this opens the next `Unreleased` section per the release checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
