### PR TITLE
fix(daemon,serve): handle log WriteStream and HTTP body stream errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 ### CLI
 
 - Authenticate OpenClaw extension-backed Chrome control with Browser Relay Authentication v2 over one retained loopback socket from HMAC challenge through CDP upgrade, never transmitting the host key or retrying legacy relay auth, while preserving configurable `prefer` / `require` / `off` routing and the OS-protected one-use child handoff.
+- Tear down both sides of streamed `mcporter serve --http` responses on client aborts or body errors, preventing orphaned readers. (PR #280, thanks @SebTardif)
 
 ### Daemon
 
 - Invalidate keep-alive Chrome DevTools state when relay policy, URL, timeout, OpenClaw credential paths, or the derived relay `keyId` change, keep `require` fail-closed across retries, and expose the last safe relay decision in `mcporter daemon status`.
+- Keep the daemon alive after asynchronous log-file ENOSPC/EIO failures by handling writer errors immediately and falling back to console logging. (PR #280, thanks @SebTardif)
 
 ### OAuth
 

--- a/src/daemon/log-context.ts
+++ b/src/daemon/log-context.ts
@@ -23,9 +23,18 @@ export function createLogContext(options: {
   if (derivedEnabled && options.logPath) {
     try {
       fsSync.mkdirSync(path.dirname(options.logPath), { recursive: true });
-      context.writer = fsSync.createWriteStream(options.logPath, {
+      const writer = fsSync.createWriteStream(options.logPath, {
         flags: 'a',
       });
+      // Attach before any write: a long-lived WriteStream with no error
+      // listener turns ENOSPC/EIO into an uncaughtException and kills the daemon.
+      writer.on('error', (error) => {
+        console.warn(`[daemon] Log file write error (${options.logPath}): ${error.message}`);
+        if (context.writer === writer) {
+          context.writer = undefined;
+        }
+      });
+      context.writer = writer;
     } catch (error) {
       console.warn(`[daemon] Failed to open log file ${options.logPath}: ${(error as Error).message}`);
     }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -245,12 +245,8 @@ export async function pipeHttpResponseBody(body: Readable, response: http.Server
   try {
     await pipeline(body, response);
   } catch {
-    if (!response.destroyed) {
-      response.destroy();
-    }
-    if (!body.destroyed) {
-      body.destroy();
-    }
+    // pipeline owns teardown for both streams; disconnects and body failures
+    // are terminal for this response and should not become a second 500 write.
   }
 }
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1,5 +1,6 @@
 import http from 'node:http';
 import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import {
   createMcpHandler,
   McpServer,
@@ -232,8 +233,25 @@ async function handleNodeRequest(
     return;
   }
   const body = Readable.fromWeb(webResponse.body as never);
-  body.on('error', (error) => response.destroy(error));
-  body.pipe(response);
+  await pipeHttpResponseBody(body, response);
+}
+
+/**
+ * Pipe an MCP response body into a Node HTTP response with bidirectional
+ * error cleanup. Client abort must destroy the body; body failure must
+ * destroy the response. Bare `body.pipe(response)` only handles one direction.
+ */
+export async function pipeHttpResponseBody(body: Readable, response: http.ServerResponse): Promise<void> {
+  try {
+    await pipeline(body, response);
+  } catch {
+    if (!response.destroyed) {
+      response.destroy();
+    }
+    if (!body.destroyed) {
+      body.destroy();
+    }
+  }
 }
 
 function toWebRequest(request: http.IncomingMessage): Request {

--- a/tests/daemon-log-context.test.ts
+++ b/tests/daemon-log-context.test.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createLogContext, disposeLogContext, logEvent } from '../src/daemon/log-context.js';
+
+describe('daemon log context stream safety', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      tempDir = undefined;
+    }
+  });
+
+  it('attaches an error listener when opening the daemon log WriteStream', async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-log-context-'));
+    const logPath = path.join(tempDir, 'daemon.log');
+    const context = createLogContext({
+      enabled: true,
+      logAllServers: true,
+      servers: new Set(),
+      logPath,
+    });
+
+    expect(context.writer).toBeDefined();
+    // Without an early error listener, ENOSPC / EIO on the long-lived stream
+    // becomes an uncaughtException and takes down the daemon.
+    expect(context.writer!.listenerCount('error')).toBeGreaterThan(0);
+
+    await disposeLogContext(context);
+  });
+
+  it('swallows log stream errors without uncaughtException and stops writing', async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-log-context-'));
+    const logPath = path.join(tempDir, 'daemon.log');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const uncaught: Error[] = [];
+    const onUncaught = (error: Error) => {
+      uncaught.push(error);
+    };
+    process.on('uncaughtException', onUncaught);
+
+    const context = createLogContext({
+      enabled: true,
+      logAllServers: true,
+      servers: new Set(),
+      logPath,
+    });
+    expect(context.writer).toBeDefined();
+
+    const streamError = Object.assign(new Error('no space left on device'), { code: 'ENOSPC' });
+    context.writer!.emit('error', streamError);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(uncaught).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no space left on device'));
+    expect(context.writer).toBeUndefined();
+
+    // logEvent must not throw after the stream is dropped
+    expect(() => logEvent(context, 'after stream failure')).not.toThrow();
+
+    process.off('uncaughtException', onUncaught);
+    await disposeLogContext(context);
+  });
+});

--- a/tests/daemon-log-context.test.ts
+++ b/tests/daemon-log-context.test.ts
@@ -25,24 +25,20 @@ describe('daemon log context stream safety', () => {
       logPath,
     });
 
-    expect(context.writer).toBeDefined();
-    // Without an early error listener, ENOSPC / EIO on the long-lived stream
-    // becomes an uncaughtException and takes down the daemon.
-    expect(context.writer!.listenerCount('error')).toBeGreaterThan(0);
-
-    await disposeLogContext(context);
+    try {
+      expect(context.writer).toBeDefined();
+      // Without an early error listener, ENOSPC / EIO on the long-lived stream
+      // becomes an uncaughtException and takes down the daemon.
+      expect(context.writer!.listenerCount('error')).toBeGreaterThan(0);
+    } finally {
+      await disposeLogContext(context);
+    }
   });
 
