### PR TITLE
docs(changelog): open 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # mcporter Changelog
 
+## [0.13.2] - Unreleased
+
 ## [0.13.1] - 2026-08-08
 
 ### CLI


### PR DESCRIPTION
## Summary

- open the post-release `0.13.2` Unreleased changelog section
- keep package version `0.13.1` and all published 0.13.1 notes unchanged

## Proof

Exact head: `a9fe641cf128fcca14f13ead13c7c771074fa51e`

- `pnpm docs:list` — passed
- `pnpm format:check` — passed
- `git diff --check` — passed
- global structured autoreview — clean, no accepted/actionable findings
- exact-diff secret scan — clean
- public model-identifier audit — PASS

This is changelog-only post-release closeout. It does not release or publish 0.13.2.
