### PR TITLE
fix(vault): accept dynamic client registration clientInfo in vault set

### DIFF
--- a/src/cli/vault-command.ts
+++ b/src/cli/vault-command.ts
@@ -9,6 +9,8 @@ interface VaultPayload {
   readonly clientInfo?: OAuthClientInformationMixed;
 }
 
+type VaultPayloadSource = { kind: 'file'; path: string } | { kind: 'stdin' };
+
 export interface VaultCommandOptions {
   readonly readStdin?: () => Promise<string>;
 }
@@ -44,7 +46,7 @@ async function handleVaultSet(
     throw new CliUsageError(`Unknown vault set argument '${args[0]}'.`);
   }
   const definition = runtime.getDefinition(server);
-  const payload = validateVaultPayload(parseVaultPayload(await readPayload(source, options)));
+  const payload = validateVaultPayload(parseVaultPayload(await readPayload(source, options), source));
   await saveVaultEntry(definition, {
     tokens: payload.tokens,
     ...(payload.clientInfo ? { clientInfo: payload.clientInfo } : {}),
@@ -65,7 +67,7 @@ async function handleVaultClear(runtime: Pick<Runtime, 'getDefinition'>, args: s
   console.log(`Cleared OAuth vault entry for '${definition.name}'`);
 }
 
-function consumeVaultPayloadSource(args: string[]): { kind: 'file'; path: string } | { kind: 'stdin' } {
+function consumeVaultPayloadSource(args: string[]): VaultPayloadSource {
   const fileIndex = args.indexOf('--tokens-file');
   const stdinIndex = args.indexOf('--stdin');
   if (fileIndex !== -1 && stdinIndex !== -1) {
@@ -86,10 +88,7 @@ function consumeVaultPayloadSource(args: string[]): { kind: 'file'; path: string
   throw new CliUsageError('Usage: mcporter vault set <server> (--tokens-file <path> | --stdin)');
 }
 
-async function readPayload(
-  source: { kind: 'file'; path: string } | { kind: 'stdin' },
-  options: VaultCommandOptions
-): Promise<string> {
+async function readPayload(source: VaultPayloadSource, options: VaultCommandOptions): Promise<string> {
   if (source.kind === 'file') {
     return fs.readFile(source.path, 'utf8');
   }
@@ -107,12 +106,17 @@ async function readPayload(
   });
 }
 
-function parseVaultPayload(raw: string): unknown {
+function parseVaultPayload(raw: string, source: VaultPayloadSource): unknown {
   try {
     return JSON.parse(raw) as unknown;
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error);
-    throw new CliUsageError(`Vault payload is not valid JSON: ${reason}`);
+  } catch {
+    // The parser message quotes a prefix of the input, which for this command is a
+    // credential payload, so name the source instead of repeating the reason.
+    throw new CliUsageError(
+      source.kind === 'file'
+        ? `Vault payload file '${source.path}' is not valid JSON.`
+        : 'Vault payload from stdin is not valid JSON.'
+    );
   }
 }
 
@@ -152,11 +156,13 @@ function validateOAuthTokens(tokens: Record<string, unknown>): void {
       throw new CliUsageError(`Vault payload tokens.${key} must be a string.`);
     }
   }
-  if (
-    tokens.expires_in !== undefined &&
-    (!Number.isFinite(tokens.expires_in) || typeof tokens.expires_in !== 'number')
-  ) {
-    throw new CliUsageError('Vault payload tokens.expires_in must be a finite number.');
+  // expires_in, expires_at and expiresAt are what isStoredOAuthTokens reads back as
+  // finite numbers; a non-numeric one is dropped there together with the rest of the
+  // tokens, so reject it at the input boundary instead.
+  for (const key of ['expires_in', 'expires_at', 'expiresAt'] as const) {
+    if (tokens[key] !== undefined && (typeof tokens[key] !== 'number' || !Number.isFinite(tokens[key]))) {
+      throw new CliUsageError(`Vault payload tokens.${key} must be a finite number.`);
+    }
   }
 }
 
@@ -177,15 +183,22 @@ const CLIENT_INFO_STRING_ARRAY: ClientInfoFieldRule = {
 
 const CLIENT_INFO_FINITE_NUMBER: ClientInfoFieldRule = {
   description: 'a finite number',
-  matches: (value) => Number.isFinite(value),
+  matches: (value) => typeof value === 'number' && Number.isFinite(value),
 };
 
-// Field types follow OAuthClientInformationFullSchema (RFC 7591 dynamic client
-// registration) from @modelcontextprotocol/sdk/shared/auth.js, in its declaration
-// order. `client_id` is required by both members of OAuthClientInformationMixed and
-// is checked separately. Fields the schema leaves open (`jwks`) and provider
-// extensions outside it (`registration_client_uri`, `registration_access_token`) are
-// deliberately absent, so a complete registration response reaches the vault intact.
+// Field types follow the JSON types OAuthClientInformationFullSchema (RFC 7591
+// dynamic client registration) declares in @modelcontextprotocol/sdk/shared/auth.js,
+// in its declaration order, with `issuer` appended because mcporter stores it and
+// isStoredOAuthClientInformation reads it back as a string. URL-shaped fields are
+// only checked for being strings; the SDK's stricter SafeUrlSchema would reject
+// redirect URIs that are legal in the wild, such as urn:ietf:wg:oauth:2.0:oob.
+//
+// `client_id` is required by both members of OAuthClientInformationMixed and is
+// checked separately. `redirect_uris` stays optional even though the schema's wide
+// member requires it, because the narrow member, OAuthClientInformation, is equally
+// valid here. Fields the schema leaves open (`jwks`) and provider extensions outside
+// it (`registration_client_uri`, `registration_access_token`) are deliberately
+// absent, so a complete registration response reaches the vault intact.
 const CLIENT_INFO_FIELD_RULES: Readonly<Record<string, ClientInfoFieldRule>> = {
   redirect_uris: CLIENT_INFO_STRING_ARRAY,
   token_endpoint_auth_method: CLIENT_INFO_STRING,
@@ -205,6 +218,7 @@ const CLIENT_INFO_FIELD_RULES: Readonly<Record<string, ClientInfoFieldRule>> = {
   client_secret: CLIENT_INFO_STRING,
   client_id_issued_at: CLIENT_INFO_FINITE_NUMBER,
   client_secret_expires_at: CLIENT_INFO_FINITE_NUMBER,
+  issuer: CLIENT_INFO_STRING,
 };
 
 function validateOAuthClientInfo(clientInfo: Record<string, unknown>): void {

--- a/src/cli/vault-command.ts
+++ b/src/cli/vault-command.ts
@@ -235,6 +235,9 @@ export function printVaultHelp(): void {
     '',
     'Payload:',
     '  { "tokens": { "access_token": "...", "token_type": "Bearer" }, "clientInfo": { "client_id": "..." } }',
+    '',
+    '  clientInfo accepts a full dynamic client registration response, including',
+    '  redirect_uris, grant_types, response_types and the registration timestamps.',
   ];
   console.error(lines.join('\n'));
 }

--- a/src/cli/vault-command.ts
+++ b/src/cli/vault-command.ts
@@ -44,7 +44,7 @@ async function handleVaultSet(
     throw new CliUsageError(`Unknown vault set argument '${args[0]}'.`);
   }
   const definition = runtime.getDefinition(server);
-  const payload = validateVaultPayload(JSON.parse(await readPayload(source, options)));
+  const payload = validateVaultPayload(parseVaultPayload(await readPayload(source, options)));
   await saveVaultEntry(definition, {
     tokens: payload.tokens,
     ...(payload.clientInfo ? { clientInfo: payload.clientInfo } : {}),
@@ -105,6 +105,15 @@ async function readPayload(
     process.stdin.on('end', () => resolve(data));
     process.stdin.on('error', reject);
   });
+}
+
+function parseVaultPayload(raw: string): unknown {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new CliUsageError(`Vault payload is not valid JSON: ${reason}`);
+  }
 }
 
 function validateVaultPayload(value: unknown): VaultPayload {

--- a/src/cli/vault-command.ts
+++ b/src/cli/vault-command.ts
@@ -151,10 +151,66 @@ function validateOAuthTokens(tokens: Record<string, unknown>): void {
   }
 }
 
+interface ClientInfoFieldRule {
+  readonly description: string;
+  readonly matches: (value: unknown) => boolean;
+}
+
+const CLIENT_INFO_STRING: ClientInfoFieldRule = {
+  description: 'a string',
+  matches: (value) => typeof value === 'string',
+};
+
+const CLIENT_INFO_STRING_ARRAY: ClientInfoFieldRule = {
+  description: 'an array of strings',
+  matches: (value) => Array.isArray(value) && value.every((entry) => typeof entry === 'string'),
+};
+
+const CLIENT_INFO_FINITE_NUMBER: ClientInfoFieldRule = {
+  description: 'a finite number',
+  matches: (value) => Number.isFinite(value),
+};
+
+// Field types follow OAuthClientInformationFullSchema (RFC 7591 dynamic client
+// registration) from @modelcontextprotocol/sdk/shared/auth.js, in its declaration
+// order. `client_id` is required by both members of OAuthClientInformationMixed and
+// is checked separately. Fields the schema leaves open (`jwks`) and provider
+// extensions outside it (`registration_client_uri`, `registration_access_token`) are
+// deliberately absent, so a complete registration response reaches the vault intact.
+const CLIENT_INFO_FIELD_RULES: Readonly<Record<string, ClientInfoFieldRule>> = {
+  redirect_uris: CLIENT_INFO_STRING_ARRAY,
+  token_endpoint_auth_method: CLIENT_INFO_STRING,
+  grant_types: CLIENT_INFO_STRING_ARRAY,
+  response_types: CLIENT_INFO_STRING_ARRAY,
+  client_name: CLIENT_INFO_STRING,
+  client_uri: CLIENT_INFO_STRING,
+  logo_uri: CLIENT_INFO_STRING,
+  scope: CLIENT_INFO_STRING,
+  contacts: CLIENT_INFO_STRING_ARRAY,
+  tos_uri: CLIENT_INFO_STRING,
+  policy_uri: CLIENT_INFO_STRING,
+  jwks_uri: CLIENT_INFO_STRING,
+  software_id: CLIENT_INFO_STRING,
+  software_version: CLIENT_INFO_STRING,
+  software_statement: CLIENT_INFO_STRING,
+  client_secret: CLIENT_INFO_STRING,
+  client_id_issued_at: CLIENT_INFO_FINITE_NUMBER,
+  client_secret_expires_at: CLIENT_INFO_FINITE_NUMBER,
+};
+
 function validateOAuthClientInfo(clientInfo: Record<string, unknown>): void {
-  for (const [key, value] of Object.entries(clientInfo)) {
-    if (value !== undefined && value !== null && typeof value !== 'string') {
-      throw new CliUsageError(`Vault payload clientInfo.${key} must be a string.`);
+  if (typeof clientInfo.client_id !== 'string' || clientInfo.client_id.length === 0) {
+    throw new CliUsageError('Vault payload clientInfo.client_id must be a non-empty string.');
+  }
+  // Iterate the rules rather than the payload: unknown keys pass through, and the
+  // reported field no longer depends on JSON key order.
+  for (const [key, rule] of Object.entries(CLIENT_INFO_FIELD_RULES)) {
+    const value = clientInfo[key];
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (!rule.matches(value)) {
+      throw new CliUsageError(`Vault payload clientInfo.${key} must be ${rule.description}.`);
     }
   }
 }

--- a/tests/vault-validation.test.ts
+++ b/tests/vault-validation.test.ts
@@ -1,9 +1,10 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { handleVault } from '../src/cli/vault-command.js';
 import type { ServerDefinition } from '../src/config.js';
+import { loadVaultEntry } from '../src/oauth-vault.js';
 
 const definition: ServerDefinition = {
   name: 'calendar',
@@ -11,6 +12,9 @@ const definition: ServerDefinition = {
 };
 const runtime = { getDefinition: () => definition };
 const stdin = (value: unknown) => ({ readStdin: async () => JSON.stringify(value) });
+const tokens = { access_token: 'token', token_type: 'Bearer' };
+
+const seed = (payload: unknown) => handleVault(runtime, ['set', 'calendar', '--stdin'], stdin(payload));
 
 describe('vault command input validation', () => {
   const originalDataHome = process.env.XDG_DATA_HOME;
@@ -19,11 +23,13 @@ describe('vault command input validation', () => {
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-vault-validation-'));
     process.env.XDG_DATA_HOME = tempDir;
+    vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
   afterEach(async () => {
     if (originalDataHome === undefined) delete process.env.XDG_DATA_HOME;
     else process.env.XDG_DATA_HOME = originalDataHome;
+    vi.restoreAllMocks();
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
@@ -55,17 +61,75 @@ describe('vault command input validation', () => {
       { tokens: { access_token: 'token', token_type: 'Bearer', expires_in: Number.POSITIVE_INFINITY } },
       'tokens.expires_in must be a finite number',
     ],
-    [
-      { tokens: { access_token: 'token', token_type: 'Bearer' }, clientInfo: [] },
-      "Vault payload 'clientInfo' must be an object",
-    ],
-    [
-      { tokens: { access_token: 'token', token_type: 'Bearer' }, clientInfo: { client_id: 42 } },
-      'clientInfo.client_id must be a string',
-    ],
+    [{ tokens, clientInfo: [] }, "Vault payload 'clientInfo' must be an object"],
+    [{ tokens, clientInfo: { client_id: 42 } }, 'clientInfo.client_id must be a non-empty string'],
   ])('rejects malformed payload %#', async (payload, message) => {
     await expect(handleVault(runtime, ['set', 'calendar', '--stdin'], stdin(payload))).rejects.toThrow(
       message as string
     );
+  });
+
+  it('accepts a dynamic client registration clientInfo payload', async () => {
+    const clientInfo = {
+      client_id: 'abc',
+      redirect_uris: ['https://example.test/cb'],
+      grant_types: ['authorization_code'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    };
+
+    await seed({ tokens, clientInfo });
+
+    await expect(loadVaultEntry(definition)).resolves.toMatchObject({ tokens, clientInfo });
+  });
+
+  it('accepts registration timestamps, contacts, and a jwks document', async () => {
+    const clientInfo = {
+      client_id: 'abc',
+      client_secret: 'secret',
+      client_id_issued_at: 1_754_600_000,
+      client_secret_expires_at: 0,
+      contacts: ['ops@example.test'],
+      jwks: { keys: [{ kty: 'RSA', n: 'abc', e: 'AQAB' }] },
+    };
+
+    await seed({ tokens, clientInfo });
+
+    await expect(loadVaultEntry(definition)).resolves.toMatchObject({ tokens, clientInfo });
+  });
+
+  it('preserves unknown clientInfo fields and seeded token expiry', async () => {
+    const payload = {
+      tokens: { ...tokens, expires_in: 3600, expires_at: 1_754_600_000, id_token: 'id-token' },
+      clientInfo: {
+        client_id: 'abc',
+        registration_client_uri: 'https://example.test/register/abc',
+        registration_access_token: 'registration-token',
+      },
+    };
+
+    await seed(payload);
+
+    await expect(loadVaultEntry(definition)).resolves.toMatchObject(payload);
+  });
+
+  it('treats null clientInfo fields as absent', async () => {
+    const clientInfo = { client_id: 'abc', client_secret: null, redirect_uris: null };
+
+    await seed({ tokens, clientInfo });
+
+    await expect(loadVaultEntry(definition)).resolves.toMatchObject({ clientInfo });
+  });
+
+  it.each([
+    [{ client_id: 'abc', redirect_uris: ['https://example.test/cb', 42] }, 'redirect_uris must be an array of strings'],
+    [{ client_id: 'abc', redirect_uris: 'https://example.test/cb' }, 'redirect_uris must be an array of strings'],
+    [{ client_id: 'abc', grant_types: 'authorization_code' }, 'grant_types must be an array of strings'],
+    [{ client_id: 'abc', client_id_issued_at: 'yesterday' }, 'client_id_issued_at must be a finite number'],
+    [{ client_id: 'abc', client_secret_expires_at: 'never' }, 'client_secret_expires_at must be a finite number'],
+    [{ client_id: 'abc', client_name: 42 }, 'client_name must be a string'],
+    [{}, 'clientInfo.client_id must be a non-empty string'],
+  ])('rejects malformed clientInfo %#', async (clientInfo, message) => {
+    await expect(seed({ tokens, clientInfo })).rejects.toThrow(message as string);
   });
 });

--- a/tests/vault-validation.test.ts
+++ b/tests/vault-validation.test.ts
@@ -69,6 +69,12 @@ describe('vault command input validation', () => {
     );
   });
 
+  it('reports malformed JSON as a usage error', async () => {
+    await expect(
+      handleVault(runtime, ['set', 'calendar', '--stdin'], { readStdin: async () => '{"tokens":' })
+    ).rejects.toThrow('Vault payload is not valid JSON');
+  });
+
   it('accepts a dynamic client registration clientInfo payload', async () => {
     const clientInfo = {
       client_id: 'abc',

--- a/tests/vault-validation.test.ts
+++ b/tests/vault-validation.test.ts
@@ -61,6 +61,14 @@ describe('vault command input validation', () => {
       { tokens: { access_token: 'token', token_type: 'Bearer', expires_in: Number.POSITIVE_INFINITY } },
       'tokens.expires_in must be a finite number',
     ],
+    [
+      { tokens: { access_token: 'token', token_type: 'Bearer', expires_at: 'soon' } },
+      'tokens.expires_at must be a finite number',
+    ],
+    [
+      { tokens: { access_token: 'token', token_type: 'Bearer', expiresAt: 'soon' } },
+      'tokens.expiresAt must be a finite number',
+    ],
     [{ tokens, clientInfo: [] }, "Vault payload 'clientInfo' must be an object"],
     [{ tokens, clientInfo: { client_id: 42 } }, 'clientInfo.client_id must be a non-empty string'],
   ])('rejects malformed payload %#', async (payload, message) => {
@@ -69,10 +77,19 @@ describe('vault command input validation', () => {
     );
   });
 
-  it('reports malformed JSON as a usage error', async () => {
+  it('reports malformed stdin JSON as a usage error without echoing the payload', async () => {
     await expect(
-      handleVault(runtime, ['set', 'calendar', '--stdin'], { readStdin: async () => '{"tokens":' })
-    ).rejects.toThrow('Vault payload is not valid JSON');
+      handleVault(runtime, ['set', 'calendar', '--stdin'], { readStdin: async () => 'sk-live-9f8e7d6c5b4a' })
+    ).rejects.toThrow('Vault payload from stdin is not valid JSON.');
+  });
+
+  it('names the file when its JSON is malformed', async () => {
+    const payloadPath = path.join(tempDir, 'tokens.json');
+    await fs.writeFile(payloadPath, '{"tokens":', 'utf8');
+
+    await expect(handleVault(runtime, ['set', 'calendar', '--tokens-file', payloadPath])).rejects.toThrow(
+      `Vault payload file '${payloadPath}' is not valid JSON.`
+    );
   });
 
   it('accepts a dynamic client registration clientInfo payload', async () => {
@@ -109,6 +126,7 @@ describe('vault command input validation', () => {
       tokens: { ...tokens, expires_in: 3600, expires_at: 1_754_600_000, id_token: 'id-token' },
       clientInfo: {
         client_id: 'abc',
+        issuer: 'https://issuer.example',
         registration_client_uri: 'https://example.test/register/abc',
         registration_access_token: 'registration-token',
       },
@@ -119,7 +137,7 @@ describe('vault command input validation', () => {
     await expect(loadVaultEntry(definition)).resolves.toMatchObject(payload);
   });
 
-  it('treats null clientInfo fields as absent', async () => {
+  it('persists null clientInfo fields verbatim', async () => {
     const clientInfo = { client_id: 'abc', client_secret: null, redirect_uris: null };
 
     await seed({ tokens, clientInfo });
@@ -134,6 +152,7 @@ describe('vault command input validation', () => {
     [{ client_id: 'abc', client_id_issued_at: 'yesterday' }, 'client_id_issued_at must be a finite number'],
     [{ client_id: 'abc', client_secret_expires_at: 'never' }, 'client_secret_expires_at must be a finite number'],
     [{ client_id: 'abc', client_name: 42 }, 'client_name must be a string'],
+    [{ client_id: 'abc', issuer: 42 }, 'clientInfo.issuer must be a string'],
     [{}, 'clientInfo.client_id must be a non-empty string'],
   ])('rejects malformed clientInfo %#', async (clientInfo, message) => {
     await expect(seed({ tokens, clientInfo })).rejects.toThrow(message as string);


### PR DESCRIPTION
## Summary

Fixes #286. `mcporter vault set` rejects every `clientInfo` value that is not a string, so no real dynamic client registration response can be seeded into the vault. In RFC 7591, `redirect_uris`, `grant_types`, `response_types` and `contacts` are string arrays, and `client_id_issued_at` and `client_secret_expires_at` are numbers. A headless deployment that already holds OAuth credentials has no way to install them.

The declared type says otherwise. `VaultPayload.clientInfo` is `OAuthClientInformationMixed`, and mcporter builds that same array-valued shape itself in `buildStaticClientInformation` (`src/oauth-client-info.ts:15`) and during registration (`src/oauth.ts:115`), then reads `clientInfo.redirect_uris` back as an array (`src/oauth.ts:506`). Its own client information cannot round-trip through its own command.

### Root cause

`src/cli/vault-command.ts:154`

```ts
function validateOAuthClientInfo(clientInfo: Record<string, unknown>): void {
  for (const [key, value] of Object.entries(clientInfo)) {
    if (value !== undefined && value !== null && typeof value !== 'string') {
      throw new CliUsageError(`Vault payload clientInfo.${key} must be a string.`);
    }
  }
}
```

One rule for every field. `validateOAuthTokens`, directly above it, already does the opposite: `access_token` and `token_type` non-empty strings, `refresh_token`/`scope`/`issuer` optional strings, `expires_in` a finite number. So the tokens half of the payload accepts its real shape and the client-information half does not.

## Fix

`validateOAuthClientInfo` now checks each field against the JSON type `OAuthClientInformationFullSchema` declares for it (`@modelcontextprotocol/sdk/shared/auth.js`), in that schema's declaration order:

| Type | Fields |
| --- | --- |
| non-empty string, required | `client_id` |
| string | `token_endpoint_auth_method`, `client_name`, `client_uri`, `logo_uri`, `scope`, `tos_uri`, `policy_uri`, `jwks_uri`, `software_id`, `software_version`, `software_statement`, `client_secret`, `issuer` |
| array of strings | `redirect_uris`, `grant_types`, `response_types`, `contacts` |
| finite number | `client_id_issued_at`, `client_secret_expires_at` |

The loop walks the rule table rather than the payload. Unknown keys therefore pass through untouched, so a full registration response keeps `registration_client_uri`, `registration_access_token` and whatever else the provider returned, and the reported field no longer depends on JSON key order. `jwks` stays unconstrained because the SDK types it as `z.any()`. `redirect_uris` stays optional even though the schema's wide member requires it, since the narrow member `OAuthClientInformation` is equally valid here. `null` is still treated as absent, as before.

URL-shaped fields are only checked for being strings. The SDK's `SafeUrlSchema` would additionally require a parseable URL. That starts rejecting redirect URIs that are legal in the wild, such as `urn:ietf:wg:oauth:2.0:oob` and custom-scheme mobile redirects, which is the wrong trade in a change whose point is to stop over-rejecting.

I kept the SDK's zod schemas out of this path for a related reason. They are all `.strip()`, so validating through them invites persisting `result.data`, which would quietly drop seeded fields the vault depends on: `tokens.expires_at` is read at `src/oauth-persistence-stores.ts:37`, `src/oauth-token-refresh.ts:33` and `src/runtime/oauth.ts:123`, and `validateVaultPayload` deliberately returns the raw objects by reference. A union of `OAuthClientInformationFullSchema` and `OAuthClientInformationSchema` would not validate much either, since the second member requires only `client_id` and strips the rest, so `{ client_id: "abc", redirect_uris: 42 }` passes it.

`validateVaultPayload` is unchanged, including the order in which it validates tokens before client information.

### Also: three fields the read path requires and the write path did not check

`externalVaultEntry` (`src/oauth-vault.ts:220`) runs stored credentials through `isStoredOAuthTokens` and `isStoredOAuthClientInformation`, and drops the whole `tokens` or `clientInfo` object when a guard fails. Those guards require `clientInfo.issuer` to be a string and `tokens.expires_at`/`tokens.expiresAt` to be finite numbers. `vault set` checked none of the three, so a typo in one field silently discarded everything next to it, and the command still printed `Saved OAuth credentials`.

`clientInfo.issuer` was covered incidentally by the old string-only rule, so the per-field table has to keep covering it. It is worth naming because `vault set` is the only writer of that field and its only consumer is a security check: `assertRefreshIssuerBinding` (`src/oauth-token-refresh.ts:86`) pins refresh to the recorded issuer, and an unusable value turns the pin into a no-op. `tokens.expires_at` and `expiresAt` are the pre-existing half, folded into the same loop as `expires_in`.

### Deliberate tightening: client_id is now required

Today `{"clientInfo": {}}` is accepted. Both members of `OAuthClientInformationMixed` require `client_id`, so the existing `as OAuthClientInformationMixed` cast does not hold for that value. And `{}` is not read downstream as "no client information": it is a truthy object that `saveVaultEntry` persists and `getClientInformation()` later hands back in place of the statically configured client, so the failure surfaces much later as an opaque SDK error during refresh. `clientIdFromEntry` (`src/oauth-vault.ts:302`) and same-URL credential inheritance both need it too. This does make the write side stricter than `isStoredOAuthClientInformation`, which does not require `client_id`, and it is a behavior change, so I would rather flag it than bury it. It is one `if` plus one test case if you would rather not take it.

### Two adjacent fixes in the same input path

- `JSON.parse` at line 47 was unguarded, so an unparsable payload left the command as a raw `SyntaxError` and printed a stack trace through the unexpected-error path instead of the usage path every other payload problem already uses. It now fails as a `CliUsageError` naming the source. The message deliberately does not repeat the parser's reason: V8 quotes a prefix of the input (`Unexpected token 's', "sk-live-9f"... is not valid JSON`), and the input here is credential material that can end up in a CI log. Naming the file follows `src/cli/call-arguments.ts:373`.
- The `vault set` help text showed `clientInfo` as `client_id` alone, which reads as the whole contract and is plausibly where the expectation in the issue came from. It now says a full registration response is accepted.

## Behavior proof

The real CLI through `tsx src/cli.ts`, throwaway `XDG_CONFIG_HOME` and `XDG_DATA_HOME`, and the payload from the issue verbatim. The access token is fake and `https://example.test/mcp` is never contacted.

```
=== BEFORE (main @ 764bb87) ===
--- mcporter vault set demo --stdin
[mcporter] Vault payload clientInfo.redirect_uris must be a string.
--- stored vault entry
(no credentials file written)
--- mcporter vault set demo --stdin  (truncated JSON)
[mcporter] Unexpected end of JSON input
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)

=== AFTER (this branch) ===
--- mcporter vault set demo --stdin
Saved OAuth credentials for 'demo' to <temp>/mcporter/credentials.json
--- stored vault entry
{
  "tokens": {
    "access_token": "fake",
    "token_type": "Bearer",
    "__mcporter_generation": "a344f320-3658-4b95-b6b4-972186d02740"
  },
  "clientInfo": {
    "client_id": "abc",
    "redirect_uris": [
      "https://example.test/cb"
    ],
    "grant_types": [
      "authorization_code"
    ],
    "response_types": [
      "code"
    ],
    "token_endpoint_auth_method": "none",
    "__mcporter_client_generation": "8468dd59-b501-47ff-a77e-7a76f3b471ab"
  }
}
--- mcporter vault set demo --stdin  (truncated JSON)
[mcporter] Vault payload from stdin is not valid JSON.
```

Same harness for the guard mismatch, reading the entry back through `loadVaultEntry` so the read-path guards actually run:

```
=== BEFORE (main @ 764bb87) ===
--- tokens.expires_at = "soon"
Saved OAuth credentials for 'demo' to <temp>/mcporter/credentials.json
    loadVaultEntry: (entry carries neither tokens nor clientInfo)
--- clientInfo.issuer = 42
[mcporter] Vault payload clientInfo.issuer must be a string.
    loadVaultEntry: (no vault entry)

=== AFTER (this branch) ===
--- tokens.expires_at = "soon"
[mcporter] Vault payload tokens.expires_at must be a finite number.
    loadVaultEntry: (no vault entry)
--- clientInfo.issuer = 42
[mcporter] Vault payload clientInfo.issuer must be a string.
    loadVaultEntry: (no vault entry)
```

The first case is the silent loss: the command reports success and the credentials are unreadable. The second is the one the old rule already caught and the new table has to keep catching.

## Tests

`tests/vault-validation.test.ts` goes from 16 to 32 cases, in the table-driven style the file already uses:

- `accepts a dynamic client registration clientInfo payload` — the issue's payload verbatim.
- `accepts registration timestamps, contacts, and a jwks document` — `client_secret`, `client_id_issued_at`, `client_secret_expires_at: 0`, `contacts`, and a `jwks` document. Both acceptance cases assert the stored entry through `loadVaultEntry`, not the input object, so a dropped `clientInfo` fails the test.
- `preserves unknown clientInfo fields and seeded token expiry` — `issuer`, `registration_client_uri`, `registration_access_token`, `tokens.expires_at` and `id_token` all reach the vault verbatim. This is the case that fails if anyone later swaps the validator for one that reparses the payload.
- `persists null clientInfo fields verbatim` — the pre-0.12.1 null tolerance, held in place.
- `rejects malformed clientInfo` — a non-string entry inside `redirect_uris`, `redirect_uris` and `grant_types` given as bare strings, `client_id_issued_at` and `client_secret_expires_at` given as strings, a non-string `client_name`, a non-string `issuer`, and `clientInfo` with no `client_id`.
- `rejects malformed payload` — the existing rows plus `tokens.expires_at` and `tokens.expiresAt` given as strings.
- `reports malformed stdin JSON as a usage error without echoing the payload` and `names the file when its JSON is malformed` — one per input source.

Reverting only `src/cli/vault-command.ts` to main and keeping the tests:

```
=== tests against the unpatched validator ===
 FAIL  rejects malformed payload 6            (tokens.expires_at)
 FAIL  rejects malformed payload 7            (tokens.expiresAt)
 FAIL  rejects malformed payload 9            (clientInfo.client_id message)
 FAIL  reports malformed stdin JSON as a usage error without echoing the payload
 FAIL  names the file when its JSON is malformed
 FAIL  accepts a dynamic client registration clientInfo payload
 FAIL  accepts registration timestamps, contacts, and a jwks document
 FAIL  rejects malformed clientInfo 0         (redirect_uris entry)
 FAIL  rejects malformed clientInfo 1         (redirect_uris as string)
 FAIL  rejects malformed clientInfo 2         (grant_types as string)
 FAIL  rejects malformed clientInfo 3         (client_id_issued_at)
 FAIL  rejects malformed clientInfo 4         (client_secret_expires_at)
 FAIL  rejects malformed clientInfo 7         (missing client_id)
      Tests  13 failed | 19 passed (32)
```

The other 19 pass on both sides and cover what this change must not alter, including `rejects malformed clientInfo 6`, the `issuer` case.

One committed expectation moved: the row asserting `clientInfo.client_id must be a string` for `client_id: 42` now expects `must be a non-empty string`, matching `tokens.access_token`.

## Gates

Windows 11, Node 22.20.0, pnpm 10.33.2.

- `pnpm exec vitest run tests/vault-validation.test.ts tests/vault-command.test.ts` — 37 passed.
- `pnpm check` — oxfmt, type-aware oxlint and `tsc --noEmit` clean.
- `pnpm build` — clean.
- `pnpm test` — 1283 passed, 84 skipped, 7 failed. The 7 are in `tests/chrome-devtools-relay-handoff.test.ts` and `tests/runtime-chrome-relay-handoff.test.ts`, and they fail identically on unmodified `main` at 764bb87 on this machine (`Invalid URL` from the relay handoff), so they predate this branch and touch nothing it changes. I could not clear them here because this box is below the engine floor the repo declares (`node >=24`). CI settles it: `build` passes on ubuntu-latest, macos-15 and windows-latest for this branch.

Thanks @feniix for the report. The version table and the pointer straight at the validator left nothing to guess.