-  it('swallows log stream errors without uncaughtException and stops writing', async () => {
+  it('handles log stream errors directly and stops writing', async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-log-context-'));
     const logPath = path.join(tempDir, 'daemon.log');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const uncaught: Error[] = [];
-    const onUncaught = (error: Error) => {
-      uncaught.push(error);
-    };
-    process.on('uncaughtException', onUncaught);
-
     const context = createLogContext({
       enabled: true,
       logAllServers: true,
@@ -50,20 +46,32 @@ describe('daemon log context stream safety', () => {
       logPath,
     });
     expect(context.writer).toBeDefined();
+    const writer = context.writer!;
 
-    const streamError = Object.assign(new Error('no space left on device'), { code: 'ENOSPC' });
-    context.writer!.emit('error', streamError);
+    try {
+      const streamError = Object.assign(new Error('no space left on device'), { code: 'ENOSPC' });
+      expect(() => writer.emit('error', streamError)).not.toThrow();
 
-    await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => setImmediate(resolve));
 
-    expect(uncaught).toEqual([]);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no space left on device'));
-    expect(context.writer).toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('no space left on device'));
+      expect(context.writer).toBeUndefined();
 
-    // logEvent must not throw after the stream is dropped
-    expect(() => logEvent(context, 'after stream failure')).not.toThrow();
-
-    process.off('uncaughtException', onUncaught);
-    await disposeLogContext(context);
+      // logEvent must not throw after the stream is dropped.
+      expect(() => logEvent(context, 'after stream failure')).not.toThrow();
+    } finally {
+      await destroyWriter(writer);
+      await disposeLogContext(context);
+    }
   });
 });
+
+async function destroyWriter(writer: import('node:fs').WriteStream): Promise<void> {
+  if (writer.closed) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    writer.once('close', resolve);
+    writer.destroy();
+  });
+}

