### PR TITLE
chore(release): prepare 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # mcporter Changelog
 
-## [0.13.1] - Unreleased
+## [0.13.1] - 2026-08-08
 
 ### CLI
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcporter",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "TypeScript runtime and CLI for connecting to configured Model Context Protocol servers.",
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary

- set the package version to `0.13.1`
- stamp the audited 0.13.1 changelog date as `2026-08-08`
- leave the lockfile, release notes, source, dependencies, and release automation unchanged

## Proof

Exact head: `9f99aed742d56510fb132cfd3ef55b87beb594db`

- `pnpm install --frozen-lockfile` — passed; lockfile unchanged
- `./scripts/release.sh gates` — passed check, 187 test files / 1,438 tests, Node and Bun builds, release-contract mocks, artifact inventory/checksums/provenance, and zero-advisory audit
- `pnpm docs:list` — passed
- `pnpm docs:site` — passed
- `git diff --check` — passed
- structured autoreview — clean, no accepted/actionable findings
- exact-diff secret scan — clean
- public model-identifier audit — PASS

This PR performs source preparation only. It does not create a tag, native artifacts, GitHub Release, npm publication, or Homebrew update.
