### PR TITLE
test(oauth): cover static client-information + client-secret resolver

### DIFF
--- a/tests/oauth-client-info.test.ts
+++ b/tests/oauth-client-info.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ServerDefinition } from '../src/config.js';
+import { buildStaticClientInformation, resolveOAuthClientSecret } from '../src/oauth-client-info.js';
+
+const SECRET_ENV = 'MCPORTER_TEST_CLIENT_INFO_SECRET';
+
+function definition(overrides: Partial<ServerDefinition> = {}): ServerDefinition {
+  return {
+    name: 'test-server',
+    command: { kind: 'http', url: new URL('https://example.com/mcp') },
+    auth: 'oauth',
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  delete process.env[SECRET_ENV];
+});
+
+describe('resolveOAuthClientSecret', () => {
+  it('returns the referenced env var value', () => {
+    process.env[SECRET_ENV] = 'from-env';
+    expect(resolveOAuthClientSecret(definition({ oauthClientSecretEnv: SECRET_ENV }))).toBe('from-env');
+  });
+
+  it('throws when the referenced env var is unset', () => {
+    expect(() => resolveOAuthClientSecret(definition({ oauthClientSecretEnv: SECRET_ENV }))).toThrow(SECRET_ENV);
+  });
+
+  it('throws on an empty-string env value regardless of rejectBlank', () => {
+    process.env[SECRET_ENV] = '';
+    expect(() => resolveOAuthClientSecret(definition({ oauthClientSecretEnv: SECRET_ENV }))).toThrow(SECRET_ENV);
+  });
+
+  it('returns a whitespace-only env value when rejectBlank is not set', () => {
+    process.env[SECRET_ENV] = '   ';
+    expect(resolveOAuthClientSecret(definition({ oauthClientSecretEnv: SECRET_ENV }))).toBe('   ');
+  });
+
+  it('throws on a whitespace-only env value when rejectBlank is set', () => {
+    process.env[SECRET_ENV] = '   ';
+    expect(() =>
+      resolveOAuthClientSecret(definition({ oauthClientSecretEnv: SECRET_ENV }), { rejectBlank: true })
+    ).toThrow(SECRET_ENV);
+  });
+
+  it('returns the inline secret when no env var is configured', () => {
+    expect(resolveOAuthClientSecret(definition({ oauthClientSecret: 'inline' }))).toBe('inline');
+  });
+
+  it('returns undefined when neither env var nor inline secret is set', () => {
+    expect(resolveOAuthClientSecret(definition())).toBeUndefined();
+  });
+});
+
+describe('buildStaticClientInformation', () => {
+  it('returns undefined when no client id is configured', () => {
+    expect(buildStaticClientInformation(definition())).toBeUndefined();
+  });
+
+  it('emits the fixed grant and response types for a static client', () => {
+    expect(buildStaticClientInformation(definition({ oauthClientId: 'client-1' }))).toMatchObject({
+      client_id: 'client-1',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+    });
+  });
+
+  it('includes the resolved client secret', () => {
+    process.env[SECRET_ENV] = 'from-env';
+    const info = buildStaticClientInformation(
+      definition({ oauthClientId: 'client-1', oauthClientSecretEnv: SECRET_ENV })
+    );
+    expect(info).toMatchObject({ client_secret: 'from-env' });
+  });
+
+  it('omits the client secret when none is configured', () => {
+    const info = buildStaticClientInformation(definition({ oauthClientId: 'client-1' }));
+    expect(info).not.toHaveProperty('client_secret');
+  });
+
+  it('propagates the required-secret error when the configured env var is unset', () => {
+    expect(() =>
+      buildStaticClientInformation(definition({ oauthClientId: 'client-1', oauthClientSecretEnv: SECRET_ENV }))
+    ).toThrow(SECRET_ENV);
+  });
+
+  it('includes redirect_uris derived from a URL redirect', () => {
+    const info = buildStaticClientInformation(definition({ oauthClientId: 'client-1' }), {
+      redirectUrl: new URL('http://127.0.0.1:8080/callback'),
+    });
+    expect(info).toMatchObject({ redirect_uris: ['http://127.0.0.1:8080/callback'] });
+  });
+
+  it('accepts a string redirect and omits redirect_uris when none is given', () => {
+    const withRedirect = buildStaticClientInformation(definition({ oauthClientId: 'client-1' }), {
+      redirectUrl: 'http://127.0.0.1:9090/cb',
+    });
+    expect(withRedirect).toMatchObject({ redirect_uris: ['http://127.0.0.1:9090/cb'] });
+    expect(buildStaticClientInformation(definition({ oauthClientId: 'client-1' }))).not.toHaveProperty('redirect_uris');
+  });
+
+  it('includes token_endpoint_auth_method only when configured', () => {
+    const withMethod = buildStaticClientInformation(
+      definition({ oauthClientId: 'client-1', oauthTokenEndpointAuthMethod: 'client_secret_post' })
+    );
+    expect(withMethod).toMatchObject({ token_endpoint_auth_method: 'client_secret_post' });
+    expect(buildStaticClientInformation(definition({ oauthClientId: 'client-1' }))).not.toHaveProperty(
+      'token_endpoint_auth_method'
+    );
+  });
+});

