### PR TITLE
fix(oauth): constrain origin issuer aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### OAuth
 
+- Accept one-segment HTTPS authorization-server aliases whose metadata canonically identifies the same origin, while requiring every advertised security endpoint to remain on that origin. (Issue #244, thanks @emmanuelchucks)
 - Honor `MCPORTER_OAUTH_NO_BROWSER` across serve/daemon OAuth flows, fail once with actionable reauthorization guidance without logging authorization URLs, and restart daemons when the normalized setting changes. (PR #284 / issue #283, thanks @vitalijssilins)
 - Accept RFC 7591 dynamic-client-registration arrays and timestamps in `mcporter vault set` while preserving null-compatible partial client information and provider metadata. (PR #288 / issue #286, thanks @feniix)
 

--- a/src/oauth-issuer-policy.ts
+++ b/src/oauth-issuer-policy.ts
@@ -1,0 +1,142 @@
+import type { OAuthDiscoveryState } from '@modelcontextprotocol/client';
+import { discoverOAuthServerInfo } from '@modelcontextprotocol/client';
+
+const TRUSTED_ENDPOINT_FIELDS = [
+  'authorization_endpoint',
+  'token_endpoint',
+  'registration_endpoint',
+  'jwks_uri',
+  'revocation_endpoint',
+  'introspection_endpoint',
+  'pushed_authorization_request_endpoint',
+  'device_authorization_endpoint',
+  'userinfo_endpoint',
+  'end_session_endpoint',
+  'backchannel_authentication_endpoint',
+] as const;
+
+// The SDK exposes only a boolean issuer-check opt-out. MCPorter enables it only
+// while routing every fresh and cached discovery state through the replacement
+// policy below before DCR, authorization, token exchange, or refresh can run.
+export const OAUTH_ISSUER_POLICY_SDK_OPTIONS = { skipIssuerMetadataValidation: true } as const;
+
+export class OAuthIssuerPolicyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OAuthIssuerPolicyError';
+  }
+}
+
+function issuersMatchExactly(first: string, second: string): boolean {
+  return (
+    first === second ||
+    (first.endsWith('/') && first.slice(0, -1) === second) ||
+    (second.endsWith('/') && second.slice(0, -1) === first)
+  );
+}
+
+function parsePolicyUrl(value: string, label: string): URL {
+  try {
+    return new URL(value);
+  } catch {
+    throw new OAuthIssuerPolicyError(`Invalid ${label} URL in OAuth metadata.`);
+  }
+}
+
+function assertTrustedEndpoint(value: unknown, field: string, trustedOrigin: string): void {
+  if (value === undefined) return;
+  if (typeof value !== 'string') {
+    throw new OAuthIssuerPolicyError(`Invalid ${field} in OAuth metadata.`);
+  }
+  const endpoint = parsePolicyUrl(value, field);
+  if (
+    endpoint.protocol !== 'https:' ||
+    endpoint.origin !== trustedOrigin ||
+    endpoint.username !== '' ||
+    endpoint.password !== '' ||
+    endpoint.hash !== ''
+  ) {
+    throw new OAuthIssuerPolicyError(`OAuth metadata ${field} is outside the trusted issuer origin.`);
+  }
+}
+
+function assertOriginIssuerAlias(
+  authorizationServerUrl: string,
+  metadata: NonNullable<OAuthDiscoveryState['authorizationServerMetadata']>
+): void {
+  const selected = parsePolicyUrl(authorizationServerUrl, 'authorization server');
+  const issuer = parsePolicyUrl(metadata.issuer, 'issuer');
+  const opaqueSegments = selected.pathname.split('/').filter(Boolean);
+
+  // Treat only one unambiguous path segment as an alias for the exact HTTPS
+  // origin that served it. Same-origin endpoint checks below keep credentials
+  // away from any other host, scheme, or port.
+  if (
+    selected.protocol !== 'https:' ||
+    selected.username !== '' ||
+    selected.password !== '' ||
+    selected.search !== '' ||
+    selected.hash !== '' ||
+    opaqueSegments.length !== 1 ||
+    !/^\/[A-Za-z0-9._~-]+$/.test(selected.pathname) ||
+    issuer.protocol !== 'https:' ||
+    issuer.origin !== selected.origin ||
+    issuer.pathname !== '/' ||
+    issuer.search !== '' ||
+    issuer.hash !== '' ||
+    issuer.username !== '' ||
+    issuer.password !== ''
+  ) {
+    throw new OAuthIssuerPolicyError(
+      `OAuth metadata issuer does not match the selected authorization server under the origin-alias policy.`
+    );
+  }
+
+  if (typeof metadata.authorization_endpoint !== 'string' || typeof metadata.token_endpoint !== 'string') {
+    throw new OAuthIssuerPolicyError('OAuth origin-alias metadata must declare authorization and token endpoints.');
+  }
+  for (const field of TRUSTED_ENDPOINT_FIELDS) {
+    assertTrustedEndpoint((metadata as Record<string, unknown>)[field], field, issuer.origin);
+  }
+  const mtlsAliases = (metadata as Record<string, unknown>).mtls_endpoint_aliases;
+  if (mtlsAliases !== undefined) {
+    if (!mtlsAliases || typeof mtlsAliases !== 'object' || Array.isArray(mtlsAliases)) {
+      throw new OAuthIssuerPolicyError('Invalid mtls_endpoint_aliases in OAuth metadata.');
+    }
+    for (const [field, value] of Object.entries(mtlsAliases)) {
+      assertTrustedEndpoint(value, `mtls_endpoint_aliases.${field}`, issuer.origin);
+    }
+  }
+}
+
+export function assertOAuthDiscoveryIssuerPolicy(state: OAuthDiscoveryState): void {
+  const metadata = state.authorizationServerMetadata;
+  if (!metadata) return;
+  if (typeof metadata.issuer !== 'string' || metadata.issuer.length === 0) {
+    throw new OAuthIssuerPolicyError('OAuth authorization-server metadata is missing its issuer.');
+  }
+  if (issuersMatchExactly(state.authorizationServerUrl, metadata.issuer)) return;
+  assertOriginIssuerAlias(state.authorizationServerUrl, metadata);
+}
+
+type OAuthDiscoveryOptions = NonNullable<Parameters<typeof discoverOAuthServerInfo>[1]>;
+
+export async function discoverOAuthServerInfoWithIssuerPolicy(
+  serverUrl: string | URL,
+  options: Omit<OAuthDiscoveryOptions, 'skipIssuerMetadataValidation'> = {}
+): Promise<Awaited<ReturnType<typeof discoverOAuthServerInfo>>> {
+  const info = await discoverOAuthServerInfo(serverUrl, {
+    ...options,
+    ...OAUTH_ISSUER_POLICY_SDK_OPTIONS,
+  });
+  assertOAuthDiscoveryIssuerPolicy({
+    authorizationServerUrl: info.authorizationServerUrl,
+    authorizationServerMetadata: info.authorizationServerMetadata,
+    resourceMetadata: info.resourceMetadata,
+  });
+  return info;
+}
+
+export function oauthIssuerFromDiscovery(info: Awaited<ReturnType<typeof discoverOAuthServerInfo>>): string {
+  return info.authorizationServerMetadata?.issuer ?? info.authorizationServerUrl;
+}

--- a/src/oauth-token-refresh.ts
+++ b/src/oauth-token-refresh.ts
@@ -6,15 +6,15 @@ import type {
   StoredOAuthClientInformation,
   StoredOAuthTokens,
 } from '@modelcontextprotocol/client';
-import {
-  checkResourceAllowed,
-  discoverOAuthServerInfo,
-  refreshAuthorization,
-  resourceUrlFromServerUrl,
-} from '@modelcontextprotocol/client';
+import { checkResourceAllowed, refreshAuthorization, resourceUrlFromServerUrl } from '@modelcontextprotocol/client';
 import type { ServerDefinition } from './config.js';
 import type { Logger } from './logging.js';
 import { buildStaticClientInformation, resolveOAuthClientSecret } from './oauth-client-info.js';
+import {
+  discoverOAuthServerInfoWithIssuerPolicy,
+  OAuthIssuerPolicyError,
+  oauthIssuerFromDiscovery,
+} from './oauth-issuer-policy.js';
 import { clearLegacyOAuthArtifacts } from './oauth-persistence-stores.js';
 import type { OAuthPersistence } from './oauth-persistence.js';
 import { sameOAuthTokenGeneration } from './oauth-token-generation.js';
@@ -169,14 +169,9 @@ export async function readCachedAccessTokenWithPersistence(
     if (definition.command.kind !== 'http') {
       return tokens.access_token;
     }
-    const serverInfo = await discoverOAuthServerInfo(definition.command.url);
-    await assertRefreshIssuerBinding(
-      definition,
-      persistence,
-      tokens,
-      clientInformation,
-      serverInfo.authorizationServerUrl
-    );
+    const serverInfo = await discoverOAuthServerInfoWithIssuerPolicy(definition.command.url);
+    const issuer = oauthIssuerFromDiscovery(serverInfo);
+    await assertRefreshIssuerBinding(definition, persistence, tokens, clientInformation, issuer);
     const resource = resourceForRefresh(definition.command.url, serverInfo.resourceMetadata);
     const refreshed = await refreshAuthorization(serverInfo.authorizationServerUrl, {
       metadata: serverInfo.authorizationServerMetadata,
@@ -184,7 +179,7 @@ export async function readCachedAccessTokenWithPersistence(
       refreshToken: tokens.refresh_token,
       ...(resource ? { resource } : {}),
     });
-    await persistence.saveTokens({ ...refreshed, issuer: serverInfo.authorizationServerUrl });
+    await persistence.saveTokens({ ...refreshed, issuer });
     logger?.debug?.(`Refreshed cached OAuth access token for '${definition.name}' (non-interactive).`);
     return refreshed.access_token;
   } catch (error) {
@@ -194,6 +189,9 @@ export async function readCachedAccessTokenWithPersistence(
       }`
     );
     if (error instanceof OAuthIssuerMismatchError) {
+      throw error;
+    }
+    if (error instanceof OAuthIssuerPolicyError) {
       throw error;
     }
     const unrecoverableCode = unrecoverableOAuthRefreshCode(error);

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -14,6 +14,7 @@ import { validateClientMetadataUrl } from '@modelcontextprotocol/client';
 import type { ServerDefinition } from './config.js';
 import { suppressBrowserLaunchFromEnv } from './oauth-browser-suppression.js';
 import { buildStaticClientInformation } from './oauth-client-info.js';
+import { assertOAuthDiscoveryIssuerPolicy } from './oauth-issuer-policy.js';
 import type { OAuthPersistence } from './oauth-persistence.js';
 import { buildOAuthPersistence } from './oauth-persistence.js';
 
@@ -412,11 +413,14 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
   }
 
   async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
+    assertOAuthDiscoveryIssuerPolicy(state);
     await this.persistence.saveDiscoveryState(state);
   }
 
   async discoveryState(): Promise<OAuthDiscoveryState | undefined> {
-    return this.persistence.readDiscoveryState();
+    const state = await this.persistence.readDiscoveryState();
+    if (state) assertOAuthDiscoveryIssuerPolicy(state);
+    return state;
   }
 
   async saveAuthorizationServerUrl(url: string): Promise<void> {

--- a/src/runtime/http-transport.ts
+++ b/src/runtime/http-transport.ts
@@ -10,6 +10,7 @@ import type { ServerDefinition } from '../config.js';
 import { analyzeConnectionError } from '../error-classifier.js';
 import type { Logger } from '../logging.js';
 import { createOAuthSession, type OAuthSession } from '../oauth.js';
+import { OAUTH_ISSUER_POLICY_SDK_OPTIONS } from '../oauth-issuer-policy.js';
 import { materializeHeaders } from '../runtime-header-utils.js';
 import { isUnauthorizedError, maybeEnableOAuth } from '../runtime-oauth-support.js';
 import { closeTransportAndWait } from '../runtime-process-utils.js';
@@ -26,6 +27,7 @@ import type { ClientContext, CreateClientContextOptions, WrapRecordTransport } f
 interface ResolvedHttpTransportOptions {
   requestInit?: RequestInit;
   authProvider?: OAuthSession['provider'];
+  skipIssuerMetadataValidation?: boolean;
   fetch?: typeof nodeHttp1Fetch;
   standaloneSseStarted: Promise<void>;
 }
@@ -91,6 +93,7 @@ function createHttpTransportOptions(
   return {
     requestInit: effectiveHeaders ? { headers: effectiveHeaders as HeadersInit } : undefined,
     authProvider: oauthSession?.provider,
+    ...(oauthSession ? OAUTH_ISSUER_POLICY_SDK_OPTIONS : {}),
     fetch: trackedFetch.fetch,
     standaloneSseStarted: trackedFetch.started,
   };

--- a/src/runtime/oauth.ts
+++ b/src/runtime/oauth.ts
@@ -7,6 +7,7 @@ import {
 } from '@modelcontextprotocol/client';
 import type { Logger } from '../logging.js';
 import type { OAuthAuthorizationResponse, OAuthSession } from '../oauth.js';
+import { OAUTH_ISSUER_POLICY_SDK_OPTIONS } from '../oauth-issuer-policy.js';
 import { isUnauthorizedError } from '../runtime-oauth-support.js';
 
 export const DEFAULT_OAUTH_CODE_TIMEOUT_MS = 300_000;
@@ -269,6 +270,7 @@ async function completeProactiveAuthorization(
     const result = await sdkAuth(session.provider, {
       serverUrl: options.serverUrl,
       fetchFn: options.fetchFn,
+      ...OAUTH_ISSUER_POLICY_SDK_OPTIONS,
     });
     if (result !== 'REDIRECT') {
       await session.close().catch(() => {});

--- a/tests/oauth-issuer-policy.test.ts
+++ b/tests/oauth-issuer-policy.test.ts
@@ -1,0 +1,136 @@
+import type { OAuthDiscoveryState } from '@modelcontextprotocol/client';
+import { describe, expect, it } from 'vitest';
+import {
+  assertOAuthDiscoveryIssuerPolicy,
+  discoverOAuthServerInfoWithIssuerPolicy,
+  OAuthIssuerPolicyError,
+  oauthIssuerFromDiscovery,
+} from '../src/oauth-issuer-policy.js';
+
+const ORIGIN = 'https://auth.example.test';
+
+function metadata(
+  overrides: Record<string, unknown> = {}
+): NonNullable<OAuthDiscoveryState['authorizationServerMetadata']> {
+  return {
+    issuer: ORIGIN,
+    authorization_endpoint: `${ORIGIN}/authorize`,
+    token_endpoint: `${ORIGIN}/oauth/token`,
+    registration_endpoint: `${ORIGIN}/oauth/register`,
+    jwks_uri: `${ORIGIN}/.well-known/jwks.json`,
+    response_types_supported: ['code'],
+    ...overrides,
+  } as NonNullable<OAuthDiscoveryState['authorizationServerMetadata']>;
+}
+
+function discoveryState(
+  authorizationServerUrl = `${ORIGIN}/opaque-tenant`,
+  overrides: Record<string, unknown> = {}
+): OAuthDiscoveryState {
+  return {
+    authorizationServerUrl,
+    authorizationServerMetadata: metadata(overrides),
+  };
+}
+
+describe('OAuth discovery issuer policy', () => {
+  it('discovers an origin issuer from an opaque authorization-server path', async () => {
+    const fetchFn = async (input: string | URL | Request) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      if (url.origin === 'https://resource.example.test') {
+        return new Response(
+          JSON.stringify({
+            resource: 'https://resource.example.test/mcp',
+            authorization_servers: [`${ORIGIN}/opaque-tenant`],
+          }),
+          { headers: { 'content-type': 'application/json' } }
+        );
+      }
+      return new Response(JSON.stringify(metadata()), { headers: { 'content-type': 'application/json' } });
+    };
+
+    await expect(
+      discoverOAuthServerInfoWithIssuerPolicy('https://resource.example.test/mcp', { fetchFn })
+    ).resolves.toMatchObject({
+      authorizationServerUrl: `${ORIGIN}/opaque-tenant`,
+      authorizationServerMetadata: { issuer: ORIGIN },
+    });
+  });
+
+  it('accepts one opaque HTTPS path whose metadata canonicalizes to its exact origin', () => {
+    expect(() => assertOAuthDiscoveryIssuerPolicy(discoveryState())).not.toThrow();
+    expect(
+      oauthIssuerFromDiscovery({
+        authorizationServerUrl: `${ORIGIN}/opaque-tenant`,
+        authorizationServerMetadata: metadata(),
+      })
+    ).toBe(ORIGIN);
+  });
+
+  it('preserves ordinary exact issuer matching, including a trailing slash', () => {
+    expect(() =>
+      assertOAuthDiscoveryIssuerPolicy(discoveryState(`${ORIGIN}/issuer-path`, { issuer: `${ORIGIN}/issuer-path/` }))
+    ).not.toThrow();
+  });
+
+  it.each([
+    ['unrelated host', `${ORIGIN}/opaque-tenant`, { issuer: 'https://other.example.test' }],
+    ['unrelated scheme', `${ORIGIN}/opaque-tenant`, { issuer: 'http://auth.example.test' }],
+    ['unrelated port', `${ORIGIN}/opaque-tenant`, { issuer: 'https://auth.example.test:444' }],
+    ['inverse relationship', ORIGIN, { issuer: `${ORIGIN}/opaque-tenant` }],
+    ['broader selected path', `${ORIGIN}/opaque/tenant`, {}],
+    ['selected query', `${ORIGIN}/opaque-tenant?issuer=${encodeURIComponent(ORIGIN)}`, {}],
+    ['selected fragment', `${ORIGIN}/opaque-tenant#issuer`, {}],
+    ['issuer query', `${ORIGIN}/opaque-tenant`, { issuer: `${ORIGIN}?tenant=opaque` }],
+    ['issuer fragment', `${ORIGIN}/opaque-tenant`, { issuer: `${ORIGIN}#opaque` }],
+    ['encoded path ambiguity', `${ORIGIN}/opaque%2Ftenant`, {}],
+  ])('rejects %s', (_name, authorizationServerUrl, overrides) => {
+    expect(() => assertOAuthDiscoveryIssuerPolicy(discoveryState(authorizationServerUrl, overrides))).toThrow(
+      OAuthIssuerPolicyError
+    );
+  });
+
+  it.each([
+    'authorization_endpoint',
+    'token_endpoint',
+    'registration_endpoint',
+    'jwks_uri',
+    'revocation_endpoint',
+    'introspection_endpoint',
+    'pushed_authorization_request_endpoint',
+    'device_authorization_endpoint',
+    'userinfo_endpoint',
+  ])('rejects an off-origin %s', (field) => {
+    expect(() =>
+      assertOAuthDiscoveryIssuerPolicy(discoveryState(undefined, { [field]: `https://attacker.example/${field}` }))
+    ).toThrow(/outside the trusted issuer origin/);
+  });
+
+  it('rejects off-origin mTLS endpoint aliases', () => {
+    expect(() =>
+      assertOAuthDiscoveryIssuerPolicy(
+        discoveryState(undefined, {
+          mtls_endpoint_aliases: { token_endpoint: 'https://attacker.example/oauth/token' },
+        })
+      )
+    ).toThrow(/outside the trusted issuer origin/);
+  });
+
+  it('requires explicit authorization and token endpoints for an origin alias', () => {
+    expect(() =>
+      assertOAuthDiscoveryIssuerPolicy(discoveryState(undefined, { authorization_endpoint: undefined }))
+    ).toThrow(/must declare authorization and token endpoints/);
+    expect(() => assertOAuthDiscoveryIssuerPolicy(discoveryState(undefined, { token_endpoint: undefined }))).toThrow(
+      /must declare authorization and token endpoints/
+    );
+  });
+
+  it('rejects cached authorization-server metadata without an issuer', () => {
+    expect(() =>
+      assertOAuthDiscoveryIssuerPolicy({
+        authorizationServerUrl: `${ORIGIN}/opaque-tenant`,
+        authorizationServerMetadata: metadata({ issuer: undefined }),
+      })
+    ).toThrow(/missing its issuer/);
+  });
+});

