### PR TITLE
chore(deps): refresh mature security tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
 
       - run: corepack enable
-      - run: corepack prepare pnpm@10.33.2 --activate
+      - run: corepack prepare pnpm@10.34.5 --activate
 
       - name: Locate pnpm store
         id: pnpm-store
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload coverage report
         if: matrix.os == 'ubuntu-latest' && always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage/

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   NODE_VERSION: '24'
-  PNPM_VERSION: '10.33.2'
+  PNPM_VERSION: '10.34.5'
 
 jobs:
   hydrate:
@@ -43,11 +43,11 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6.0.10
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/live-conformance.yml
+++ b/.github/workflows/live-conformance.yml
@@ -24,12 +24,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
 
       - run: corepack enable
-      - run: corepack prepare pnpm@10.33.2 --activate
+      - run: corepack prepare pnpm@10.34.5 --activate
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
 
@@ -151,7 +151,7 @@ jobs:
             ./scripts/verify-release.sh "$RELEASE_TAG" "$RUNNER_TEMP/release-assets"
 
       - name: Preserve exact verified asset identity
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: verified-assets-${{ matrix.arch }}
           path: ${{ runner.temp }}/verified-assets.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   NODE_VERSION: 24
-  PNPM_VERSION: 10.33.2
+  PNPM_VERSION: 10.34.5
 
 jobs:
   release:
@@ -89,11 +89,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6.0.10
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           check-latest: true
@@ -278,7 +278,7 @@ jobs:
           ref: ${{ needs.release.outputs.tag }}
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           check-latest: true

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           check-latest: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Tooling
 
+- Refresh pnpm, GitHub Actions runtimes, and mature security overrides for fast-uri, Hono, ip-address, and nanoid.
 - Remove the obsolete scoped-commit helper and use standard Git commands in isolated worktrees.
 
 ## [0.13.0] - 2026-08-02

--- a/package.json
+++ b/package.json
@@ -111,5 +111,5 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,10 @@ overrides:
   body-parser: 2.3.0
   brace-expansion: 5.0.9
   esbuild: 0.28.1
-  fast-uri: 3.1.4
-  hono: 4.12.27
-  ip-address: 10.2.0
+  fast-uri: 3.1.5
+  hono: 4.13.0
+  ip-address: 10.4.0
+  nanoid: 3.3.17
   qs: 6.15.3
   vite: 8.2.1
 
@@ -287,7 +288,7 @@ packages:
     resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: 4.12.27
+      hono: 4.13.0
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
@@ -1098,8 +1099,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1162,8 +1163,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.27:
-    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -1180,8 +1181,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -1356,8 +1357,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1835,9 +1836,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@hono/node-server@2.0.12(hono@4.12.27)':
+  '@hono/node-server@2.0.12(hono@4.13.0)':
     dependencies:
-      hono: 4.12.27
+      hono: 4.13.0
 
   '@iarna/toml@2.2.5': {}
 
@@ -1866,7 +1867,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.12(hono@4.12.27)
+      '@hono/node-server': 2.0.12(hono@4.13.0)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -1876,7 +1877,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.6.1(express@5.2.1)
-      hono: 4.12.27
+      hono: 4.13.0
       jose: 6.2.6
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -2254,7 +2255,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2423,7 +2424,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -2462,7 +2463,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -2524,7 +2525,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.27: {}
+  hono@4.13.0: {}
 
   html-escaper@2.0.2: {}
 
@@ -2542,7 +2543,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -2669,7 +2670,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   negotiator@1.0.0: {}
 
@@ -2781,7 +2782,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,9 +4,10 @@ overrides:
   body-parser: 2.3.0
   brace-expansion: 5.0.9
   esbuild: 0.28.1
-  fast-uri: 3.1.4
-  hono: 4.12.27
-  ip-address: 10.2.0
+  fast-uri: 3.1.5
+  hono: 4.13.0
+  ip-address: 10.4.0
+  nanoid: 3.3.17
   qs: 6.15.3
   vite: 8.2.1
 


### PR DESCRIPTION
## Summary

Refresh the mature dependency/security/tooling set found during the final 0.13.1 readiness audit, while preserving `minimumReleaseAge: 2880` with no exceptions.

Security overrides:

- `fast-uri` 3.1.4 → 3.1.5 — same-major fix for GHSA-7p8r-x3mc-p8w7.
- Hono 4.12.27 → 4.13.0 — mature compatible release containing the 4.12.34 security fixes for CORS ReDoS, request-context SSR disclosure, proxy hop-by-hop headers, and language middleware complexity.
- `ip-address` 10.2.0 → 10.4.0 — mature compatible release containing the 10.3.1 host-confusion/classification fixes plus Node 12 compatibility and byte-array validation.
- `nanoid` 3.3.16 → 3.3.17 — same-major fix for the zero-size custom-generator infinite loop.

Tooling:

- pnpm 10.33.2 → 10.34.5 across `packageManager` and every workflow pin. This mature same-major release includes path-traversal and project-proxy-placeholder hardening.
- `actions/setup-node` v6 → v7.
- `actions/upload-artifact` v6 → v7.
- `pnpm/action-setup` 6.0.8 → 6.0.10.

Existing current-major Action references (`checkout` v7, cache v5, Pages actions, and `create-github-app-token` v3.2.0) were already current.

## Release-age and compatibility proof

Audit timestamp: 2026-08-08T22:36:35Z.

Every selected package/action was published no later than 2026-08-03 and therefore exceeded the 48-hour minimum. Node engines remain compatible with the repository's Node ≥24 contract. The Hono and `ip-address` choices stay within the transitive semver ranges used by MCP SDK v1 fixtures; fast-uri and nanoid stay on their existing major lines.

Explicitly deferred as too young:

- tsx 4.23.11 — published 2026-08-07T12:48:28Z; eligible 2026-08-09T12:48:28Z.
- `@types/node` 26.2.0 — published 2026-08-07T17:52:06Z; eligible 2026-08-09T17:52:06Z.
- esbuild 0.28.2 — published 2026-08-08T20:00:55Z; eligible 2026-08-10T20:00:55Z.
- Hono 4.13.1 — published 2026-08-07T06:45:13Z; eligible 2026-08-09T06:45:13Z.
- nanoid 3.3.18 — published 2026-08-07T16:41:05Z; eligible 2026-08-09T16:41:05Z.

`pnpm outdated` is empty with repository policy active; disabling the age filter only for the read-only audit reports tsx and Node types above.

## Proof

Exact head: `e24bdcc8a83f14f3e355ae4372b221b79859216c`.

- `pnpm install --frozen-lockfile` — passed under pnpm 10.34.5.
- `pnpm docs:list` — passed.
- `pnpm check` — passed.
- `pnpm test` — 187 files passed, 4 skipped; 1,438 tests passed, 26 skipped.
- `pnpm docs:site` — passed.
- `pnpm build:bun` — passed; 379 modules compiled.
- `pnpm audit` — zero advisories, down from 9 (3 high, 5 moderate, 1 low).
- `git diff --check` — passed.
- Codex-backed autoreview — clean, no accepted/actionable findings.
- Exact-diff secret scan — clean.
- Public model-identifier audit — PASS; this is not a model-bearing change.

No version, release, tag, package publication, or native signing step is included.
