### PR TITLE
fix(oauth): preserve DCR client through silent refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### OAuth
 
 - Honor `MCPORTER_OAUTH_NO_BROWSER` across serve/daemon OAuth flows, fail once with actionable reauthorization guidance without logging authorization URLs, and restart daemons when the normalized setting changes. (PR #284 / issue #283, thanks @vitalijssilins)
+- Preserve refreshable dynamic OAuth client registrations across fresh callback ports, replacing an obsolete redirect registration only when interactive authorization is required. (Issue #290, thanks @elecnix)
 - Accept RFC 7591 dynamic-client-registration arrays and timestamps in `mcporter vault set` while preserving null-compatible partial client information and provider metadata. (PR #288 / issue #286, thanks @feniix)
 - Sanitize malformed `mcporter vault set` JSON diagnostics and reject non-finite `expires_at` / `expiresAt` token values before persistence. (Follow-up to PR #287, thanks @Yigtwxx)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.13.2] - Unreleased
 
+### OAuth
+
+- Preserve refreshable dynamic OAuth client registrations across fresh callback ports, replacing an obsolete redirect registration only when interactive authorization is required. (Issue #290, thanks @elecnix)
+
 ## [0.13.1] - 2026-08-08
 
 ### CLI
@@ -17,7 +21,6 @@
 ### OAuth
 
 - Honor `MCPORTER_OAUTH_NO_BROWSER` across serve/daemon OAuth flows, fail once with actionable reauthorization guidance without logging authorization URLs, and restart daemons when the normalized setting changes. (PR #284 / issue #283, thanks @vitalijssilins)
-- Preserve refreshable dynamic OAuth client registrations across fresh callback ports, replacing an obsolete redirect registration only when interactive authorization is required. (Issue #290, thanks @elecnix)
 - Accept RFC 7591 dynamic-client-registration arrays and timestamps in `mcporter vault set` while preserving null-compatible partial client information and provider metadata. (PR #288 / issue #286, thanks @feniix)
 - Sanitize malformed `mcporter vault set` JSON diagnostics and reject non-finite `expires_at` / `expiresAt` token values before persistence. (Follow-up to PR #287, thanks @Yigtwxx)
 

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -481,7 +481,7 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
   }
 
   private async invalidateObsoleteDynamicRegistration(): Promise<void> {
-    if (!this.usesDynamicPort || this.definition.oauthClientId || this.definition.oauthClientMetadataUrl) {
+    if (!this.usesDynamicPort || this.definition.oauthClientId) {
       return;
     }
     let snapshot: OAuthPersistenceSnapshot;
@@ -492,6 +492,12 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
       throw error;
     }
     const cachedClient = snapshot.clientInfo;
+    // Configuring a metadata URL does not mean the authorization server accepted
+    // URL-based client IDs. The SDK falls back to DCR when support is absent, so
+    // only preserve the registration when that URL is the client identity in use.
+    if (cachedClient?.client_id === this.definition.oauthClientMetadataUrl) {
+      return;
+    }
     const cachedRedirect = firstRedirectUri(cachedClient);
     if (!cachedClient || !cachedRedirect || cachedRedirect === this.redirectUrlValue.toString()) {
       return;

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -14,7 +14,7 @@ import { validateClientMetadataUrl } from '@modelcontextprotocol/client';
 import type { ServerDefinition } from './config.js';
 import { suppressBrowserLaunchFromEnv } from './oauth-browser-suppression.js';
 import { buildStaticClientInformation } from './oauth-client-info.js';
-import type { OAuthPersistence } from './oauth-persistence.js';
+import type { OAuthPersistence, OAuthPersistenceSnapshot } from './oauth-persistence.js';
 import { buildOAuthPersistence } from './oauth-persistence.js';
 
 const CALLBACK_HOST = '127.0.0.1';
@@ -49,6 +49,13 @@ export class BrowserLaunchSuppressedError extends Error {
     );
     this.name = 'BrowserLaunchSuppressedError';
     this.serverName = serverName;
+  }
+}
+
+export class OAuthRedirectUriMismatchError extends Error {
+  constructor(serverName: string) {
+    super(`OAuth client registration for '${serverName}' used an obsolete redirect URI.`);
+    this.name = 'OAuthRedirectUriMismatchError';
   }
 }
 
@@ -120,6 +127,7 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
     persistence: OAuthPersistence,
     redirectUrl: URL,
     logger: OAuthLogger,
+    private readonly usesDynamicPort: boolean,
     private readonly options: OAuthSessionOptions = {}
   ) {
     this.redirectUrlValue = redirectUrl;
@@ -181,31 +189,14 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
       redirectUrl.pathname = callbackPath;
     }
 
-    // When using a dynamic port, the redirect URI changes every run.  If a
-    // previous client registration is cached with a different redirect URI the
-    // auth server will reject the request with `invalid_redirect_uri`.  Clear
-    // the stale registration so the next flow re-registers with the new URI.
-    // Wrapped in try/catch so non-recoverable persistence errors (for example,
-    // permission issues) close the already-bound callback server instead of leaking it.
-    if (usesDynamicPort) {
-      try {
-        const cachedClient = await persistence.readClientInfo();
-        const cachedRedirect = firstRedirectUri(cachedClient);
-        if (cachedRedirect && cachedRedirect !== redirectUrl.toString()) {
-          logger.info(
-            `Redirect URI changed (${cachedRedirect} → ${redirectUrl.toString()}); clearing stale client registration.`
-          );
-          await persistence.clear('client');
-        }
-      } catch (error) {
-        await new Promise<void>((resolve) => {
-          server.close(() => resolve());
-        });
-        throw error;
-      }
-    }
-
-    const provider = new PersistentOAuthClientProvider(definition, persistence, redirectUrl, logger, options);
+    const provider = new PersistentOAuthClientProvider(
+      definition,
+      persistence,
+      redirectUrl,
+      logger,
+      usesDynamicPort,
+      options
+    );
     provider.attachServer(server);
     return {
       provider,
@@ -328,6 +319,7 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
   }
 
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    await this.invalidateObsoleteDynamicRegistration();
     this.authorizationRedirectStarted = true;
     this.ensureAuthorizationDeferred();
     const challenge = authorizationUrl.searchParams.get('code_challenge');
@@ -486,6 +478,36 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
   private clearInteractiveAuthorization(): void {
     this.interactiveAuthorization = null;
     this.pendingVerifiersByChallenge.clear();
+  }
+
+  private async invalidateObsoleteDynamicRegistration(): Promise<void> {
+    if (!this.usesDynamicPort || this.definition.oauthClientId || this.definition.oauthClientMetadataUrl) {
+      return;
+    }
+    let snapshot: OAuthPersistenceSnapshot;
+    try {
+      snapshot = await this.persistence.readSnapshot();
+    } catch (error) {
+      await this.close();
+      throw error;
+    }
+    const cachedClient = snapshot.clientInfo;
+    const cachedRedirect = firstRedirectUri(cachedClient);
+    if (!cachedClient || !cachedRedirect || cachedRedirect === this.redirectUrlValue.toString()) {
+      return;
+    }
+    this.logger.info(
+      `Redirect URI changed (${cachedRedirect} → ${this.redirectUrlValue.toString()}); replacing obsolete client registration before interactive authorization.`
+    );
+    try {
+      // A failed refresh makes this exact token/client pair unusable for the
+      // upcoming callback. Generation checks preserve any concurrent winner.
+      await this.persistence.clearRejectedCredentials(snapshot.tokens, cachedClient);
+    } catch (error) {
+      await this.close();
+      throw error;
+    }
+    throw new OAuthRedirectUriMismatchError(this.definition.name);
   }
 }
 

--- a/src/runtime/http-transport.ts
+++ b/src/runtime/http-transport.ts
@@ -287,20 +287,17 @@ async function connectSseFallbackTransport(
   wrapRecordTransport: WrapRecordTransport,
   clientFactory: HttpClientFactory
 ): Promise<ClientContext> {
+  const createSseTransport = () =>
+    wrapRecordTransport(new SSEClientTransport(command.url, transportOptions), definition, options);
   try {
-    const transport = await connectHttpTransport(
-      client,
-      wrapRecordTransport(new SSEClientTransport(command.url, transportOptions), definition, options),
-      oauthSession,
-      logger,
-      {
-        serverName: definition.name,
-        serverUrl: command.url,
-        maxAttempts: options.maxOAuthAttempts,
-        oauthTimeoutMs: options.oauthTimeoutMs,
-        signal: options.signal,
-      }
-    );
+    const transport = await connectHttpTransport(client, createSseTransport(), oauthSession, logger, {
+      serverName: definition.name,
+      serverUrl: command.url,
+      maxAttempts: options.maxOAuthAttempts,
+      oauthTimeoutMs: options.oauthTimeoutMs,
+      signal: options.signal,
+      recreateTransport: async () => createSseTransport(),
+    });
     return { client, transport, definition, oauthSession };
   } catch (sseError) {
     await closeOAuthSession(oauthSession);

--- a/src/runtime/oauth.ts
+++ b/src/runtime/oauth.ts
@@ -6,7 +6,7 @@ import {
   type Transport,
 } from '@modelcontextprotocol/client';
 import type { Logger } from '../logging.js';
-import type { OAuthAuthorizationResponse, OAuthSession } from '../oauth.js';
+import { type OAuthAuthorizationResponse, OAuthRedirectUriMismatchError, type OAuthSession } from '../oauth.js';
 import { isUnauthorizedError } from '../runtime-oauth-support.js';
 
 export const DEFAULT_OAUTH_CODE_TIMEOUT_MS = 300_000;
@@ -34,6 +34,7 @@ interface OAuthConnectState {
   activeTransport: OAuthCapableTransport;
   attempt: number;
   hasCompletedAuthFlow: boolean;
+  repairedRedirectMismatch: boolean;
 }
 
 export class OAuthTimeoutError extends Error {
@@ -136,6 +137,7 @@ export async function connectWithAuth(
     activeTransport: transport,
     attempt: 0,
     hasCompletedAuthFlow: false,
+    repairedRedirectMismatch: false,
   };
 
   while (true) {
@@ -155,6 +157,15 @@ export async function connectWithAuth(
       }
       return state.activeTransport;
     } catch (error) {
+      if (error instanceof OAuthRedirectUriMismatchError) {
+        if (state.repairedRedirectMismatch || !recreateTransport) {
+          await closeReplacementTransport(transport, state.activeTransport);
+          throw markOAuthFlowError(error);
+        }
+        state.repairedRedirectMismatch = true;
+        state.activeTransport = await recreateOAuthTransport(state.activeTransport, recreateTransport);
+        continue;
+      }
       const unauthorized = isUnauthorizedError(error);
       if (!shouldRetryAuthorization(state, unauthorized, session)) {
         await closeReplacementTransport(transport, state.activeTransport);
@@ -223,6 +234,15 @@ async function closeReplacementTransport(
   await activeTransport.close().catch(() => {});
 }
 
+async function recreateOAuthTransport(
+  activeTransport: OAuthCapableTransport,
+  recreateTransport: (transport: OAuthCapableTransport) => Promise<OAuthCapableTransport>
+): Promise<OAuthCapableTransport> {
+  const replacement = await recreateTransport(activeTransport);
+  await activeTransport.close().catch(() => {});
+  return replacement;
+}
+
 async function completeAuthorizationChallenge(
   transport: OAuthCapableTransport,
   session: OAuthSession,
@@ -258,7 +278,8 @@ async function completeProactiveAuthorization(
   logger: Logger,
   options: Pick<ConnectWithAuthOptions, 'serverName' | 'oauthTimeoutMs' | 'serverUrl' | 'fetchFn'>
 ): Promise<void> {
-  if (!options.serverUrl) {
+  const serverUrl = options.serverUrl;
+  if (!serverUrl) {
     return;
   }
   try {
@@ -266,10 +287,20 @@ async function completeProactiveAuthorization(
     if (hasUsableCachedAccessToken(cachedTokens)) {
       return;
     }
-    const result = await sdkAuth(session.provider, {
-      serverUrl: options.serverUrl,
-      fetchFn: options.fetchFn,
-    });
+    const runAuth = () =>
+      sdkAuth(session.provider, {
+        serverUrl,
+        fetchFn: options.fetchFn,
+      });
+    let result;
+    try {
+      result = await runAuth();
+    } catch (error) {
+      if (!(error instanceof OAuthRedirectUriMismatchError)) {
+        throw error;
+      }
+      result = await runAuth();
+    }
     if (result !== 'REDIRECT') {
       await session.close().catch(() => {});
       return;

--- a/tests/fixtures/oauth-refresh-process.mjs
+++ b/tests/fixtures/oauth-refresh-process.mjs
@@ -1,0 +1,59 @@
+import { buildOAuthPersistence, readCachedAccessToken } from '../../dist/oauth-persistence.js';
+import { createOAuthSession } from '../../dist/oauth.js';
+import { connectWithAuth } from '../../dist/runtime/oauth.js';
+
+const action = process.argv[2];
+const endpoint = process.env.MCPORTER_TEST_OAUTH_ENDPOINT;
+const tokenCacheDir = process.env.MCPORTER_TEST_OAUTH_CACHE_DIR;
+if (!action || !endpoint || !tokenCacheDir) {
+  throw new Error('Expected action, MCPORTER_TEST_OAUTH_ENDPOINT, and MCPORTER_TEST_OAUTH_CACHE_DIR.');
+}
+
+const definition = {
+  name: 'oauth-refresh-process',
+  command: { kind: 'http', url: new URL(endpoint) },
+  auth: 'oauth',
+  tokenCacheDir,
+};
+const logger = { info() {}, warn() {}, error() {}, debug() {} };
+
+if (action === 'seed') {
+  const persistence = await buildOAuthPersistence(definition, logger);
+  await persistence.saveClientInfo({
+    client_id: 'fresh-process-client',
+    redirect_uris: ['http://127.0.0.1:41000/callback'],
+    token_endpoint_auth_method: 'none',
+  });
+  await persistence.saveTokens({
+    access_token: 'expired-process-token',
+    token_type: 'Bearer',
+    refresh_token: 'fresh-process-refresh-token',
+    expires_at: 1,
+  });
+  process.stdout.write('seeded\n');
+} else if (action === 'refresh') {
+  const accessToken = await readCachedAccessToken(definition, logger);
+  let authorizationPrompts = 0;
+  const session = await createOAuthSession(definition, logger, {
+    suppressBrowserLaunch: true,
+    onAuthorizationUrl: () => {
+      authorizationPrompts += 1;
+    },
+  });
+  await connectWithAuth({ connect: async () => {} }, { close: async () => {} }, session, logger, {
+    serverName: definition.name,
+    serverUrl: endpoint,
+    fetchFn: fetch,
+  });
+  const snapshot = await (await buildOAuthPersistence(definition, logger)).readSnapshot();
+  process.stdout.write(
+    `${JSON.stringify({
+      accessToken,
+      authorizationPrompts,
+      clientId: snapshot.clientInfo?.client_id,
+      refreshToken: snapshot.tokens?.refresh_token,
+    })}\n`
+  );
+} else {
+  throw new Error(`Unknown action '${action}'.`);
+}

--- a/tests/oauth-refresh-process.integration.test.ts
+++ b/tests/oauth-refresh-process.integration.test.ts
@@ -1,0 +1,142 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ensureDistBuilt } from './helpers/dist.js';
+import { budget } from './helpers/timing.js';
+
+const CLI_ENTRY = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
+const PROCESS_FIXTURE = fileURLToPath(new URL('./fixtures/oauth-refresh-process.mjs', import.meta.url));
+
+describe('OAuth refresh across fresh built-artifact processes', () => {
+  let server: Server;
+  let endpoint: string;
+  let authOrigin: string;
+  let tempDir: string;
+  const tokenRequests: URLSearchParams[] = [];
+
+  beforeAll(async () => {
+    await ensureDistBuilt(CLI_ENTRY);
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-refresh-process-'));
+    server = createServer(async (request, response) => {
+      const base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+      const url = new URL(request.url ?? '/', base);
+      if (url.pathname.includes('.well-known/oauth-protected-resource')) {
+        return sendJson(response, {
+          resource: endpoint,
+          authorization_servers: [authOrigin],
+        });
+      }
+      if (
+        url.pathname.includes('.well-known/oauth-authorization-server') ||
+        url.pathname.includes('openid-configuration')
+      ) {
+        return sendJson(response, {
+          issuer: authOrigin,
+          authorization_endpoint: `${authOrigin}/authorize`,
+          token_endpoint: `${authOrigin}/token`,
+          registration_endpoint: `${authOrigin}/register`,
+          response_types_supported: ['code'],
+          grant_types_supported: ['authorization_code', 'refresh_token'],
+          token_endpoint_auth_methods_supported: ['none'],
+          code_challenge_methods_supported: ['S256'],
+        });
+      }
+      if (url.pathname === '/token' && request.method === 'POST') {
+        const body = await readBody(request);
+        tokenRequests.push(new URLSearchParams(body));
+        return sendJson(response, {
+          access_token: 'fresh-process-access-token',
+          token_type: 'Bearer',
+          refresh_token: 'rotated-process-refresh-token',
+          expires_in: 3600,
+        });
+      }
+      response.statusCode = 404;
+      response.end('not found');
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    authOrigin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    endpoint = `${authOrigin}/mcp`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it(
+    'keeps the dynamic client identity after a silent refresh in a new process',
+    async () => {
+      const env = {
+        ...process.env,
+        HOME: path.join(tempDir, 'home'),
+        XDG_CONFIG_HOME: path.join(tempDir, 'config'),
+        XDG_DATA_HOME: path.join(tempDir, 'data'),
+        XDG_CACHE_HOME: path.join(tempDir, 'cache'),
+        XDG_STATE_HOME: path.join(tempDir, 'state'),
+        MCPORTER_TEST_OAUTH_ENDPOINT: endpoint,
+        MCPORTER_TEST_OAUTH_CACHE_DIR: path.join(tempDir, 'oauth-cache'),
+      };
+
+      await runFixture('seed', env);
+      const result = JSON.parse(await runFixture('refresh', env)) as {
+        accessToken: string;
+        authorizationPrompts: number;
+        clientId: string;
+        refreshToken: string;
+      };
+
+      expect(result).toEqual({
+        accessToken: 'fresh-process-access-token',
+        authorizationPrompts: 0,
+        clientId: 'fresh-process-client',
+        refreshToken: 'rotated-process-refresh-token',
+      });
+      expect(tokenRequests).toHaveLength(1);
+      expect(tokenRequests[0]?.get('grant_type')).toBe('refresh_token');
+      expect(tokenRequests[0]?.get('refresh_token')).toBe('fresh-process-refresh-token');
+      expect(tokenRequests[0]?.get('client_id')).toBe('fresh-process-client');
+    },
+    budget(20_000)
+  );
+});
+
+function runFixture(action: string, env: NodeJS.ProcessEnv): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      process.execPath,
+      [PROCESS_FIXTURE, action],
+      { env, timeout: budget(15_000), maxBuffer: 1024 * 1024 },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(`${error.message}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`));
+          return;
+        }
+        resolve(stdout.trim());
+      }
+    );
+  });
+}
+
+function sendJson(response: import('node:http').ServerResponse, body: unknown): void {
+  response.statusCode = 200;
+  response.setHeader('Content-Type', 'application/json');
+  response.end(JSON.stringify(body));
+}
+
+async function readBody(request: import('node:http').IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}

--- a/tests/oauth-session.test.ts
+++ b/tests/oauth-session.test.ts
@@ -1,10 +1,11 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import http from 'node:http';
+import type { AddressInfo } from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { resolveClientMetadata } from '@modelcontextprotocol/client';
+import { auth as sdkAuth, resolveClientMetadata } from '@modelcontextprotocol/client';
 import type { ServerDefinition } from '../src/config.js';
 import { __oauthInternals, createOAuthSession, OAuthRedirectUriMismatchError } from '../src/oauth.js';
 import { loadVaultEntry } from '../src/oauth-vault.js';
@@ -375,6 +376,118 @@ describe('FileOAuthClientProvider session lifecycle', () => {
     const pending = session.waitForAuthorizationCode().catch(() => undefined);
     await session.close();
     await pending;
+  });
+
+  it('repairs a stale DCR client when a configured metadata URL is unsupported', async () => {
+    const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
+    tempDirs.push(tokenCacheDir);
+    const oauthServer = await startOAuthMetadataServer(false);
+    const metadataUrl = 'https://client.example.com/oauth/metadata.json';
+    const issuer = new URL(oauthServer.serverUrl).origin;
+    await fs.writeFile(
+      path.join(tokenCacheDir, 'tokens.json'),
+      JSON.stringify({ access_token: 'expired-token', token_type: 'Bearer', expires_at: 1, issuer }),
+      'utf8'
+    );
+    await fs.writeFile(
+      path.join(tokenCacheDir, 'client.json'),
+      JSON.stringify({
+        client_id: 'fallback-dcr-client',
+        redirect_uris: ['http://127.0.0.1:9999/callback'],
+        token_endpoint_auth_method: 'none',
+        issuer,
+      }),
+      'utf8'
+    );
+    const definition: ServerDefinition = {
+      name: 'test-oauth-cimd-dcr-fallback',
+      command: { kind: 'http', url: new URL(oauthServer.serverUrl) },
+      auth: 'oauth',
+      tokenCacheDir,
+      oauthClientMetadataUrl: metadataUrl,
+    };
+    const authorizationRequests: URL[] = [];
+    const session = await createOAuthSession(
+      definition,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      {
+        suppressBrowserLaunch: true,
+        onAuthorizationUrl: ({ authorizationUrl }) => {
+          authorizationRequests.push(new URL(authorizationUrl));
+        },
+      }
+    );
+
+    try {
+      await expect(sdkAuth(session.provider, { serverUrl: oauthServer.serverUrl })).rejects.toBeInstanceOf(
+        OAuthRedirectUriMismatchError
+      );
+      expect(oauthServer.registrationCount()).toBe(0);
+      await expect(fs.access(path.join(tokenCacheDir, 'client.json'))).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.access(path.join(tokenCacheDir, 'tokens.json'))).rejects.toMatchObject({ code: 'ENOENT' });
+
+      await expect(sdkAuth(session.provider, { serverUrl: oauthServer.serverUrl })).resolves.toBe('REDIRECT');
+      expect(oauthServer.registrationCount()).toBe(1);
+      expect(authorizationRequests).toHaveLength(1);
+      expect(authorizationRequests[0]?.searchParams.get('client_id')).toBe('replacement-dcr-client');
+      await expect(session.provider.clientInformation()).resolves.toMatchObject({
+        client_id: 'replacement-dcr-client',
+        redirect_uris: [String(session.provider.redirectUrl)],
+      });
+    } finally {
+      const pending = session.waitForAuthorizationCode().catch(() => undefined);
+      await session.close();
+      await pending;
+      await oauthServer.close();
+    }
+  });
+
+  it('preserves a genuine metadata-URL client identity across callback ports', async () => {
+    const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
+    tempDirs.push(tokenCacheDir);
+    const oauthServer = await startOAuthMetadataServer(true);
+    const metadataUrl = 'https://client.example.com/oauth/metadata.json';
+    const issuer = new URL(oauthServer.serverUrl).origin;
+    await fs.writeFile(
+      path.join(tokenCacheDir, 'client.json'),
+      JSON.stringify({
+        client_id: metadataUrl,
+        redirect_uris: ['http://127.0.0.1:9999/callback'],
+        issuer,
+      }),
+      'utf8'
+    );
+    const definition: ServerDefinition = {
+      name: 'test-oauth-cimd-client',
+      command: { kind: 'http', url: new URL(oauthServer.serverUrl) },
+      auth: 'oauth',
+      tokenCacheDir,
+      oauthClientMetadataUrl: metadataUrl,
+    };
+    const authorizationRequests: URL[] = [];
+    const session = await createOAuthSession(
+      definition,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      {
+        suppressBrowserLaunch: true,
+        onAuthorizationUrl: ({ authorizationUrl }) => {
+          authorizationRequests.push(new URL(authorizationUrl));
+        },
+      }
+    );
+
+    try {
+      await expect(sdkAuth(session.provider, { serverUrl: oauthServer.serverUrl })).resolves.toBe('REDIRECT');
+      expect(oauthServer.registrationCount()).toBe(0);
+      expect(authorizationRequests).toHaveLength(1);
+      expect(authorizationRequests[0]?.searchParams.get('client_id')).toBe(metadataUrl);
+      await expect(session.provider.clientInformation()).resolves.toMatchObject({ client_id: metadataUrl });
+    } finally {
+      const pending = session.waitForAuthorizationCode().catch(() => undefined);
+      await session.close();
+      await pending;
+      await oauthServer.close();
+    }
   });
 
   it('closes the callback server when interactive stale-client reads have I/O errors', async () => {
@@ -785,3 +898,70 @@ describe('FileOAuthClientProvider session lifecycle', () => {
     }
   });
 });
+
+async function startOAuthMetadataServer(supportsUrlBasedClientId: boolean): Promise<{
+  serverUrl: string;
+  registrationCount: () => number;
+  close: () => Promise<void>;
+}> {
+  let origin = '';
+  let serverUrl = '';
+  let registrations = 0;
+  const server = http.createServer(async (request, response) => {
+    const url = new URL(request.url ?? '/', origin);
+    if (url.pathname.includes('.well-known/oauth-protected-resource')) {
+      sendJson(response, { resource: serverUrl, authorization_servers: [origin] });
+      return;
+    }
+    if (
+      url.pathname.includes('.well-known/oauth-authorization-server') ||
+      url.pathname.includes('openid-configuration')
+    ) {
+      sendJson(response, {
+        issuer: origin,
+        authorization_endpoint: `${origin}/authorize`,
+        token_endpoint: `${origin}/token`,
+        registration_endpoint: `${origin}/register`,
+        response_types_supported: ['code'],
+        grant_types_supported: ['authorization_code', 'refresh_token'],
+        token_endpoint_auth_methods_supported: ['none'],
+        code_challenge_methods_supported: ['S256'],
+        client_id_metadata_document_supported: supportsUrlBasedClientId,
+      });
+      return;
+    }
+    if (url.pathname === '/register' && request.method === 'POST') {
+      registrations += 1;
+      const body = await readRequestJson(request);
+      sendJson(response, { ...body, client_id: 'replacement-dcr-client' });
+      return;
+    }
+    response.statusCode = 404;
+    response.end('not found');
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  serverUrl = `${origin}/mcp`;
+  return {
+    serverUrl,
+    registrationCount: () => registrations,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+function sendJson(response: http.ServerResponse, body: unknown): void {
+  response.statusCode = 200;
+  response.setHeader('Content-Type', 'application/json');
+  response.end(JSON.stringify(body));
+}
+
+async function readRequestJson(request: http.IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>;
+}

--- a/tests/oauth-session.test.ts
+++ b/tests/oauth-session.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resolveClientMetadata } from '@modelcontextprotocol/client';
 import type { ServerDefinition } from '../src/config.js';
-import { __oauthInternals, createOAuthSession } from '../src/oauth.js';
+import { __oauthInternals, createOAuthSession, OAuthRedirectUriMismatchError } from '../src/oauth.js';
 import { loadVaultEntry } from '../src/oauth-vault.js';
 import { createIsolatedTestHome, type IsolatedTestHome } from './helpers/isolated-test-home.js';
 
@@ -265,12 +265,33 @@ describe('FileOAuthClientProvider session lifecycle', () => {
     await session.close();
   });
 
-  it('clears stale client registrations when redirect URI changes with dynamic ports', async () => {
+  it('preserves refreshable credentials when a new session allocates a different dynamic port', async () => {
     const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
     tempDirs.push(tokenCacheDir);
     await fs.writeFile(
+      path.join(tokenCacheDir, 'tokens.json'),
+      JSON.stringify(
+        {
+          access_token: 'expired-token',
+          token_type: 'Bearer',
+          refresh_token: 'refresh-token',
+          expires_at: 1,
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+    await fs.writeFile(
       path.join(tokenCacheDir, 'client.json'),
-      JSON.stringify({ redirect_uris: ['http://127.0.0.1:9999/callback'] }, null, 2),
+      JSON.stringify(
+        {
+          client_id: 'refreshable-client',
+          redirect_uris: ['http://127.0.0.1:9999/callback'],
+        },
+        null,
+        2
+      ),
       'utf8'
     );
     const definition: ServerDefinition = {
@@ -289,13 +310,74 @@ describe('FileOAuthClientProvider session lifecycle', () => {
     const session = await createOAuthSession(definition, logger);
     await session.close();
 
-    await expect(fs.readFile(path.join(tokenCacheDir, 'client.json'), 'utf8')).rejects.toMatchObject({
-      code: 'ENOENT',
+    await expect(fs.readFile(path.join(tokenCacheDir, 'client.json'), 'utf8').then(JSON.parse)).resolves.toMatchObject({
+      client_id: 'refreshable-client',
+      redirect_uris: ['http://127.0.0.1:9999/callback'],
     });
-    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('clearing stale client registration'));
+    await expect(fs.readFile(path.join(tokenCacheDir, 'tokens.json'), 'utf8').then(JSON.parse)).resolves.toMatchObject({
+      refresh_token: 'refresh-token',
+    });
+    expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining('clearing stale client registration'));
   });
 
-  it('closes the callback server when stale-client reads have I/O errors', async () => {
+  it('replaces an obsolete dynamic registration only when interactive authorization starts', async () => {
+    const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
+    tempDirs.push(tokenCacheDir);
+    await fs.writeFile(
+      path.join(tokenCacheDir, 'tokens.json'),
+      JSON.stringify({
+        access_token: 'expired-token',
+        token_type: 'Bearer',
+        refresh_token: 'rejected-refresh-token',
+        expires_at: 1,
+      }),
+      'utf8'
+    );
+    await fs.writeFile(
+      path.join(tokenCacheDir, 'client.json'),
+      JSON.stringify({
+        client_id: 'obsolete-client',
+        redirect_uris: ['http://127.0.0.1:9999/callback'],
+      }),
+      'utf8'
+    );
+    const definition: ServerDefinition = {
+      name: 'test-oauth-interactive-replacement',
+      command: { kind: 'http', url: new URL('https://example.com/mcp') },
+      auth: 'oauth',
+      tokenCacheDir,
+    };
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const onAuthorizationUrl = vi.fn();
+    const session = await createOAuthSession(definition, logger, {
+      suppressBrowserLaunch: true,
+      onAuthorizationUrl,
+    });
+    const provider = session.provider;
+    const authorizationUrl = new URL('https://auth.example.com/authorize');
+
+    await expect(provider.redirectToAuthorization(authorizationUrl)).rejects.toBeInstanceOf(
+      OAuthRedirectUriMismatchError
+    );
+    await expect(fs.access(path.join(tokenCacheDir, 'client.json'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.access(path.join(tokenCacheDir, 'tokens.json'))).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(onAuthorizationUrl).not.toHaveBeenCalled();
+
+    const replacement = {
+      client_id: 'replacement-client',
+      redirect_uris: [String(provider.redirectUrl)],
+    };
+    await provider.saveClientInformation?.(replacement);
+    await provider.redirectToAuthorization(authorizationUrl);
+
+    expect(onAuthorizationUrl).toHaveBeenCalledTimes(1);
+    await expect(provider.clientInformation()).resolves.toMatchObject(replacement);
+    const pending = session.waitForAuthorizationCode().catch(() => undefined);
+    await session.close();
+    await pending;
+  });
+
+  it('closes the callback server when interactive stale-client reads have I/O errors', async () => {
     const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
     tempDirs.push(tokenCacheDir);
     const definition: ServerDefinition = {
@@ -312,7 +394,6 @@ describe('FileOAuthClientProvider session lifecycle', () => {
     };
 
     const readError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
-    const readFileSpy = vi.spyOn(fs, 'readFile').mockRejectedValueOnce(readError);
     const originalCreateServer = http.createServer.bind(http);
     const createdServers: http.Server[] = [];
     const createServerSpy = vi.spyOn(http, 'createServer').mockImplementation((...args) => {
@@ -322,12 +403,16 @@ describe('FileOAuthClientProvider session lifecycle', () => {
     });
 
     try {
-      await expect(createOAuthSession(definition, logger)).rejects.toMatchObject({ code: 'EACCES' });
+      const session = await createOAuthSession(definition, logger);
+      const readFileSpy = vi.spyOn(fs, 'readFile').mockRejectedValueOnce(readError);
+      await expect(
+        session.provider.redirectToAuthorization(new URL('https://auth.example.com/authorize'))
+      ).rejects.toMatchObject({ code: 'EACCES' });
+      readFileSpy.mockRestore();
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(createdServers).toHaveLength(1);
       expect(createdServers[0]?.listening).toBe(false);
     } finally {
-      readFileSpy.mockRestore();
       createServerSpy.mockRestore();
     }
   });

--- a/tests/runtime-oauth-connect.test.ts
+++ b/tests/runtime-oauth-connect.test.ts
@@ -1,6 +1,6 @@
 import { type Client, UnauthorizedError, validateAuthorizationResponseIssuer } from '@modelcontextprotocol/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { OAuthSession } from '../src/oauth.js';
+import { OAuthRedirectUriMismatchError, type OAuthSession } from '../src/oauth.js';
 import {
   connectWithAuth,
   isOAuthFlowError,
@@ -121,6 +121,28 @@ describe('connectWithAuth', () => {
     expect(connect).toHaveBeenNthCalledWith(1, transport);
     expect(connect).toHaveBeenNthCalledWith(2, replacement);
     expect(connectedTransport).toBe(replacement);
+  });
+
+  it('recreates the transport once after repairing an obsolete redirect registration', async () => {
+    const mismatch = new OAuthRedirectUriMismatchError('test-server');
+    const connect = vi.fn().mockRejectedValueOnce(mismatch).mockRejectedValueOnce(mismatch);
+    const client = { connect } as unknown as Client;
+    const { session } = createPendingAuthorizationSession();
+    const transport = new MockTransport();
+    const replacement = new MockTransport();
+    const recreateTransport = vi.fn(async () => replacement);
+
+    await expect(
+      connectWithAuth(client, transport, session, createLogger(), {
+        serverName: 'test-server',
+        maxAttempts: 1,
+        recreateTransport,
+      })
+    ).rejects.toSatisfy((error: unknown) => error === mismatch && isOAuthFlowError(error));
+
+    expect(connect).toHaveBeenNthCalledWith(1, transport);
+    expect(connect).toHaveBeenNthCalledWith(2, replacement);
+    expect(recreateTransport).toHaveBeenCalledTimes(1);
   });
 
   it('marks reconnect failures after auth as post-auth transport errors', async () => {
@@ -297,6 +319,32 @@ describe('connectWithAuth', () => {
     });
     expect(waitForAuthorizationCode).not.toHaveBeenCalled();
     expect(transport.calls).toEqual([]);
+    expect(session.close).toHaveBeenCalled();
+    expect(connectedTransport).toBe(transport);
+  });
+
+  it('retries proactive OAuth once after repairing an obsolete redirect registration', async () => {
+    const connect = vi.fn().mockResolvedValueOnce(undefined);
+    const client = { connect } as unknown as Client;
+    const { session, waitForAuthorizationCode } = createPendingAuthorizationSession();
+    session.provider.tokens = vi.fn(async () => ({
+      access_token: 'expired-token',
+      token_type: 'Bearer',
+      expires_at: Math.floor(Date.now() / 1000) - 60,
+    }));
+    mocks.sdkAuth
+      .mockRejectedValueOnce(new OAuthRedirectUriMismatchError('calendar'))
+      .mockResolvedValueOnce('AUTHORIZED');
+
+    const transport = new MockTransport();
+    const connectedTransport = await connectWithAuth(client, transport, session, createLogger(), {
+      serverName: 'calendar',
+      maxAttempts: 1,
+      serverUrl: 'https://calendar.example/mcp',
+    });
+
+    expect(mocks.sdkAuth).toHaveBeenCalledTimes(2);
+    expect(waitForAuthorizationCode).not.toHaveBeenCalled();
     expect(session.close).toHaveBeenCalled();
     expect(connectedTransport).toBe(transport);
   });


### PR DESCRIPTION
## Summary

- preserve a saved dynamic OAuth client/token pair when a fresh process allocates a different loopback callback port
- move redirect-mismatch invalidation from generic session construction to the interactive authorization boundary, after refresh is unavailable
- compare-and-clear the exact stale credential generation and retry DCR once across proactive, Streamable HTTP, and SSE paths
- distinguish genuine metadata-URL client IDs from servers that fall back to persisted DCR
- add the 0.13.2 changelog entry thanking @elecnix

## Root cause

PR #72 prevented interactive `invalid_redirect_uri` failures by deleting a cached dynamic registration when the callback port changed. That deletion ran during session construction, however, after MCPorter could already have silently refreshed with the saved `client_id`. The fresh session then deleted the identity required by the next process.

The repaired boundary preserves credentials while refresh remains usable. Once OAuth reaches interactive authorization with an obsolete dynamic callback registration, the provider compare-clears that generation and the runtime retries registration once. A second mismatch fails closed.

## Integration and proof

- Exact candidate: `a865f4ccb906c8cf044fa07186dd603dad0c6da8`
- Authenticated WorkOS proof on pre-integration head `fdd76abebf602470e0c2732733850654fd66f84c`: https://github.com/openclaw/mcporter/pull/292#issuecomment-5228650001
- The integrated candidate has the identical production `src` tree hash `352f4fca8066a27acc5778d3a1caee73bfc06927`; `src`, `pnpm-lock.yaml`, and `pnpm-workspace.yaml` are byte-for-byte unchanged from the live-proven head.
- Main advanced only through the 0.13.1 release metadata and the 0.13.2 changelog closeout. The existing user-visible fix entry now lives under `0.13.2 - Unreleased`.
- Focused OAuth/session/runtime/process suite: 11 files, 209 tests passed.
- Full suite: 188 files / 1,444 tests passed, with 4 files / 26 tests skipped.
- `pnpm docs:list`, `pnpm check`, `pnpm docs:site`, and `git diff --check` passed.

Closes #290