--- a/tests/oauth-persistence.test.ts
+++ b/tests/oauth-persistence.test.ts
@@ -373,7 +373,10 @@ describe('oauth persistence', () => {
 
     authMocks.discoverOAuthServerInfo.mockResolvedValue({
       authorizationServerUrl: 'https://auth.example.com',
-      authorizationServerMetadata: { token_endpoint: 'https://auth.example.com/token' },
+      authorizationServerMetadata: {
+        issuer: 'https://auth.example.com',
+        token_endpoint: 'https://auth.example.com/token',
+      },
       resourceMetadata: { resource: 'https://example.com/mcp' },
     });
     authMocks.refreshAuthorization.mockResolvedValue({
@@ -421,7 +424,10 @@ describe('oauth persistence', () => {
 
     authMocks.discoverOAuthServerInfo.mockResolvedValue({
       authorizationServerUrl: 'https://auth.example.com',
-      authorizationServerMetadata: { token_endpoint: 'https://auth.example.com/token' },
+      authorizationServerMetadata: {
+        issuer: 'https://auth.example.com',
+        token_endpoint: 'https://auth.example.com/token',
+      },
     });
     authMocks.refreshAuthorization.mockResolvedValue({
       access_token: 'fresh-token',
@@ -858,7 +864,10 @@ describe('oauth persistence', () => {
 
     authMocks.discoverOAuthServerInfo.mockResolvedValue({
       authorizationServerUrl: 'https://auth.example.com',
-      authorizationServerMetadata: { token_endpoint: 'https://auth.example.com/token' },
+      authorizationServerMetadata: {
+        issuer: 'https://auth.example.com',
+        token_endpoint: 'https://auth.example.com/token',
+      },
       resourceMetadata: { resource: 'https://example.com/mcp' },
     });
     authMocks.refreshAuthorization.mockResolvedValue({
@@ -911,7 +920,10 @@ describe('oauth persistence', () => {
     );
     authMocks.discoverOAuthServerInfo.mockResolvedValue({
       authorizationServerUrl: 'https://issuer-b.example',
-      authorizationServerMetadata: { token_endpoint: 'https://issuer-b.example/token' },
+      authorizationServerMetadata: {
+        issuer: 'https://issuer-b.example',
+        token_endpoint: 'https://issuer-b.example/token',
+      },
     });
 
     const definition = mkDef('issuer-bound-service', cacheDir);
@@ -924,7 +936,7 @@ describe('oauth persistence', () => {
     await expect(readJsonFile(path.join(cacheDir, 'client.json'))).resolves.toBeUndefined();
   });
 
-  it('stamps refreshed OAuth tokens with the discovered issuer', async () => {
+  it('refreshes an opaque authorization-server path under its canonical origin issuer', async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-refresh-issuer-stamp-'));
     tempRoots.push(tmp);
     homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmp);
@@ -947,8 +959,12 @@ describe('oauth persistence', () => {
       JSON.stringify({ client_id: 'client-123', issuer: 'https://auth.example.com' })
     );
     authMocks.discoverOAuthServerInfo.mockResolvedValue({
-      authorizationServerUrl: 'https://auth.example.com',
-      authorizationServerMetadata: { token_endpoint: 'https://auth.example.com/token' },
+      authorizationServerUrl: 'https://auth.example.com/opaque-tenant',
+      authorizationServerMetadata: {
+        issuer: 'https://auth.example.com',
+        authorization_endpoint: 'https://auth.example.com/authorize',
+        token_endpoint: 'https://auth.example.com/token',
+      },
     });
     authMocks.refreshAuthorization.mockResolvedValue({
       access_token: 'fresh-token',
@@ -958,6 +974,10 @@ describe('oauth persistence', () => {
     });
 
     await expect(readCachedAccessToken(mkDef('issuer-stamp-service', cacheDir))).resolves.toBe('fresh-token');
+    expect(authMocks.refreshAuthorization).toHaveBeenCalledWith(
+      'https://auth.example.com/opaque-tenant',
+      expect.objectContaining({ refreshToken: 'refresh-123' })
+    );
     await expect(readJsonFile(path.join(cacheDir, 'tokens.json'))).resolves.toMatchObject({
       access_token: 'fresh-token',
       issuer: 'https://auth.example.com',
@@ -985,7 +1005,10 @@ describe('oauth persistence', () => {
 
     authMocks.discoverOAuthServerInfo.mockResolvedValue({
       authorizationServerUrl: 'https://auth.example.com',
-      authorizationServerMetadata: { token_endpoint: 'https://auth.example.com/token' },
+      authorizationServerMetadata: {
+        issuer: 'https://auth.example.com',
+        token_endpoint: 'https://auth.example.com/token',
+      },
     });
     authMocks.refreshAuthorization.mockResolvedValue({
       access_token: 'fresh-token',

--- a/tests/oauth-session.test.ts
+++ b/tests/oauth-session.test.ts
@@ -4,7 +4,7 @@ import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { resolveClientMetadata } from '@modelcontextprotocol/client';
+import { type OAuthDiscoveryState, resolveClientMetadata } from '@modelcontextprotocol/client';
 import type { ServerDefinition } from '../src/config.js';
 import { __oauthInternals, createOAuthSession } from '../src/oauth.js';
 import { loadVaultEntry } from '../src/oauth-vault.js';
@@ -192,6 +192,42 @@ describe('FileOAuthClientProvider session lifecycle', () => {
       authorizationServerUrl: 'https://auth.example.com',
       resourceUrl: 'https://example.com/mcp',
     });
+    await session.close();
+  });
+
+  it('persists only discovery state accepted by the issuer policy', async () => {
+    const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
+    tempDirs.push(tokenCacheDir);
+    const definition: ServerDefinition = {
+      name: 'test-oauth-origin-issuer-alias',
+      command: { kind: 'http', url: new URL('https://example.com/mcp') },
+      auth: 'oauth',
+      tokenCacheDir,
+    };
+    const session = await createOAuthSession(definition, { info: vi.fn(), warn: vi.fn(), error: vi.fn() });
+    const state = {
+      authorizationServerUrl: 'https://auth.example.com/opaque-tenant',
+      authorizationServerMetadata: {
+        issuer: 'https://auth.example.com',
+        authorization_endpoint: 'https://auth.example.com/authorize',
+        token_endpoint: 'https://auth.example.com/oauth/token',
+        registration_endpoint: 'https://auth.example.com/oauth/register',
+        response_types_supported: ['code'],
+      },
+    } as OAuthDiscoveryState;
+
+    await expect(session.provider.saveDiscoveryState?.(state)).resolves.toBeUndefined();
+    await expect(session.provider.discoveryState?.()).resolves.toEqual(state);
+
+    const unsafe = {
+      ...state,
+      authorizationServerMetadata: {
+        ...state.authorizationServerMetadata,
+        token_endpoint: 'https://attacker.example/oauth/token',
+      },
+    } as OAuthDiscoveryState;
+    await expect(session.provider.saveDiscoveryState?.(unsafe)).rejects.toThrow(/outside the trusted issuer origin/);
+    await expect(session.provider.discoveryState?.()).resolves.toEqual(state);
     await session.close();
   });
 

--- a/tests/runtime-oauth-connect.test.ts
+++ b/tests/runtime-oauth-connect.test.ts
@@ -210,6 +210,7 @@ describe('connectWithAuth', () => {
     expect(mocks.sdkAuth).toHaveBeenCalledWith(session.provider, {
       serverUrl: new URL('https://calendar.example/mcp'),
       fetchFn: undefined,
+      skipIssuerMetadataValidation: true,
     });
     expect(waitForAuthorizationCode).toHaveBeenCalledTimes(1);
     expect(transport.calls).toEqual(['proactive-code']);
@@ -294,6 +295,7 @@ describe('connectWithAuth', () => {
     expect(mocks.sdkAuth).toHaveBeenCalledWith(session.provider, {
       serverUrl: 'https://courtlistener.example/mcp',
       fetchFn: undefined,
+      skipIssuerMetadataValidation: true,
     });
     expect(waitForAuthorizationCode).not.toHaveBeenCalled();
     expect(transport.calls).toEqual([]);

--- a/tests/runtime-transport.test.ts
+++ b/tests/runtime-transport.test.ts
@@ -699,8 +699,9 @@ describe('createClientContext (HTTP)', () => {
 
     const clientConnect = vi.spyOn(Client.prototype, 'connect').mockImplementationOnce(async (transport) => {
       expect(transport).toBeInstanceOf(StreamableHTTPClientTransport);
-      const requestInit = (transport as { _requestInit?: RequestInit })._requestInit;
-      expect(requestInit?.headers).toEqual({ 'X-Trace': 'keep-me' });
+      const internal = transport as { _requestInit?: RequestInit; _skipIssuerMetadataValidation?: boolean };
+      expect(internal._requestInit?.headers).toEqual({ 'X-Trace': 'keep-me' });
+      expect(internal._skipIssuerMetadataValidation).toBe(true);
     });
 
     const context = await createClientContext(definition, logger, clientInfo, { maxOAuthAttempts: 1 });


### PR DESCRIPTION
## Problem

Issue #244's current-main trace established a discovery failure before browser authorization or DCR: protected-resource metadata selected an HTTPS authorization-server URL with one opaque path segment, while the metadata served for that URL declared the exact origin as its canonical issuer. SDK v2 correctly rejected that relationship under RFC 8414 §3.3 before any credential existed.

The originally reported post-authorization DCR persistence failure remains a separate, unconfirmed symptom on current main. This PR does not synthesize client information from tokens or otherwise change persistence ownership.

At the time of this PR, Atlassian's public unauthenticated metadata has changed: the selected authorization-server URL and metadata issuer are now byte-identical, so the historical mismatch no longer reproduces against the public discovery surface. The local fixture therefore proves the policy mechanically, not authenticated Atlassian behavior.

## Security boundary

This is not a blanket `skipIssuerMetadataValidation` and contains no provider hostname allowlist. MCPorter replaces the SDK's boolean-only comparison with one centralized policy that accepts either the SDK's existing exact/trailing-slash match or this single alias shape:

- selected authorization-server URL uses HTTPS with no userinfo, query, or fragment;
- its path is exactly one non-empty, unencoded segment;
- metadata issuer is the selected URL's exact origin, with no path, query, fragment, or userinfo;
- authorization and token endpoints are explicit;
- every advertised authorization, token, registration, JWKS, revocation, introspection, PAR, device, user-info, session, backchannel, and mTLS alias endpoint remains HTTPS on that same scheme/host/port.

The policy rejects unrelated hosts, schemes, ports, inverse or multi-segment relationships, encoded-path ambiguity, query/fragment tricks, and attacker-controlled endpoint origins. The authorization-server origin serves the path-specific metadata and canonically identifies itself as the origin; credentials remain bound and stamped to that canonical metadata issuer.

The same owner validates fresh and cached SDK discovery state before interactive DCR/authorization/token work and wraps standalone silent-refresh discovery. RFC 9207 callback `iss` validation is unchanged and continues comparing the response issuer with the metadata issuer before code redemption.

Rejected alternatives:

- unconditional SDK issuer-validation opt-out;
- Atlassian hostname special case;
- arbitrary same-origin paths or path-prefix matching;
- accepting inverse path relationships, cross-origin endpoints, or canonicalizing encoded/query-bearing URLs.

## Evidence

Exact candidate: `ef461b1bbeaefe4fc10cd2afbdc91edb748bcf3f`.

Local baseline reproduction using SDK v2 and the reported relationship:

```text
IssuerMismatchError: expected https://auth.atlassian.com/<opaque>, received https://auth.atlassian.com
```

Built local fixture against the candidate:

- discovered a one-segment authorization-server alias with its exact origin issuer;
- completed dynamic client registration and produced persistable `client_id` information;
- completed refresh-token exchange through the advertised same-origin token endpoint;
- rejected an off-origin token endpoint before use.

Focused tests:

```text
5 files passed; 165 tests passed
```

Repository gates:

- `pnpm docs:list` — passed
- `pnpm check` — passed
- `pnpm test` — 187 files passed, 4 skipped; 1,450 tests passed, 26 skipped
- `pnpm docs:site` — passed
- `git diff --check` — passed
- Codex-backed autoreview — clean, no accepted/actionable findings
- exact-diff TruffleHog scan — 0 verified/unknown findings
- public model-identifier audit — PASS; this is not a model-bearing change

## Required live gate — do not merge yet

Authenticated exact-head Atlassian proof is unavailable on this machine: no Atlassian MCP entry or account state is configured, and the public metadata currently takes the ordinary strict-match path.

Before merge, exact head must pass `auth --reset` against the affected Atlassian MCP server, persist the DCR `clientInfo`, refresh after forced expiry without browser reauthorization, and complete an authenticated MCP call. Credentials and private response data must remain redacted.

Refs #244. Thanks @emmanuelchucks for the isolated cross-platform report and current-main trace.
