### PR TITLE
fix(vault): validate credential input safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Honor `MCPORTER_OAUTH_NO_BROWSER` across serve/daemon OAuth flows, fail once with actionable reauthorization guidance without logging authorization URLs, and restart daemons when the normalized setting changes. (PR #284 / issue #283, thanks @vitalijssilins)
 - Accept RFC 7591 dynamic-client-registration arrays and timestamps in `mcporter vault set` while preserving null-compatible partial client information and provider metadata. (PR #288 / issue #286, thanks @feniix)
+- Sanitize malformed `mcporter vault set` JSON diagnostics and reject non-finite `expires_at` / `expiresAt` token values before persistence. (Follow-up to PR #287, thanks @Yigtwxx)
 
 ### Tooling
 

--- a/src/cli/vault-command.ts
+++ b/src/cli/vault-command.ts
@@ -9,6 +9,8 @@ interface VaultPayload {
   readonly clientInfo?: OAuthClientInformationMixed;
 }
 
+type VaultPayloadSource = { kind: 'file'; path: string } | { kind: 'stdin' };
+
 export interface VaultCommandOptions {
   readonly readStdin?: () => Promise<string>;
 }
@@ -44,7 +46,7 @@ async function handleVaultSet(
     throw new CliUsageError(`Unknown vault set argument '${args[0]}'.`);
   }
   const definition = runtime.getDefinition(server);
-  const payload = validateVaultPayload(JSON.parse(await readPayload(source, options)));
+  const payload = validateVaultPayload(parseVaultPayload(await readPayload(source, options), source));
   await saveVaultEntry(definition, {
     tokens: payload.tokens,
     ...(payload.clientInfo ? { clientInfo: payload.clientInfo } : {}),
@@ -65,7 +67,7 @@ async function handleVaultClear(runtime: Pick<Runtime, 'getDefinition'>, args: s
   console.log(`Cleared OAuth vault entry for '${definition.name}'`);
 }
 
-function consumeVaultPayloadSource(args: string[]): { kind: 'file'; path: string } | { kind: 'stdin' } {
+function consumeVaultPayloadSource(args: string[]): VaultPayloadSource {
   const fileIndex = args.indexOf('--tokens-file');
   const stdinIndex = args.indexOf('--stdin');
   if (fileIndex !== -1 && stdinIndex !== -1) {
@@ -86,10 +88,7 @@ function consumeVaultPayloadSource(args: string[]): { kind: 'file'; path: string
   throw new CliUsageError('Usage: mcporter vault set <server> (--tokens-file <path> | --stdin)');
 }
 
-async function readPayload(
-  source: { kind: 'file'; path: string } | { kind: 'stdin' },
-  options: VaultCommandOptions
-): Promise<string> {
+async function readPayload(source: VaultPayloadSource, options: VaultCommandOptions): Promise<string> {
   if (source.kind === 'file') {
     return fs.readFile(source.path, 'utf8');
   }
@@ -105,6 +104,20 @@ async function readPayload(
     process.stdin.on('end', () => resolve(data));
     process.stdin.on('error', reject);
   });
+}
+
+function parseVaultPayload(raw: string, source: VaultPayloadSource): unknown {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    // V8 parser diagnostics can quote a prefix of the credential input. Name
+    // only the source so secrets and token fragments cannot reach logs.
+    throw new CliUsageError(
+      source.kind === 'file'
+        ? `Vault payload file '${source.path}' is not valid JSON.`
+        : 'Vault payload from stdin is not valid JSON.'
+    );
+  }
 }
 
 function validateVaultPayload(value: unknown): VaultPayload {
@@ -143,11 +156,13 @@ function validateOAuthTokens(tokens: Record<string, unknown>): void {
       throw new CliUsageError(`Vault payload tokens.${key} must be a string.`);
     }
   }
-  if (
-    tokens.expires_in !== undefined &&
-    (!Number.isFinite(tokens.expires_in) || typeof tokens.expires_in !== 'number')
-  ) {
-    throw new CliUsageError('Vault payload tokens.expires_in must be a finite number.');
+  // Keep the write boundary aligned with isStoredOAuthTokens: zero, negative,
+  // and fractional values remain valid, but every accepted alias is finite.
+  for (const key of ['expires_in', 'expires_at', 'expiresAt'] as const) {
+    const value = tokens[key];
+    if (value !== undefined && (typeof value !== 'number' || !Number.isFinite(value))) {
+      throw new CliUsageError(`Vault payload tokens.${key} must be a finite number.`);
+    }
   }
 }
 

--- a/tests/vault-cli.integration.test.ts
+++ b/tests/vault-cli.integration.test.ts
@@ -1,0 +1,163 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ServerDefinition } from '../src/config.js';
+import { loadVaultEntry } from '../src/oauth-vault.js';
+
+const CLI_ENTRY = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
+const SERVER_URL = 'https://example.test/mcp';
+const definition: ServerDefinition = {
+  name: 'demo',
+  command: { kind: 'http', url: new URL(SERVER_URL) },
+  auth: 'oauth',
+};
+
+interface CliResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+describe('built vault CLI input boundary', () => {
+  const originalDataHome = process.env.XDG_DATA_HOME;
+  let configPath: string;
+  let dataHome: string;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-vault-cli-'));
+    dataHome = path.join(tempDir, 'data');
+    configPath = path.join(tempDir, 'mcporter.json');
+    process.env.XDG_DATA_HOME = dataHome;
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ imports: [], mcpServers: { demo: { baseUrl: SERVER_URL, auth: 'oauth' } } }),
+      'utf8'
+    );
+  });
+
+  afterEach(async () => {
+    if (originalDataHome === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = originalDataHome;
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('does not echo malformed credential input through parser diagnostics', async () => {
+    const marker = 'VAULT_SECRET_MARKER_7H3K9';
+    const result = await runVault(['--stdin'], `${marker} malformed`);
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.exitCode).not.toBe(0);
+    expect(output).toContain('Vault payload from stdin is not valid JSON.');
+    expect(output).not.toContain(marker);
+    expect(output).not.toContain('VAULT_SECR');
+    expect(output).not.toContain('SyntaxError');
+    expect(output).not.toContain('Unexpected token');
+  });
+
+  it('names a malformed credential file without echoing its contents', async () => {
+    const marker = 'VAULT_FILE_SECRET_MARKER_2Q8M4';
+    const payloadPath = path.join(tempDir, 'tokens.json');
+    await fs.writeFile(payloadPath, `${marker} malformed`, 'utf8');
+    const result = await runVault(['--tokens-file', payloadPath]);
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.exitCode).not.toBe(0);
+    expect(output).toContain(`Vault payload file '${payloadPath}' is not valid JSON.`);
+    expect(output).not.toContain(marker);
+    expect(output).not.toContain('VAULT_FILE_SECR');
+    expect(output).not.toContain('SyntaxError');
+  });
+
+  it.each([
+    ['expires_at string', JSON.stringify(payload({ expires_at: 'soon' })), 'tokens.expires_at'],
+    ['expiresAt string', JSON.stringify(payload({ expiresAt: 'soon' })), 'tokens.expiresAt'],
+    ['expires_at positive infinity', rawPayload('expires_at', '1e999'), 'tokens.expires_at'],
+    ['expiresAt negative infinity', rawPayload('expiresAt', '-1e999'), 'tokens.expiresAt'],
+  ])('rejects invalid %s', async (_name, input, field) => {
+    const result = await runVault(['--stdin'], input);
+    expect(result.exitCode).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(`${field} must be a finite number`);
+  });
+
+  it('rejects a JSON NaN literal at the sanitized parse boundary', async () => {
+    const result = await runVault(['--stdin'], rawPayload('expires_at', 'NaN'));
+    expect(result.exitCode).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain('Vault payload from stdin is not valid JSON.');
+  });
+
+  it.each([
+    ['expires_at', 0],
+    ['expiresAt', 1_754_600_000.5],
+  ] as const)('persists finite %s values and unrelated valid credential fields', async (field, value) => {
+    const input = {
+      tokens: {
+        access_token: 'fake-access-token',
+        token_type: 'Bearer',
+        refresh_token: 'fake-refresh-token',
+        scope: 'read write',
+        issuer: 'https://issuer.example',
+        expires_in: 3600.25,
+        [field]: value,
+        id_token: 'fake-id-token',
+      },
+      clientInfo: {
+        client_id: 'fake-client',
+        redirect_uris: ['https://example.test/callback'],
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        client_name: null,
+        provider_metadata: { tenant: 'demo' },
+      },
+    };
+
+    const result = await runVault(['--stdin'], JSON.stringify(input));
+    expect(result.exitCode, result.stderr).toBe(0);
+    await expect(loadVaultEntry(definition)).resolves.toMatchObject(input);
+  });
+
+  async function runVault(sourceArgs: string[], input?: string): Promise<CliResult> {
+    const home = path.join(tempDir, 'home');
+    await fs.mkdir(home, { recursive: true });
+    return new Promise<CliResult>((resolve, reject) => {
+      const child = spawn(
+        process.execPath,
+        [CLI_ENTRY, '--config', configPath, 'vault', 'set', 'demo', ...sourceArgs],
+        {
+          cwd: tempDir,
+          env: {
+            ...process.env,
+            HOME: home,
+            XDG_CONFIG_HOME: path.join(home, 'config'),
+            XDG_DATA_HOME: dataHome,
+            XDG_CACHE_HOME: path.join(home, 'cache'),
+            XDG_STATE_HOME: path.join(home, 'state'),
+            MCPORTER_NO_FORCE_EXIT: '1',
+          },
+          stdio: ['pipe', 'pipe', 'pipe'],
+        }
+      );
+      let stdout = '';
+      let stderr = '';
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+      child.stdout.on('data', (chunk: string) => (stdout += chunk));
+      child.stderr.on('data', (chunk: string) => (stderr += chunk));
+      child.once('error', reject);
+      child.once('exit', (exitCode) => resolve({ exitCode, stdout, stderr }));
+      child.stdin.end(input);
+    });
+  }
+});
+
+function payload(expiry: Record<string, unknown>): Record<string, unknown> {
+  return { tokens: { access_token: 'fake-access-token', token_type: 'Bearer', ...expiry } };
+}
+
+function rawPayload(field: string, value: string): string {
+  return `{"tokens":{"access_token":"fake-access-token","token_type":"Bearer","${field}":${value}}}`;
+}

--- a/tests/vault-validation.test.ts
+++ b/tests/vault-validation.test.ts
@@ -56,6 +56,18 @@ describe('vault command input validation', () => {
       'tokens.expires_in must be a finite number',
     ],
     [
+      { tokens: { access_token: 'token', token_type: 'Bearer', expires_at: 'soon' } },
+      'tokens.expires_at must be a finite number',
+    ],
+    [
+      { tokens: { access_token: 'token', token_type: 'Bearer', expires_at: Number.NaN } },
+      'tokens.expires_at must be a finite number',
+    ],
+    [
+      { tokens: { access_token: 'token', token_type: 'Bearer', expiresAt: Number.NEGATIVE_INFINITY } },
+      'tokens.expiresAt must be a finite number',
+    ],
+    [
       { tokens: { access_token: 'token', token_type: 'Bearer' }, clientInfo: [] },
       "Vault payload 'clientInfo' must be an object",
     ],
@@ -83,5 +95,36 @@ describe('vault command input validation', () => {
     await expect(handleVault(runtime, ['set', 'calendar', '--stdin'], stdin(payload))).rejects.toThrow(
       message as string
     );
+  });
+
+  it('sanitizes malformed stdin JSON without retaining its input prefix', async () => {
+    const marker = 'VAULT_SECRET_MARKER_7H3K9';
+    const error = await handleVault(runtime, ['set', 'calendar', '--stdin'], {
+      readStdin: async () => `${marker} malformed`,
+    }).then(
+      () => undefined,
+      (reason: unknown) => reason
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe('Vault payload from stdin is not valid JSON.');
+    expect(String(error)).not.toContain(marker);
+    expect((error as Error).stack).not.toContain(marker);
+  });
+
+  it('names a malformed credential file without echoing its contents', async () => {
+    const payloadPath = path.join(tempDir, 'tokens.json');
+    const marker = 'VAULT_FILE_SECRET_MARKER_2Q8M4';
+    await fs.writeFile(payloadPath, `${marker} malformed`, 'utf8');
+
+    const error = await handleVault(runtime, ['set', 'calendar', '--tokens-file', payloadPath]).then(
+      () => undefined,
+      (reason: unknown) => reason
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(`Vault payload file '${payloadPath}' is not valid JSON.`);
+    expect(String(error)).not.toContain(marker);
+    expect((error as Error).stack).not.toContain(marker);
   });
 });


### PR DESCRIPTION
## Summary

This is the bounded follow-up preserved when contributor PR #287 was superseded by the narrower DCR compatibility fix in #288.

- Convert malformed `vault set` JSON into source-specific usage errors that never include V8 parser text or credential-input prefixes.
- Validate `tokens.expires_at` and `tokens.expiresAt` as finite numbers at the same input boundary that already validates `expires_in`.

No client-information policy, token persistence format, refresh behavior, or token schema is redesigned here.

## Behavior

Malformed stdin now reports only:

```text
Vault payload from stdin is not valid JSON.
```

Malformed files report only the file path:

```text
Vault payload file '<path>' is not valid JSON.
```

The original parser reason is deliberately discarded because V8 may quote a prefix of credential input in the diagnostic.

Expiry validation mirrors the existing `isStoredOAuthTokens` read guard exactly. `expires_in`, `expires_at`, and `expiresAt` accept any finite number, including zero, negative values, and fractions. Strings, null/serialized NaN, and numeric overflow to positive or negative infinity reject. If both aliases are present and finite, both remain accepted; this PR does not invent conflict or timestamp policy.

Unknown token fields, valid DCR client information, null-compatible client fields, and provider metadata still pass through unchanged.

## Provenance

The parsing wrapper and expiry-field analysis are materially adapted from @Yigtwxx's commits in #287, especially `df2956fdfb6ad9a645c706393398a5efdcd30805` and `2733f0c98895e781db609243e294792bae321f0a`. Contributor credit is preserved in the commit trailer and changelog.

PR #288 intentionally did not carry these adjacent findings because it retained partial-object and null-compatible client information semantics while resolving issue #286. This PR is the separate follow-up promised in the #287 close comment.

## Proof

Exact head: `38168dc5b48281d44fdec0e790be69601b82b8fb`.

Built CLI redaction proof with a distinctive fake marker:

```text
[mcporter] Vault payload from stdin is not valid JSON.
```

The marker, its prefix, `SyntaxError`, parser reason, and source contents were absent. The built CLI also rejected `1e999` as non-finite and persisted both `expires_at: 0` and fractional `expiresAt`, alongside unrelated fake token/client metadata.

- Focused built/unit vault suite: 3 files, 40 tests passed
- `pnpm docs:list` — passed
- `pnpm check` — passed
- `pnpm test` — 187 files passed, 4 skipped; 1,438 tests passed, 26 skipped
- `pnpm docs:site` — passed
- `git diff --check` — passed
- Codex-backed autoreview — clean, no accepted/actionable findings
- exact-diff TruffleHog scan — 0 verified/unknown findings
- public model-identifier audit — PASS; this is not a model-bearing change

No live provider proof is required: the changed boundary is local JSON parsing, validation, and persistence using fake credentials only.