--- a/tests/serve-stream-errors.test.ts
+++ b/tests/serve-stream-errors.test.ts
@@ -1,0 +1,51 @@
+import http from 'node:http';
+import { Readable, Writable } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import { pipeHttpResponseBody } from '../src/serve.js';
+
+function createMockResponse(): http.ServerResponse {
+  const dest = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+  // pipeHttpResponseBody only needs a Writable destination with destroy().
+  return dest as unknown as http.ServerResponse;
+}
+
+describe('serve HTTP body pipe error cleanup', () => {
+  it('destroys the response body when the client response errors', async () => {
+    const body = new Readable({
+      read() {
+        this.push(Buffer.alloc(16, 1));
+      },
+    });
+    const destroySpy = vi.spyOn(body, 'destroy');
+    const response = createMockResponse();
+
+    const pipePromise = pipeHttpResponseBody(body, response);
+    // Simulate client abort / socket error on the HTTP response side.
+    response.emit('error', new Error('socket hang up'));
+
+    await expect(pipePromise).resolves.toBeUndefined();
+    expect(destroySpy).toHaveBeenCalled();
+    expect(body.destroyed).toBe(true);
+  });
+
+  it('destroys the HTTP response when the body stream errors', async () => {
+    const body = new Readable({
+      read() {
+        this.push(Buffer.alloc(8, 2));
+      },
+    });
+    const response = createMockResponse();
+    const destroySpy = vi.spyOn(response, 'destroy');
+
+    const pipePromise = pipeHttpResponseBody(body, response);
+    body.destroy(new Error('upstream truncated'));
+
+    await expect(pipePromise).resolves.toBeUndefined();
+    expect(destroySpy).toHaveBeenCalled();
+    expect(response.destroyed).toBe(true);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Two long-lived Node stream paths in mcporter can take down or leak work under ordinary I/O failures:

1. **Daemon log file** (`createLogContext`): the append `WriteStream` had no `error` listener until `dispose`. Disk-full / EIO on that stream becomes an uncaughtException and kills the daemon process.
2. **HTTP serve body** (`handleNodeRequest`): only `body.on('error')` destroyed the response. Client abort / response-side errors did not destroy the body stream, so partial writes and open readers could leak until GC.

## Summary

- Attach an `error` listener immediately after opening the daemon log `WriteStream`; warn, drop the writer, and keep logging to console.
- Route serve response bodies through `pipeline()` (exported as `pipeHttpResponseBody`) so body and HTTP response clean each other up on either side error.

## Evidence

Live Node against a build of this branch (`722f57c`), not a test runner. Three boundaries:

1. `createLogContext` ENOSPC on the real WriteStream
2. Real HTTP server using production `pipeHttpResponseBody` with a live client (full stream success + mid-stream abort)
3. Production `serveHttp` `/mcp` endpoint completing initialize + tools/list

```console
$ node -v
v26.5.1

$ node --input-type=module proof.mjs
=== daemon log WriteStream (createLogContext) ===
writer error listeners at open: 1
uncaught after ENOSPC emit: 0
writer cleared after error: true
[daemon] Log file write error (.../daemon.log): ENOSPC: no space left on device

=== real HTTP success path (pipeHttpResponseBody + live client) ===
listen: 127.0.0.1:50157
response chunks received: 5
response body: "chunk-0\nchunk-1\nchunk-2\nchunk-3\nchunk-4\n"
completed full stream (chunk-4 present): true

=== real HTTP abort path (client destroy mid-stream) ===
listen: 127.0.0.1:50159
client chunks before destroy: 2
pipeHttpResponseBody settled: true
server-owned body destroyed after client abort: true

=== serveHttp production endpoint (ordinary completion) ===
listen: 127.0.0.1:50161/mcp
initialize status: 200
tools/list status: 200
tools/list body (truncated): event: message data: {"result":{"tools":[{"name":"alpha__ping","description":"[alpha] ping","inputSchema":{"type":"object"}}]},"jsonrpc":"2.0","id":2}
tools/list includes ping: true
```

Without the log fix, `listenerCount('error')` is 0 and ENOSPC becomes uncaught. Without pipeline cleanup, client abort leaves the server-owned body stream alive.

## Real behavior proof

- **Behavior or issue addressed:** Daemon log WriteStream errors no longer crash the process; HTTP response body streams are destroyed on client abort while ordinary streamed and serveHttp responses still complete.
- **Real environment tested:** macOS, Node v26.5.1, mcporter built from branch tip `722f57c` under `/tmp/oc-mcporter-280`.
- **Exact steps or command run after this patch:** Built the branch, then ran a live Node script that (1) opened `createLogContext` and emitted ENOSPC on the real WriteStream, (2) started a real `http.createServer` that pipes a multi-chunk Readable through production `pipeHttpResponseBody` and completed a full client GET, (3) repeated with the client calling `req.destroy()` after 2 chunks, and (4) started production `serveHttp` on `127.0.0.1` and completed initialize + tools/list against `/mcp`.
- **Evidence after fix:** terminal output from the patched build:

  ```console
  writer error listeners at open: 1
  uncaught after ENOSPC emit: 0
  writer cleared after error: true
  [daemon] Log file write error (.../daemon.log): ENOSPC: no space left on device
  response chunks received: 5
  completed full stream (chunk-4 present): true
  client chunks before destroy: 2
  pipeHttpResponseBody settled: true
  server-owned body destroyed after client abort: true
  initialize status: 200
  tools/list status: 200
  tools/list includes ping: true
  ```

- **Observed result after fix:** ENOSPC is warned and the writer is cleared with zero uncaught exceptions. A live HTTP client can fully drain a streamed body. Aborting that client mid-stream settles `pipeHttpResponseBody` and destroys the server-owned body. Production `serveHttp` still returns successful initialize and tools/list over the real `/mcp` endpoint.
- **What was not tested:** Multi-hour daemon uptime under sustained disk pressure; TLS-terminated reverse proxies in front of serve.
