### PR TITLE
fix(oauth): honor MCPORTER_OAUTH_NO_BROWSER outside the auth command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### OAuth
 
+- Honor `MCPORTER_OAUTH_NO_BROWSER` across serve/daemon OAuth flows, fail once with actionable reauthorization guidance without logging authorization URLs, and restart daemons when the normalized setting changes. (PR #284 / issue #283, thanks @vitalijssilins)
 - Accept RFC 7591 dynamic-client-registration arrays and timestamps in `mcporter vault set` while preserving null-compatible partial client information and provider metadata. (PR #288 / issue #286, thanks @feniix)
 
 ### Tooling

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -45,6 +45,8 @@ Eligible servers start the daemon automatically when a list or call needs them. 
 
 Daemon calls are non-interactive. If a server requests elicitation, the call is declined with a hint to use an ephemeral terminal call instead. See [protocols and interactive requests](protocols.md).
 
+Set `MCPORTER_OAUTH_NO_BROWSER=1` (also accepts `true` or `yes`) on a serve/daemon process to suppress automatic OAuth browser launches. Affected calls fail once with the server name and an `mcporter auth <name> --no-browser` hint instead of restarting or replaying. Changing the normalized setting replaces an already-running daemon on the next operation.
+
 The local socket timeout is an idle liveness budget rather than a cap on the whole operation. A current daemon emits progress frames while work is in flight, allowing interactive OAuth to run to its own deadline without causing a daemon restart or a duplicate browser prompt. Mixed versions remain compatible: a current client falls back to the previous flat deadline with an older daemon, while a current daemon sends the single-response format expected by older clients unless the caller explicitly opts into progress frames.
 
 ## Expose servers to another MCP client

--- a/src/cli/auth-command.ts
+++ b/src/cli/auth-command.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import type { ServerDefinition } from '../config-schema.js';
 import type { OAuthAuthorizationRequest, OAuthSessionOptions } from '../oauth.js';
+import { suppressBrowserLaunchFromEnv } from '../oauth-browser-suppression.js';
 import { analyzeConnectionError } from '../error-classifier.js';
 import { clearOAuthCaches } from '../oauth-persistence.js';
 import type { Runtime } from '../runtime.js';
@@ -19,9 +20,6 @@ type BrowserSuppression = 'default' | 'no-browser';
 export interface AuthCommandOptions {
   readonly oauthTimeoutMs?: number;
 }
-
-const TRUE_VALUES = new Set(['1', 'true', 'yes']);
-const FALSE_VALUES = new Set(['0', 'false', 'no']);
 
 export async function handleAuth(runtime: Runtime, args: string[], options: AuthCommandOptions = {}): Promise<void> {
   const browserSuppression = consumeBrowserSuppression(args, process.env);
@@ -192,7 +190,7 @@ function buildNoBrowserOAuthOptions(
 }
 
 function consumeBrowserSuppression(args: string[], env: NodeJS.ProcessEnv): BrowserSuppression {
-  let mode = resolveBrowserSuppressionFromEnv(env.MCPORTER_OAUTH_NO_BROWSER);
+  let mode: BrowserSuppression = suppressBrowserLaunchFromEnv(env) ? 'no-browser' : 'default';
   const noBrowserIndex = args.indexOf('--no-browser');
   if (noBrowserIndex !== -1) {
     args.splice(noBrowserIndex, 1);
@@ -211,20 +209,6 @@ function consumeBrowserSuppression(args: string[], env: NodeJS.ProcessEnv): Brow
     mode = 'no-browser';
   }
   return mode;
-}
-
-function resolveBrowserSuppressionFromEnv(raw: string | undefined): BrowserSuppression {
-  if (raw === undefined) {
-    return 'default';
-  }
-  const normalized = raw.trim().toLowerCase();
-  if (!normalized || FALSE_VALUES.has(normalized)) {
-    return 'default';
-  }
-  if (TRUE_VALUES.has(normalized)) {
-    return 'no-browser';
-  }
-  return 'default';
 }
 
 function shouldRetryAuthError(error: unknown): boolean {

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { hashChromeDevtoolsRelayProcessEnvironment } from '../chrome-devtools-relay.js';
 import { withFileLock } from '../fs-json.js';
 import { isProcessRunning } from '../process-utils.js';
+import { suppressBrowserLaunchFromEnv } from '../oauth-browser-suppression.js';
 import { collectConfigLayers, normalizeConfigLayers } from './config-layers.js';
 import { getDaemonMetadataPath, getDaemonSocketPath } from './paths.js';
 import {
@@ -52,6 +53,7 @@ interface DaemonMetadata {
   readonly logPath?: string | null;
   readonly relayEnvironmentHash?: string;
   readonly relayEnvironmentKeys?: string[];
+  readonly oauthNoBrowser?: boolean;
 }
 
 type DaemonConfigState = 'missing' | 'fresh' | 'stale';
@@ -270,6 +272,9 @@ export class DaemonClient {
       !metadata.relayEnvironmentKeys ||
       metadata.relayEnvironmentHash !== hashChromeDevtoolsRelayProcessEnvironment(metadata.relayEnvironmentKeys)
     ) {
+      return 'stale';
+    }
+    if ((metadata.oauthNoBrowser ?? false) !== suppressBrowserLaunchFromEnv()) {
       return 'stale';
     }
     return 'fresh';

--- a/src/daemon/host.ts
+++ b/src/daemon/host.ts
@@ -14,9 +14,10 @@ import { readJsonFile, withFileLock, writeJsonFile } from '../fs-json.js';
 import { isKeepAliveServer } from '../lifecycle.js';
 import { configureAutoSelectFamilyAttemptTimeout } from '../network-family-autoselection.js';
 import { isProcessRunning } from '../process-utils.js';
+import { suppressBrowserLaunchFromEnv } from '../oauth-browser-suppression.js';
 import { createRuntime, type Runtime } from '../runtime.js';
 import { createNonInteractiveElicitationResponder, NON_INTERACTIVE_ELICITATION_HINT } from '../runtime/elicitation.js';
-import { OAuthTimeoutError, resolveOAuthTimeoutFromEnv } from '../runtime/oauth.js';
+import { isOAuthFlowError, OAuthTimeoutError, resolveOAuthTimeoutFromEnv } from '../runtime/oauth.js';
 import { raceWithTimeout } from '../runtime/utils.js';
 import { collectConfigLayers, normalizeConfigLayers, statConfigMtime } from './config-layers.js';
 import { hashDaemonDefinitions } from './definition-hash.js';
@@ -29,6 +30,7 @@ import {
   shouldLogServer,
 } from './log-context.js';
 import {
+  DAEMON_OAUTH_FLOW_ERROR_CODE,
   DAEMON_OPERATION_TIMEOUT_CODE,
   DAEMON_PROGRESS_INTERVAL_MS,
   DAEMON_PROTOCOL_VERSION,
@@ -81,6 +83,7 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
   const definitionHash = hashDaemonDefinitions(keepAliveDefinitions);
   const relayEnvironmentKeys = chromeDevtoolsRelayEnvironmentKeys(keepAliveDefinitions);
   const relayEnvironmentHash = hashChromeDevtoolsRelayProcessEnvironment(relayEnvironmentKeys);
+  const oauthNoBrowser = suppressBrowserLaunchFromEnv();
   if (keepAliveDefinitions.length === 0) {
     throw new Error('No MCP servers require keep-alive; daemon will not start.');
   }
@@ -189,6 +192,7 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
           definitionHash,
           relayEnvironmentHash,
           relayEnvironmentKeys,
+          oauthNoBrowser,
         },
         logContext,
         shutdown,
@@ -225,7 +229,8 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
           configMtimeMs,
           definitionHash,
           relayEnvironmentHash,
-          relayEnvironmentKeys
+          relayEnvironmentKeys,
+          oauthNoBrowser
         )
       ) {
         if (!(await metadataMatches(options.metadataPath, live))) {
@@ -255,6 +260,7 @@ export async function runDaemonHost(options: DaemonHostOptions): Promise<void> {
       definitionHash,
       relayEnvironmentHash,
       relayEnvironmentKeys,
+      oauthNoBrowser,
     });
     claimed = true;
   });
@@ -327,6 +333,7 @@ function metadataFromStatus(
   definitionHash?: string;
   relayEnvironmentHash?: string;
   relayEnvironmentKeys?: string[];
+  oauthNoBrowser?: boolean;
 } {
   return {
     pid: status.pid,
@@ -340,6 +347,7 @@ function metadataFromStatus(
     definitionHash: status.definitionHash,
     relayEnvironmentHash: status.relayEnvironmentHash,
     relayEnvironmentKeys: status.relayEnvironmentKeys,
+    oauthNoBrowser: status.oauthNoBrowser,
   };
 }
 
@@ -350,7 +358,8 @@ function daemonConfigMatches(
   currentConfigMtimeMs: number | null,
   currentDefinitionHash: string,
   currentRelayEnvironmentHash: string,
-  currentRelayEnvironmentKeys: readonly string[]
+  currentRelayEnvironmentKeys: readonly string[],
+  currentOauthNoBrowser: boolean
 ): boolean {
   if (live.definitionHash !== currentDefinitionHash) {
     return false;
@@ -359,6 +368,9 @@ function daemonConfigMatches(
     return false;
   }
   if (JSON.stringify(live.relayEnvironmentKeys) !== JSON.stringify(currentRelayEnvironmentKeys)) {
+    return false;
+  }
+  if ((live.oauthNoBrowser ?? false) !== currentOauthNoBrowser) {
     return false;
   }
   const liveLayers = normalizeConfigLayers(
@@ -528,6 +540,7 @@ async function handleSocketRequest(
     definitionHash?: string;
     relayEnvironmentHash?: string;
     relayEnvironmentKeys?: string[];
+    oauthNoBrowser?: boolean;
   },
   logContext: LogContext,
   shutdown: () => Promise<void>,
@@ -605,6 +618,9 @@ function daemonRuntimeErrorCode(error: unknown): string {
   ) {
     return DAEMON_OPERATION_TIMEOUT_CODE;
   }
+  if (isOAuthFlowError(error)) {
+    return DAEMON_OAUTH_FLOW_ERROR_CODE;
+  }
   return 'runtime_error';
 }
 
@@ -638,6 +654,7 @@ async function processRequest(
     definitionHash?: string;
     relayEnvironmentHash?: string;
     relayEnvironmentKeys?: string[];
+    oauthNoBrowser?: boolean;
   },
   logContext: LogContext,
   preParsedRequest?: DaemonRequest
@@ -819,6 +836,7 @@ async function processRequest(
           definitionHash: metadata.definitionHash,
           relayEnvironmentHash: metadata.relayEnvironmentHash,
           relayEnvironmentKeys: metadata.relayEnvironmentKeys,
+          oauthNoBrowser: metadata.oauthNoBrowser,
           socketPath: metadata.socketPath,
           logPath: metadata.logPath ?? undefined,
           servers: Array.from(managedServers.values()).map((def) => {
@@ -879,6 +897,7 @@ export async function __testProcessRequest(
     definitionHash?: string;
     relayEnvironmentHash?: string;
     relayEnvironmentKeys?: string[];
+    oauthNoBrowser?: boolean;
   },
   logContext: LogContext,
   preParsedRequest?: DaemonRequest

--- a/src/daemon/protocol.ts
+++ b/src/daemon/protocol.ts
@@ -2,6 +2,7 @@ import type { ChromeDevtoolsRelayDecision } from '../chrome-devtools-relay.js';
 
 export const DAEMON_PROTOCOL_VERSION = 2;
 export const DAEMON_OPERATION_TIMEOUT_CODE = 'operation_timeout';
+export const DAEMON_OAUTH_FLOW_ERROR_CODE = 'oauth_flow_error';
 export const DAEMON_PROGRESS_INTERVAL_MS = 250;
 
 export function resolveProgressInterval(idleTimeoutMs: number): number {
@@ -147,6 +148,7 @@ export interface StatusResult {
   readonly definitionHash?: string;
   readonly relayEnvironmentHash?: string;
   readonly relayEnvironmentKeys?: string[];
+  readonly oauthNoBrowser?: boolean;
   readonly socketPath: string;
   readonly logPath?: string;
   readonly servers: Array<{

--- a/src/daemon/runtime-wrapper.ts
+++ b/src/daemon/runtime-wrapper.ts
@@ -11,7 +11,7 @@ import type {
   Runtime,
 } from '../runtime.js';
 import type { DaemonClient } from './client.js';
-import { DAEMON_OPERATION_TIMEOUT_CODE } from './protocol.js';
+import { DAEMON_OAUTH_FLOW_ERROR_CODE, DAEMON_OPERATION_TIMEOUT_CODE } from './protocol.js';
 
 interface KeepAliveRuntimeOptions {
   readonly daemonClient: DaemonClient | null;
@@ -181,8 +181,11 @@ function shouldRestartDaemonServer(error: unknown): boolean {
   if (!error) {
     return false;
   }
-  if (typeof error === 'object' && (error as { code?: unknown }).code === DAEMON_OPERATION_TIMEOUT_CODE) {
-    return false;
+  if (typeof error === 'object') {
+    const code = (error as { code?: unknown }).code;
+    if (code === DAEMON_OPERATION_TIMEOUT_CODE || code === DAEMON_OAUTH_FLOW_ERROR_CODE) {
+      return false;
+    }
   }
   // Restarting cannot repair a missing or rejected credential, and replaying the
   // operation re-enters interactive authorization, duplicating prompts (issue #247).

--- a/src/oauth-browser-suppression.ts
+++ b/src/oauth-browser-suppression.ts
@@ -1,0 +1,6 @@
+const TRUE_VALUES = new Set(['1', 'true', 'yes']);
+
+export function suppressBrowserLaunchFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.MCPORTER_OAUTH_NO_BROWSER;
+  return raw !== undefined && TRUE_VALUES.has(raw.trim().toLowerCase());
+}

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -12,6 +12,7 @@ import type {
 } from '@modelcontextprotocol/client';
 import { validateClientMetadataUrl } from '@modelcontextprotocol/client';
 import type { ServerDefinition } from './config.js';
+import { suppressBrowserLaunchFromEnv } from './oauth-browser-suppression.js';
 import { buildStaticClientInformation } from './oauth-client-info.js';
 import type { OAuthPersistence } from './oauth-persistence.js';
 import { buildOAuthPersistence } from './oauth-persistence.js';
@@ -35,17 +36,6 @@ export interface OAuthAuthorizationResponse {
 export interface OAuthSessionOptions {
   suppressBrowserLaunch?: boolean;
   onAuthorizationUrl?: (request: OAuthAuthorizationRequest) => void | Promise<void>;
-}
-
-// Env-driven browser suppression for flows that never see CLI flags (serve/daemon
-// bridges, embedded runtimes): honors the same MCPORTER_OAUTH_NO_BROWSER values the
-// auth command accepts (issue #283). An explicit suppressBrowserLaunch option wins.
-const NO_BROWSER_TRUE_VALUES = new Set(['1', 'true', 'yes']);
-function suppressBrowserLaunchFromEnv(raw = process.env.MCPORTER_OAUTH_NO_BROWSER): boolean {
-  if (raw === undefined) {
-    return false;
-  }
-  return NO_BROWSER_TRUE_VALUES.has(raw.trim().toLowerCase());
 }
 
 // Thrown when interactive authorization is needed but browser launch is suppressed
@@ -370,20 +360,18 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
         await this.options.onAuthorizationUrl(request);
         return;
       }
-      // No callback registered (serve/daemon path): surface the URL in the log and
-      // reject the pending authorization so waiters fail fast with a server-named
+      // No callback registered (serve/daemon path): reject the pending
+      // authorization so waiters fail fast with a server-named
       // error instead of waiting out the timeout on a browser handshake nobody
       // will complete. Never throw here: the SDK invokes this from unawaited send
       // paths, where a throw becomes an unhandled rejection that kills the daemon.
-      this.logger.warn(
-        `Authorization required for ${this.definition.name}; browser launch suppressed (MCPORTER_OAUTH_NO_BROWSER). Visit ${request.authorizationUrl} to authorize.`
-      );
       const suppressed = new BrowserLaunchSuppressedError(this.definition.name);
+      this.logger.warn(suppressed.message);
       const deferred = this.ensureAuthorizationDeferred();
       // Mark the rejection handled: waiters that attach later still observe it.
       deferred.promise.catch(() => {});
       deferred.reject(suppressed);
-      this.interactiveAuthorization = null;
+      this.clearInteractiveAuthorization();
       return;
     }
     this.logger.info(`Authorization required for ${this.definition.name}. Opening browser...`);

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -37,6 +37,31 @@ export interface OAuthSessionOptions {
   onAuthorizationUrl?: (request: OAuthAuthorizationRequest) => void | Promise<void>;
 }
 
+// Env-driven browser suppression for flows that never see CLI flags (serve/daemon
+// bridges, embedded runtimes): honors the same MCPORTER_OAUTH_NO_BROWSER values the
+// auth command accepts (issue #283). An explicit suppressBrowserLaunch option wins.
+const NO_BROWSER_TRUE_VALUES = new Set(['1', 'true', 'yes']);
+function suppressBrowserLaunchFromEnv(raw = process.env.MCPORTER_OAUTH_NO_BROWSER): boolean {
+  if (raw === undefined) {
+    return false;
+  }
+  return NO_BROWSER_TRUE_VALUES.has(raw.trim().toLowerCase());
+}
+
+// Thrown when interactive authorization is needed but browser launch is suppressed
+// and no onAuthorizationUrl consumer exists (headless serve/daemon): callers get a
+// prompt server-named failure instead of waiting out the authorization timeout.
+export class BrowserLaunchSuppressedError extends Error {
+  readonly serverName: string;
+  constructor(serverName: string) {
+    super(
+      `Authorization required for '${serverName}' but browser launch is suppressed (MCPORTER_OAUTH_NO_BROWSER); run 'mcporter auth ${serverName} --no-browser' to authorize.`
+    );
+    this.name = 'BrowserLaunchSuppressedError';
+    this.serverName = serverName;
+  }
+}
+
 interface Deferred<T> {
   promise: Promise<T>;
   resolve: (value: T) => void;
@@ -340,8 +365,25 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
       authorizationUrl: authorizationUrl.toString(),
       redirectUrl: this.redirectUrlValue.toString(),
     } satisfies OAuthAuthorizationRequest;
-    if (this.options.suppressBrowserLaunch) {
-      await this.options.onAuthorizationUrl?.(request);
+    if (this.options.suppressBrowserLaunch ?? suppressBrowserLaunchFromEnv()) {
+      if (this.options.onAuthorizationUrl) {
+        await this.options.onAuthorizationUrl(request);
+        return;
+      }
+      // No callback registered (serve/daemon path): surface the URL in the log and
+      // reject the pending authorization so waiters fail fast with a server-named
+      // error instead of waiting out the timeout on a browser handshake nobody
+      // will complete. Never throw here: the SDK invokes this from unawaited send
+      // paths, where a throw becomes an unhandled rejection that kills the daemon.
+      this.logger.warn(
+        `Authorization required for ${this.definition.name}; browser launch suppressed (MCPORTER_OAUTH_NO_BROWSER). Visit ${request.authorizationUrl} to authorize.`
+      );
+      const suppressed = new BrowserLaunchSuppressedError(this.definition.name);
+      const deferred = this.ensureAuthorizationDeferred();
+      // Mark the rejection handled: waiters that attach later still observe it.
+      deferred.promise.catch(() => {});
+      deferred.reject(suppressed);
+      this.interactiveAuthorization = null;
       return;
     }
     this.logger.info(`Authorization required for ${this.definition.name}. Opening browser...`);

--- a/tests/daemon-client-config-stale.test.ts
+++ b/tests/daemon-client-config-stale.test.ts
@@ -52,6 +52,7 @@ function buildResponse(method: string, id: string) {
         configLayers: activeLayers,
         relayEnvironmentHash: activeRelayEnvironmentHash,
         relayEnvironmentKeys: activeRelayEnvironmentKeys,
+        oauthNoBrowser: activeOauthNoBrowser,
         socketPath: activeSocketPath,
         servers: [],
       },
@@ -70,9 +71,11 @@ let activeConfigMtime: number | null = null;
 let activeStatusPid = process.pid;
 let activeSocketPath: string;
 let previousDaemonDir: string | undefined;
+let previousOauthNoBrowser: string | undefined;
 let activeLayers: Array<{ path: string; mtimeMs: number | null }> = [];
 let activeRelayEnvironmentHash = hashChromeDevtoolsRelayEnvironment([], {});
 let activeRelayEnvironmentKeys: string[] = [];
+let activeOauthNoBrowser = false;
 
 vi.mock('node:net', () => {
   createConnection.mockImplementation(() => {
@@ -93,9 +96,12 @@ describe('DaemonClient config freshness', () => {
   beforeEach(() => {
     sentMethods.length = 0;
     previousDaemonDir = process.env.MCPORTER_DAEMON_DIR;
+    previousOauthNoBrowser = process.env.MCPORTER_OAUTH_NO_BROWSER;
+    delete process.env.MCPORTER_OAUTH_NO_BROWSER;
     activeLayers = [];
     activeRelayEnvironmentHash = hashChromeDevtoolsRelayEnvironment([], {});
     activeRelayEnvironmentKeys = [];
+    activeOauthNoBrowser = false;
     launchDaemonDetached.mockClear();
     launchDaemonDetached.mockImplementation(
       (options: { metadataPath: string; socketPath: string; configPath: string }) => {
@@ -113,6 +119,7 @@ describe('DaemonClient config freshness', () => {
               configLayers: activeLayers,
               relayEnvironmentHash: activeRelayEnvironmentHash,
               relayEnvironmentKeys: activeRelayEnvironmentKeys,
+              oauthNoBrowser: activeOauthNoBrowser,
             },
             null,
             2
@@ -128,6 +135,11 @@ describe('DaemonClient config freshness', () => {
       delete process.env.MCPORTER_DAEMON_DIR;
     } else {
       process.env.MCPORTER_DAEMON_DIR = previousDaemonDir;
+    }
+    if (previousOauthNoBrowser === undefined) {
+      delete process.env.MCPORTER_OAUTH_NO_BROWSER;
+    } else {
+      process.env.MCPORTER_OAUTH_NO_BROWSER = previousOauthNoBrowser;
     }
   });
 
@@ -325,6 +337,45 @@ describe('DaemonClient config freshness', () => {
       if (previousPolicy === undefined) delete process.env.MCPORTER_CHROME_DEVTOOLS_RELAY_POLICY;
       else process.env.MCPORTER_CHROME_DEVTOOLS_RELAY_POLICY = previousPolicy;
     }
+  });
+
+  it('restarts when normalized no-browser environment state changes', async () => {
+    const tmpDir = await makeShortTempDir('daemon-oauth-browser-env');
+    process.env.MCPORTER_DAEMON_DIR = tmpDir;
+    const configPath = path.join(tmpDir, 'config.json');
+    await fs.writeFile(configPath, JSON.stringify({ mcpServers: {} }), 'utf8');
+    const stat = await fs.stat(configPath);
+    const { metadataPath, socketPath } = resolveDaemonPaths(configPath);
+    activeConfigPath = configPath;
+    activeSocketPath = socketPath;
+    activeConfigMtime = stat.mtimeMs;
+    activeStatusPid = process.pid;
+    activeLayers = [{ path: configPath, mtimeMs: stat.mtimeMs }];
+    activeOauthNoBrowser = false;
+    await fs.mkdir(path.dirname(metadataPath), { recursive: true });
+    await fs.writeFile(
+      metadataPath,
+      JSON.stringify({
+        pid: process.pid,
+        socketPath,
+        configPath,
+        startedAt: Date.now() - 10_000,
+        configMtimeMs: stat.mtimeMs,
+        configLayers: activeLayers,
+        relayEnvironmentHash: activeRelayEnvironmentHash,
+        relayEnvironmentKeys: activeRelayEnvironmentKeys,
+        oauthNoBrowser: false,
+      }),
+      'utf8'
+    );
+
+    process.env.MCPORTER_OAUTH_NO_BROWSER = ' YeS ';
+    const client = new DaemonClient({ configPath, configExplicit: true, rootDir: tmpDir });
+    await client.listTools({ server: 'oauth' });
+
+    expect(sentMethods[0]).toBe('status');
+    expect(sentMethods).toContain('stop');
+    expect(launchDaemonDetached).toHaveBeenCalledOnce();
   });
 
   it('restarts when the relay key rotates at the same credential path', async () => {

--- a/tests/daemon-client-timeout.test.ts
+++ b/tests/daemon-client-timeout.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { hashChromeDevtoolsRelayProcessEnvironment } from '../src/chrome-devtools-relay.js';
 import { NON_INTERACTIVE_ELICITATION_HINT } from '../src/runtime/elicitation.js';
+import { DAEMON_OAUTH_FLOW_ERROR_CODE } from '../src/daemon/protocol.js';
 import { makeShortTempDir } from './fixtures/test-helpers.js';
 
 const timeoutRecords: Array<{ method: string; timeout: number }> = [];
@@ -183,6 +184,24 @@ describe('DaemonClient timeouts', () => {
 
     expect(warn).toHaveBeenCalledWith(`[mcporter] ${NON_INTERACTIVE_ELICITATION_HINT}`);
     warn.mockRestore();
+  });
+
+  it('reconstructs stable OAuth flow error codes from daemon responses', async () => {
+    const configPath = 'mcporter.config.json';
+    await writeFreshMetadata(configPath);
+    responseOverrides.set(
+      'callTool',
+      JSON.stringify({
+        id: 'oauth-flow',
+        ok: false,
+        error: { code: DAEMON_OAUTH_FLOW_ERROR_CODE, message: 'browser launch is suppressed' },
+      })
+    );
+    const client = new DaemonClient({ configPath, configExplicit: true });
+
+    const error = await client.callTool({ server: 'foo', tool: 'bar' }).catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({ message: 'browser launch is suppressed', code: DAEMON_OAUTH_FLOW_ERROR_CODE });
   });
 
   it('routes resource and close requests through the daemon protocol', async () => {

--- a/tests/daemon-host.test.ts
+++ b/tests/daemon-host.test.ts
@@ -14,9 +14,10 @@ import {
   runDaemonHost,
 } from '../src/daemon/host.js';
 import type { DaemonRequest, DaemonResponse, StatusResult } from '../src/daemon/protocol.js';
+import { DAEMON_OAUTH_FLOW_ERROR_CODE } from '../src/daemon/protocol.js';
 import { recordChromeDevtoolsRelayDecision } from '../src/chrome-devtools-relay.js';
 import type { Runtime } from '../src/runtime.js';
-import { OAuthTimeoutError } from '../src/runtime/oauth.js';
+import { markOAuthFlowError, OAuthTimeoutError } from '../src/runtime/oauth.js';
 
 const describeUnixSocket = process.platform === 'win32' ? describe.skip : describe;
 
@@ -188,6 +189,33 @@ describe('daemon host request handling', () => {
       id: 'oauth-timeout',
       ok: false,
       error: { code: 'operation_timeout' },
+    });
+  });
+
+  it('serializes OAuth flow failures with a stable non-retryable code', async () => {
+    const runtime = createRuntimeDouble();
+    vi.mocked(runtime.callTool).mockRejectedValue(
+      markOAuthFlowError(new Error("Authorization required for 'oauth' but browser launch is suppressed"))
+    );
+
+    const result = await __testProcessRequest(
+      '',
+      runtime as unknown as Runtime,
+      createManagedServers(),
+      new Map(),
+      metadata,
+      logContext,
+      {
+        id: 'oauth-flow-error',
+        method: 'callTool',
+        params: { server: 'oauth', tool: 'ping' },
+      }
+    );
+
+    expect(result.response).toMatchObject({
+      id: 'oauth-flow-error',
+      ok: false,
+      error: { code: DAEMON_OAUTH_FLOW_ERROR_CODE },
     });
   });
 

--- a/tests/keep-alive-runtime.test.ts
+++ b/tests/keep-alive-runtime.test.ts
@@ -2,6 +2,7 @@ import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it, vi } from 'vitest';
 import type { ServerDefinition } from '../src/config.js';
 import { createKeepAliveRuntime } from '../src/daemon/runtime-wrapper.js';
+import { DAEMON_OAUTH_FLOW_ERROR_CODE } from '../src/daemon/protocol.js';
 import type { CallOptions, ConnectOptions, ListToolsOptions, Runtime } from '../src/runtime.js';
 
 class FakeRuntime implements Runtime {
@@ -322,6 +323,28 @@ describe('createKeepAliveRuntime', () => {
 
     await expect(keepAliveRuntime.listTools('alpha', { timeoutMs: 5_000 })).rejects.toThrow('timed out');
     expect(daemon.listTools).toHaveBeenCalledTimes(1);
+    expect(daemon.closeServer).not.toHaveBeenCalled();
+  });
+
+  it('does not close or replay daemon OAuth flow failures', async () => {
+    const runtime = new FakeRuntime(definitions);
+    const oauthFlowError = Object.assign(new Error('browser launch is suppressed'), {
+      code: DAEMON_OAUTH_FLOW_ERROR_CODE,
+    });
+    const daemon = {
+      callTool: vi.fn().mockRejectedValue(oauthFlowError),
+      closeServer: vi.fn().mockResolvedValue(undefined),
+      listTools: vi.fn(),
+      listResources: vi.fn(),
+      readResource: vi.fn(),
+    };
+    const keepAliveRuntime = createKeepAliveRuntime(runtime as unknown as Runtime, {
+      daemonClient: daemon as never,
+      keepAliveServers: new Set(['alpha']),
+    });
+
+    await expect(keepAliveRuntime.callTool('alpha', 'ping', {})).rejects.toBe(oauthFlowError);
+    expect(daemon.callTool).toHaveBeenCalledTimes(1);
     expect(daemon.closeServer).not.toHaveBeenCalled();
   });
 });

--- a/tests/oauth-session.test.ts
+++ b/tests/oauth-session.test.ts
@@ -470,6 +470,85 @@ describe('FileOAuthClientProvider session lifecycle', () => {
     await waitPromise;
   });
 
+  it('suppresses browser launch via MCPORTER_OAUTH_NO_BROWSER without session options (#283)', async () => {
+    const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
+    tempDirs.push(tokenCacheDir);
+    const definition: ServerDefinition = {
+      name: 'test-oauth-env-no-browser',
+      description: 'Test OAuth server',
+      command: { kind: 'http', url: new URL('https://example.com/mcp') },
+      auth: 'oauth',
+      tokenCacheDir,
+    };
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    vi.stubEnv('MCPORTER_OAUTH_NO_BROWSER', '1');
+    try {
+      const session = await createOAuthSession(definition, logger);
+      const provider = session.provider as StatefulProvider;
+      const openSpy = vi.spyOn(__oauthInternals, 'openExternal').mockImplementation(() => {});
+      const authorizationUrl = new URL('https://example.com/auth?code=xyz');
+
+      await provider.redirectToAuthorization(authorizationUrl);
+
+      // Waiters fail fast with a server-named error instead of waiting out the
+      // authorization timeout — including ones that attach after the redirect.
+      await expect(session.waitForAuthorizationCode()).rejects.toMatchObject({
+        name: 'BrowserLaunchSuppressedError',
+        serverName: 'test-oauth-env-no-browser',
+      });
+
+      expect(openSpy).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(`Visit ${authorizationUrl.toString()} to authorize`)
+      );
+      expect(provider.hasAuthorizationRedirectStarted()).toBe(true);
+
+      await session.close();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('ignores falsy MCPORTER_OAUTH_NO_BROWSER values and still opens the browser', async () => {
+    const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
+    tempDirs.push(tokenCacheDir);
+    const definition: ServerDefinition = {
+      name: 'test-oauth-env-no-browser-falsy',
+      description: 'Test OAuth server',
+      command: { kind: 'http', url: new URL('https://example.com/mcp') },
+      auth: 'oauth',
+      tokenCacheDir,
+    };
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    vi.stubEnv('MCPORTER_OAUTH_NO_BROWSER', '0');
+    try {
+      const session = await createOAuthSession(definition, logger);
+      const provider = session.provider as StatefulProvider;
+      const openSpy = vi.spyOn(__oauthInternals, 'openExternal').mockImplementation(() => {});
+      const authorizationUrl = new URL('https://example.com/auth?code=xyz');
+      const waitPromise = session.waitForAuthorizationCode().catch(() => undefined);
+
+      await provider.redirectToAuthorization(authorizationUrl);
+
+      expect(openSpy).toHaveBeenCalledWith(authorizationUrl.toString());
+
+      await session.close();
+      await waitPromise;
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it('logs the manual OAuth URL at warn level for headless terminals (#139)', async () => {
     const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
     tempDirs.push(tokenCacheDir);

--- a/tests/oauth-session.test.ts
+++ b/tests/oauth-session.test.ts
@@ -470,80 +470,118 @@ describe('FileOAuthClientProvider session lifecycle', () => {
     await waitPromise;
   });
 
-  it('suppresses browser launch via MCPORTER_OAUTH_NO_BROWSER without session options (#283)', async () => {
-    const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
-    tempDirs.push(tokenCacheDir);
-    const definition: ServerDefinition = {
-      name: 'test-oauth-env-no-browser',
-      description: 'Test OAuth server',
-      command: { kind: 'http', url: new URL('https://example.com/mcp') },
-      auth: 'oauth',
-      tokenCacheDir,
-    };
-    const logger = {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
+  it.each(['1', 'true', 'TRUE', 'yes', ' YeS '])(
+    'suppresses browser launch via truthy MCPORTER_OAUTH_NO_BROWSER=%j without session options (#283)',
+    async (envValue) => {
+      const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
+      tempDirs.push(tokenCacheDir);
+      const definition: ServerDefinition = {
+        name: 'test-oauth-env-no-browser',
+        description: 'Test OAuth server',
+        command: { kind: 'http', url: new URL('https://example.com/mcp') },
+        auth: 'oauth',
+        tokenCacheDir,
+      };
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
 
-    vi.stubEnv('MCPORTER_OAUTH_NO_BROWSER', '1');
-    try {
-      const session = await createOAuthSession(definition, logger);
-      const provider = session.provider as StatefulProvider;
-      const openSpy = vi.spyOn(__oauthInternals, 'openExternal').mockImplementation(() => {});
-      const authorizationUrl = new URL('https://example.com/auth?code=xyz');
+      vi.stubEnv('MCPORTER_OAUTH_NO_BROWSER', envValue);
+      try {
+        const session = await createOAuthSession(definition, logger);
+        const provider = session.provider as StatefulProvider;
+        const openSpy = vi.spyOn(__oauthInternals, 'openExternal').mockImplementation(() => {});
+        const authorizationUrl = new URL('https://example.com/auth?code=xyz');
 
-      await provider.redirectToAuthorization(authorizationUrl);
+        await provider.redirectToAuthorization(authorizationUrl);
 
-      // Waiters fail fast with a server-named error instead of waiting out the
-      // authorization timeout — including ones that attach after the redirect.
-      await expect(session.waitForAuthorizationCode()).rejects.toMatchObject({
-        name: 'BrowserLaunchSuppressedError',
-        serverName: 'test-oauth-env-no-browser',
-      });
+        // Waiters fail fast with a server-named error instead of waiting out the
+        // authorization timeout — including ones that attach after the redirect.
+        await expect(session.waitForAuthorizationCode()).rejects.toMatchObject({
+          name: 'BrowserLaunchSuppressedError',
+          serverName: 'test-oauth-env-no-browser',
+        });
 
-      expect(openSpy).not.toHaveBeenCalled();
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining(`Visit ${authorizationUrl.toString()} to authorize`)
-      );
-      expect(provider.hasAuthorizationRedirectStarted()).toBe(true);
+        expect(openSpy).not.toHaveBeenCalled();
+        expect(logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining("run 'mcporter auth test-oauth-env-no-browser --no-browser' to authorize")
+        );
+        expect(logger.warn.mock.calls.flat().join('\n')).not.toContain(authorizationUrl.toString());
+        expect(provider.hasAuthorizationRedirectStarted()).toBe(true);
 
-      await session.close();
-    } finally {
-      vi.unstubAllEnvs();
+        await session.close();
+      } finally {
+        vi.unstubAllEnvs();
+      }
     }
-  });
+  );
 
-  it('ignores falsy MCPORTER_OAUTH_NO_BROWSER values and still opens the browser', async () => {
+  it.each(['0', 'false', 'FALSE', 'no', '', 'unexpected'])(
+    'ignores falsy MCPORTER_OAUTH_NO_BROWSER=%j and still opens the browser',
+    async (envValue) => {
+      const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
+      tempDirs.push(tokenCacheDir);
+      const definition: ServerDefinition = {
+        name: 'test-oauth-env-no-browser-falsy',
+        description: 'Test OAuth server',
+        command: { kind: 'http', url: new URL('https://example.com/mcp') },
+        auth: 'oauth',
+        tokenCacheDir,
+      };
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+
+      vi.stubEnv('MCPORTER_OAUTH_NO_BROWSER', envValue);
+      try {
+        const session = await createOAuthSession(definition, logger);
+        const provider = session.provider as StatefulProvider;
+        const openSpy = vi.spyOn(__oauthInternals, 'openExternal').mockImplementation(() => {});
+        const authorizationUrl = new URL('https://example.com/auth?code=xyz');
+        const waitPromise = session.waitForAuthorizationCode().catch(() => undefined);
+
+        await provider.redirectToAuthorization(authorizationUrl);
+
+        expect(openSpy).toHaveBeenCalledWith(authorizationUrl.toString());
+
+        await session.close();
+        await waitPromise;
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    }
+  );
+
+  it('lets explicit suppressBrowserLaunch false override a truthy environment value', async () => {
     const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
     tempDirs.push(tokenCacheDir);
     const definition: ServerDefinition = {
-      name: 'test-oauth-env-no-browser-falsy',
-      description: 'Test OAuth server',
+      name: 'test-oauth-explicit-browser',
       command: { kind: 'http', url: new URL('https://example.com/mcp') },
       auth: 'oauth',
       tokenCacheDir,
     };
-    const logger = {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
-
-    vi.stubEnv('MCPORTER_OAUTH_NO_BROWSER', '0');
+    vi.stubEnv('MCPORTER_OAUTH_NO_BROWSER', 'yes');
     try {
-      const session = await createOAuthSession(definition, logger);
+      const session = await createOAuthSession(
+        definition,
+        { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        { suppressBrowserLaunch: false }
+      );
       const provider = session.provider as StatefulProvider;
       const openSpy = vi.spyOn(__oauthInternals, 'openExternal').mockImplementation(() => {});
-      const authorizationUrl = new URL('https://example.com/auth?code=xyz');
-      const waitPromise = session.waitForAuthorizationCode().catch(() => undefined);
+      const authorizationUrl = new URL('https://example.com/auth?explicit=true');
+      const pending = session.waitForAuthorizationCode().catch(() => undefined);
 
       await provider.redirectToAuthorization(authorizationUrl);
 
       expect(openSpy).toHaveBeenCalledWith(authorizationUrl.toString());
-
       await session.close();
-      await waitPromise;
+      await pending;
     } finally {
       vi.unstubAllEnvs();
     }


### PR DESCRIPTION
Fixes #283.

## What

`MCPORTER_OAUTH_NO_BROWSER` was parsed only inside the auth command's argv handling (`consumeBrowserSuppression`), so the serve/daemon path still launched the system browser on every 401 — a focus-stealing, context-free tab when a token expires under an MCP bridge, and a tab loop when auth keeps failing (details in the issue).

## How

- `redirectToAuthorization` now falls back to the env var when no explicit `suppressBrowserLaunch` option was passed: `this.options.suppressBrowserLaunch ?? suppressBrowserLaunchFromEnv()`. An explicit option always wins, and the accepted values (`1`/`true`/`yes`, case-insensitive) mirror the auth command's `TRUE_VALUES`.
- When suppression is active but no `onAuthorizationUrl` callback is registered (the headless serve/daemon case), the authorization URL is logged at warn level and the pending authorization is **rejected with a server-named `BrowserLaunchSuppressedError`** — callers fail fast with an actionable message (`run 'mcporter auth <name> --no-browser'`) instead of silently waiting out the authorization timeout (the "remaining risk" flagged in #283's review).
- The rejection path is deliberate: the SDK invokes `redirectToAuthorization` from unawaited send paths, where a throw becomes an unhandled rejection that kills the daemon (we hit exactly that in a real run while iterating).
- Existing callers that pass `suppressBrowserLaunch: true` with a callback (the auth command) are unaffected.

## Real behavior proof (daemon, real 401)

Isolated `$HOME` with an empty vault (guaranteed 401), one keep-alive OAuth server (Supabase's public MCP endpoint), foreground daemon built from this branch, real `callTool` through the daemon client:

```
$ HOME=$PROOF MCPORTER_OAUTH_NO_BROWSER=1 node dist/cli.js daemon start --foreground --log
[daemon] 2026-08-07T08:41:41.627Z Daemon host started.
[daemon] 2026-08-07T08:41:45.606Z callTool start server=supabase-room tool=list_tables
[mcporter] Authorization required for supabase-room; browser launch suppressed (MCPORTER_OAUTH_NO_BROWSER). Visit https://api.supabase.com/v1/oauth/authorize?response_type=code&client_id=cf4aec55-…&code_challenge=…&redirect_uri=http%3A%2F%2F127.0.0.1%3A62199%2Fcallback&… to authorize.
[mcporter] OAuth authorization required for 'supabase-room'. Waiting for browser approval...
[mcporter] OAuth authorization failed while waiting for callback.
BrowserLaunchSuppressedError: Authorization required for 'supabase-room' but browser launch is suppressed (MCPORTER_OAUTH_NO_BROWSER); run 'mcporter auth supabase-room --no-browser' to authorize.
[daemon] 2026-08-07T08:41:47.396Z callTool error server=supabase-room tool=list_tables err=Authorization required for 'supabase-room' but browser launch is suppressed (…)
[daemon] 2026-08-07T08:41:47.399Z closeServer success server=supabase-room     ← daemon healthy, handles the error
[daemon] 2026-08-07T08:41:48.341Z Shutting down daemon host.                   ← clean shutdown at end of capture

$ time HOME=$PROOF node dist/cli.js call supabase-room list_tables
[mcporter] Authorization required for 'supabase-room' but browser launch is suppressed (MCPORTER_OAUTH_NO_BROWSER); run 'mcporter auth supabase-room --no-browser' to authorize.
call exit: 1
2.828 total    ← fails in ~3s with the actionable error, not the 300s authorization timeout
```

No browser launched at any point (no `open` spawn; nothing hit the OS). On current main the same run logs `Authorization required for supabase-room. Opening browser...` and launches the system browser from the daemon.

(The client_id in the transcript is a throwaway Dynamic Client Registration from the isolated home, since deleted.)

## Tests

- Env var set, no session options → `openExternal` not called, URL surfaced at warn level, late-attaching waiter rejects with `BrowserLaunchSuppressedError` (server-named).
- Falsy value (`0`) → browser opens as before.
- Explicit `suppressBrowserLaunch: true` + callback (auth command path) → unchanged, existing test still green.
- `pnpm check` and full `pnpm test` green (1283 passed).