--- a/tests/oauth-client-info.test.ts
+++ b/tests/oauth-client-info.test.ts
@@ -3,6 +3,8 @@ import type { ServerDefinition } from '../src/config.js';
 import { buildStaticClientInformation, resolveOAuthClientSecret } from '../src/oauth-client-info.js';
 
 const SECRET_ENV = 'MCPORTER_TEST_CLIENT_INFO_SECRET';
+const originalSecretEnvPresent = Object.hasOwn(process.env, SECRET_ENV);
+const originalSecretEnvValue = process.env[SECRET_ENV];
 
 function definition(overrides: Partial<ServerDefinition> = {}): ServerDefinition {
   return {
@@ -14,7 +16,11 @@ function definition(overrides: Partial<ServerDefinition> = {}): ServerDefinition
 }
 
 afterEach(() => {
-  delete process.env[SECRET_ENV];
+  if (originalSecretEnvPresent) {
+    process.env[SECRET_ENV] = originalSecretEnvValue!;
+  } else {
+    delete process.env[SECRET_ENV];
+  }
 });
 
 describe('resolveOAuthClientSecret', () => {
@@ -24,6 +30,7 @@ describe('resolveOAuthClientSecret', () => {
   });
 
   it('throws when the referenced env var is unset', () => {
+    delete process.env[SECRET_ENV];
     expect(() => resolveOAuthClientSecret(definition({ oauthClientSecretEnv: SECRET_ENV }))).toThrow(SECRET_ENV);
   });
 
@@ -80,6 +87,7 @@ describe('buildStaticClientInformation', () => {
   });
 
   it('propagates the required-secret error when the configured env var is unset', () => {
+    delete process.env[SECRET_ENV];
     expect(() =>
       buildStaticClientInformation(definition({ oauthClientId: 'client-1', oauthClientSecretEnv: SECRET_ENV }))
     ).toThrow(SECRET_ENV);


### PR DESCRIPTION
## What Problem This Solves

`src/oauth-client-info.ts` exports the two helpers that assemble a static OAuth client information object and resolve its client secret, and the module shipped with **no direct test coverage** — no `tests/oauth-client-info.test.ts` exists on `main`. Both helpers carry contracts a plausible refactor could silently break:

- **`resolveOAuthClientSecret(definition, options)`** — when `oauthClientSecretEnv` is set it reads the env var and **throws a labeled error** if the value is missing (`!value`) or, under `rejectBlank`, blank; otherwise it returns the env value (whitespace preserved when `rejectBlank` is off). With no env ref it falls back to the inline `oauthClientSecret`, or `undefined`.
- **`buildStaticClientInformation(definition, options)`** — returns `undefined` with no `oauthClientId`; otherwise emits fixed `grant_types`/`response_types`, **conditionally** includes `client_secret` (via the resolver), `redirect_uris` (from a `URL` or string), and `token_endpoint_auth_method`, and **propagates** the resolver's throw.

A regression in any of these — dropping the `!value` guard, inverting a conditional-spread ternary, or losing the required-secret throw — would ship green today because nothing executes the module.

## Why This Change Was Made

Coverage-only. This adds one new file, `tests/oauth-client-info.test.ts` (**+112, no production code touched**), pinning both helpers' current `main` behavior. The tests import the **real** exported functions and drive them directly — no stubs — so they exercise the production path callers actually hit. Both the primary and negative/omit paths are pinned for each helper: the resolver's env/inline/undefined returns plus its three throw paths, and the builder's `undefined` gate, each conditional field's include-and-omit pair, and the propagated throw. No new config, defaults, or dependencies.

## User Impact

No user-visible or runtime change. For maintainers, the static-client-information contract now regresses loudly instead of silently: a future edit that drops the required-secret throw, breaks a conditional-field spread, or loses the env/inline resolver fallback will fail this suite.

## Evidence

Linux, Node 22.22, `pnpm install --frozen-lockfile` from source. Branched off current `main` (base `4219927`); the module under test, `src/oauth-client-info.ts`, is **byte-identical** to its state at the earlier-verified base `58986a7` (the only change between them is `CHANGELOG.md`), so the pinned behavior is current.

**15/15 pass on current `main`:**

```console
$ ./node_modules/.bin/vitest run tests/oauth-client-info.test.ts
 RUN  v4.1.10 /home/user/mcporter
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

**Non-vacuous — the suite bites when the target is mutated** (each mutation applied to `src/oauth-client-info.ts`, suite re-run, then reverted byte-identical). The representative M1 case was re-confirmed on this exact rebased head; the full matrix was validated against the byte-identical source:

| Mutation to `oauth-client-info.ts` | Failing tests |
| --- | --- |
| drop the `!value` required-secret guard | 3 |
| drop the `rejectBlank` blank-value clause | 1 |
| env branch returns inline secret instead | 3 |
| drop the no-`oauthClientId` `undefined` gate | 1 |
| invert the `client_secret` conditional spread | 2 |
| invert the `redirect_uris` conditional spread | 2 |
| invert the `token_endpoint_auth_method` spread | 1 |
| break the fixed `grant_types` array | 1 |
| *(reverted — control)* | **0 (15 pass)** |

```console
$ # M1 re-confirmed on rebased head: drop `!value` guard
$ ./node_modules/.bin/vitest run tests/oauth-client-info.test.ts   # → 3 failed | 12 passed (15)
$ # source reverted byte-identical
$ ./node_modules/.bin/vitest run tests/oauth-client-info.test.ts   # → 15 passed (15)
```

**Format / lint / types clean on the new file:**

```console
$ ./node_modules/.bin/oxfmt --check tests/oauth-client-info.test.ts        # All matched files use the correct format.
$ ./node_modules/.bin/oxlint --type-aware --tsconfig tsconfig.json --deny-warnings tests/oauth-client-info.test.ts   # exit 0
$ ./node_modules/.bin/tsc --project tsconfig.json --noEmit                 # exit 0
```

**Scope note:** one new `*.test.ts` file under `tests/`, `+112 / -0`, no production code touched. Direct sibling of the just-landed #246 (OAuth token-generation coverage) — same module family, mirror side.

<sub>Opened from a fork via the API; if GitHub's *Allow edits by maintainers* toggle isn't honored on this PR, a maintainer can still push to the branch or supersede-and-land.</sub>

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiAfJ6NWBiCXPANbtcXc3K)_