### PR TITLE
fix(cli): reject undeclared call flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.13.2] - Unreleased
 
+### CLI
+
+- Accept `--params` as an alias for JSON call arguments and reject undeclared long-form tool flags before dispatch.
+
 ### OAuth
 
 - Preserve refreshable dynamic OAuth client registrations across fresh callback ports, replacing an obsolete redirect registration only when interactive authorization is required. (Issue #290, thanks @elecnix)

--- a/docs/call-syntax.md
+++ b/docs/call-syntax.md
@@ -61,7 +61,7 @@ Key details:
 
 ## Tips
 
-- Use `--args '{ "issueId": "LNR-123" }'`, `--json '{ "issueId": "LNR-123" }'`, or `--json -` if you already have JSON payloads.
+- Use `--args '{ "issueId": "LNR-123" }'`, `--params '{ "issueId": "LNR-123" }'`, `--json '{ "issueId": "LNR-123" }'`, or `--json -` if you already have JSON payloads.
 - The new syntax respects all existing features (timeouts, `--output`, auto-correction).
 - Required fields show by default; pass `--all-parameters` when you want the full parameter list (or `--schema` for raw JSON schemas).
 - When in doubt, run `mcporter list <server>` to see the current signature and sample invocation.
@@ -70,12 +70,12 @@ Key details:
 
 - `--key value`, `--key=value`, `key=value`, `key:value`, `key: value`, and `key:=value` all map to the same named-argument handling, so you can type whichever feels most natural for your shell. Long flag keys convert kebab-case to camelCase (`--save-to-drafts true` becomes `saveToDrafts: true`). The `:=` form is accepted as a compatibility alias for `=`.
 - By default, arguments keep the same validation pipeline as the function-call syntax—enums, numbers, and booleans are coerced automatically, and missing required fields raise errors.
-- `--args -` and `--json -` read a JSON object from stdin.
+- `--args -`, `--params -`, and `--json -` read a JSON object from stdin.
 - Named flag-style values can read exact UTF-8 text from a file with `key=@path` or `--key @path`. Paths resolve from the current working directory, file contents remain strings without coercion, and `key=@@literal` produces the literal value `@literal`. Function-call strings such as `body: "@literal"` remain literal.
 - Bare string values supplied via long flags wrap into one-item arrays when the tool schema declares that field as an array.
 - Numeric-looking `key=value` arguments are restored to their original string spelling when the tool schema declares that parameter as a string, which keeps timestamp-like IDs such as Slack `thread_ts=1234567890.123456` intact.
 - `--raw-strings` disables numeric coercion for flag-style and positional values so IDs/codes stay literal strings (`code=12345` stays `"12345"`).
 - `--no-coerce` disables all coercion for flag-style and positional values (`true`, `null`, and JSON-like values remain strings).
-- Long flags without values fail fast. Insert `--` before literal positional values that start with `--`.
+- Long tool flags are checked against the selected tool schema before dispatch; undeclared flags fail with guidance to use `key=value` or `--args`. Insert `--` before literal positional values that start with `--`.
 - `--save-images <dir>` keeps stdout formatting untouched while writing image content blocks to disk when a tool response includes `type: "image"` entries.
 - `tool=value`/`tool:value` and `server=value` still act as aliases for `--tool` / `--server` when you need to override the selector.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -47,6 +47,7 @@ A quick reference for the primary `mcporter` subcommands. Each command inherits
   pseudo-TS syntax and `--arg` flags.
 - Useful flags:
   - `--server`, `--tool` – alternate way to target a tool.
+  - `--args <json>`, `--params <json>` – provide a JSON object payload.
   - `--` – stop flag parsing so remaining tokens stay literal positional values.
   - `--timeout <ms>` – override the 60 s call timeout; `MCPORTER_CALL_TIMEOUT` provides the equivalent environment override.
   - `--output text|markdown|json|raw` – choose how to render the `CallResult`.
@@ -54,6 +55,7 @@ A quick reference for the primary `mcporter` subcommands. Each command inherits
   - `--raw-strings` – disable numeric coercion for flag-style and positional values.
   - `--no-coerce` – disable all flag-style/positional value coercion.
   - `key=@path` / `--key @path` – read a named UTF-8 string argument from a file; prefix with `@@` for a literal leading `@`.
+  - Generic long tool flags are validated against the selected tool schema before dispatch.
   - `--tail-log` – stream tail output when the tool returns log handles.
   - `--no-oauth` – never start an interactive OAuth flow; use cached
     tokens only while keeping eligible connections pooled.

--- a/docs/tool-calling.md
+++ b/docs/tool-calling.md
@@ -31,8 +31,8 @@ mcporter call context7.resolve-library-id libraryName: value
 - Use `--flag value` when you prefer long-form CLI syntax.
 - Mixed forms are fine: `mcporter call linear.create_issue --team ENG title=value due: tomorrow`.
 - Use `body=@comment.md` (or `--body @comment.md`) to read an exact UTF-8 string from a file; use `body=@@literal` when the value itself starts with `@`.
-- `--args '{"title":"Bug"}'` still ingests JSON payloads directly.
-- Unknown long flags now error instead of silently becoming tool arguments; use `title=value`, `--args`, or `--` before literal positional values beginning with `--`.
+- `--args '{"title":"Bug"}'` and `--params '{"title":"Bug"}'` ingest JSON object payloads directly.
+- Long tool flags are validated against the selected tool schema; undeclared flags error instead of being silently ignored. Use `title=value`, `--args`, or `--` before literal positional values beginning with `--` when schema-checked flag syntax is not appropriate.
 
 ## 3. Function-Call Syntax
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -521,7 +521,8 @@ async function maybeHandleSimpleDaemonFastCall(
     parsed.saveImagesDir ||
     (parsed.positionalArgs?.length ?? 0) > 0 ||
     parsed.schemaStringCoercionCandidates ||
-    parsed.schemaArrayCoercionCandidates
+    parsed.schemaArrayCoercionCandidates ||
+    (parsed.genericLongFlagArguments?.length ?? 0) > 0
   ) {
     return false;
   }

--- a/src/cli/call-arguments.ts
+++ b/src/cli/call-arguments.ts
@@ -14,6 +14,11 @@ import { consumeOutputFormat } from './output-format.js';
 import type { OutputFormat } from './output-utils.js';
 import { consumeTimeoutFlag } from './timeouts.js';
 
+export interface GenericLongFlagArgument {
+  key: string;
+  token: string;
+}
+
 export interface CallArgsParseResult {
   selector?: string;
   server?: string;
@@ -21,6 +26,7 @@ export interface CallArgsParseResult {
   args: Record<string, unknown>;
   schemaStringCoercionCandidates?: Record<string, string>;
   schemaArrayCoercionCandidates?: Record<string, string>;
+  genericLongFlagArguments?: GenericLongFlagArgument[];
   positionalArgs?: unknown[];
   tailLog: boolean;
   output: OutputFormat;
@@ -66,6 +72,7 @@ const FLAG_HANDLERS: Record<string, FlagHandler> = {
   '--raw-strings': handleRawStringsFlag,
   '--no-coerce': handleNoCoerceFlag,
   '--args': handleArgsFlag,
+  '--params': handleParamsFlag,
   '--json': handleJsonArgsFlag,
 };
 
@@ -293,6 +300,10 @@ function handleArgsFlag(context: FlagHandlerContext): number {
   return consumeJsonArgsFlag(context, '--args', '--args requires a JSON value.');
 }
 
+function handleParamsFlag(context: FlagHandlerContext): number {
+  return consumeJsonArgsFlag(context, '--params', '--params requires a JSON value.');
+}
+
 function handleJsonArgsFlag(context: FlagHandlerContext): number {
   return consumeJsonArgsFlag(context, '--json', '--json requires a JSON object value.');
 }
@@ -335,6 +346,8 @@ function handleNamedArgumentFlag(context: FlagHandlerContext): number {
     context.result.schemaArrayCoercionCandidates ??= {};
     context.result.schemaArrayCoercionCandidates[key] = schemaValue;
   }
+  context.result.genericLongFlagArguments ??= [];
+  context.result.genericLongFlagArguments.push({ key, token });
   context.result.args[key] = value;
   return context.index + (eqIndex === -1 ? 2 : 1);
 }

--- a/src/cli/call-command.ts
+++ b/src/cli/call-command.ts
@@ -1,9 +1,16 @@
 import { analyzeConnectionError, type ConnectionIssue } from '../error-classifier.js';
 import { wrapCallResult } from '../result-utils.js';
 import type { Runtime } from '../runtime.js';
-import { type CallArgsParseResult, parseCallArguments } from './call-arguments.js';
-import { CALL_HELP_ARGUMENT_LINES, CALL_HELP_EXAMPLE_LINES, CALL_HELP_RUNTIME_FLAG_LINES } from './call-help.js';
+import { type CallArgsParseResult, type GenericLongFlagArgument, parseCallArguments } from './call-arguments.js';
+import {
+  buildUnknownCallFlagMessage,
+  buildUnvalidatedCallFlagMessage,
+  CALL_HELP_ARGUMENT_LINES,
+  CALL_HELP_EXAMPLE_LINES,
+  CALL_HELP_RUNTIME_FLAG_LINES,
+} from './call-help.js';
 import { renderAdhocServerHelpLines } from './adhoc-help.js';
+import { CliUsageError } from './errors.js';
 import {
   persistPreparedEphemeralServer,
   prepareEphemeralServerTarget,
@@ -82,6 +89,7 @@ async function prepareCallRequest(runtime: Runtime, args: string[]): Promise<Pre
     hydratedArgs,
     parsed.schemaStringCoercionCandidates,
     parsed.schemaArrayCoercionCandidates,
+    parsed.genericLongFlagArguments,
     timeoutMs,
     parsed.disableOAuth
   );
@@ -337,26 +345,50 @@ async function enforceSchemaAwareArgumentTypes(
   args: Record<string, unknown>,
   stringCandidates: Record<string, string> | undefined,
   arrayCandidates: Record<string, string> | undefined,
+  genericLongFlagArguments: GenericLongFlagArgument[] | undefined,
   timeoutMs: number,
   disableOAuth: boolean | undefined
 ): Promise<Record<string, unknown>> {
+  const requiresFlagValidation = (genericLongFlagArguments?.length ?? 0) > 0;
   if (
+    !requiresFlagValidation &&
     (!stringCandidates || Object.keys(stringCandidates).length === 0) &&
     (!arrayCandidates || Object.keys(arrayCandidates).length === 0)
   ) {
     return args;
   }
 
-  const tools = await withTimeout(
-    loadToolMetadata(runtime, server, { includeSchema: true, disableOAuth }),
-    timeoutMs
-  ).catch(() => undefined);
+  let tools: Awaited<ReturnType<typeof loadToolMetadata>> | undefined;
+  try {
+    tools = await withTimeout(loadToolMetadata(runtime, server, { includeSchema: true, disableOAuth }), timeoutMs);
+  } catch {
+    if (requiresFlagValidation) {
+      throw new CliUsageError(
+        buildUnvalidatedCallFlagMessage(genericLongFlagArguments?.[0]?.token ?? '--', server, tool)
+      );
+    }
+  }
   if (!tools) {
     return args;
   }
   const toolInfo = tools.find((entry) => entry.tool.name === tool);
-  const schema = toolInfo?.tool.inputSchema as { properties?: Record<string, unknown> } | undefined;
-  if (!schema?.properties) {
+  const schema = toolInfo?.tool.inputSchema;
+  const schemaProperties = readSchemaProperties(schema);
+  const declaredOptions = new Set(toolInfo?.options.map((option) => option.property) ?? []);
+  for (const key of Object.keys(schemaProperties ?? {})) {
+    declaredOptions.add(key);
+  }
+  if (requiresFlagValidation && (!toolInfo || (!schemaProperties && declaredOptions.size === 0))) {
+    throw new CliUsageError(
+      buildUnvalidatedCallFlagMessage(genericLongFlagArguments?.[0]?.token ?? '--', server, tool)
+    );
+  }
+  for (const flag of genericLongFlagArguments ?? []) {
+    if (!declaredOptions.has(flag.key)) {
+      throw new CliUsageError(buildUnknownCallFlagMessage(flag.token));
+    }
+  }
+  if (!schemaProperties) {
     return args;
   }
 
@@ -365,7 +397,7 @@ async function enforceSchemaAwareArgumentTypes(
     if (typeof args[key] !== 'number') {
       continue;
     }
-    if (!schemaAllowsString(schema.properties[key])) {
+    if (!schemaAllowsString(schemaProperties[key])) {
       continue;
     }
     corrected ??= { ...args };
@@ -375,7 +407,7 @@ async function enforceSchemaAwareArgumentTypes(
     if (typeof args[key] !== 'string') {
       continue;
     }
-    const descriptor = schema.properties[key];
+    const descriptor = schemaProperties[key];
     if (!schemaAllowsArray(descriptor) || schemaAllowsString(descriptor)) {
       continue;
     }
@@ -383,6 +415,17 @@ async function enforceSchemaAwareArgumentTypes(
     corrected[key] = [rawValue];
   }
   return corrected ?? args;
+}
+
+function readSchemaProperties(schema: unknown): Record<string, unknown> | undefined {
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    return undefined;
+  }
+  const properties = (schema as Record<string, unknown>).properties;
+  if (!properties || typeof properties !== 'object' || Array.isArray(properties)) {
+    return undefined;
+  }
+  return properties as Record<string, unknown>;
 }
 
 function schemaAllowsString(descriptor: unknown): boolean {

--- a/src/cli/call-help.ts
+++ b/src/cli/call-help.ts
@@ -2,7 +2,7 @@ export const CALL_HELP_ARGUMENT_LINES = [
   '  key=value / key:value  Flag-style named arguments.',
   '  key=@path              Read a UTF-8 string value from a file; use @@ for a literal @.',
   '  function-call syntax   \'server.tool(arg: "value", other: 1)\'.',
-  '  --args <json>          Provide a JSON object payload.',
+  '  --args, --params <json>  Provide a JSON object payload.',
   '  positional values      Accepted when schema order is known.',
   '  --                     Treat remaining tokens as literal positional values.',
 ] as const;
@@ -26,11 +26,20 @@ export const CALL_HELP_EXAMPLE_LINES = [
 ] as const;
 
 export function buildUnknownCallFlagMessage(token: string): string {
-  const argumentName = token.startsWith('--') ? token.slice(2) : token;
+  const argumentName = (token.startsWith('--') ? token.slice(2) : token).split('=', 1)[0];
   return [
     `Unknown flag '${token}' passed to call command.`,
     `If you intended to pass a tool argument, use '${argumentName}=<value>' or --args '{"${argumentName}": ...}'.`,
     "If you intended to pass a literal positional value, insert '--' before it.",
+    "Run 'mcporter call --help' to see available flags.",
+  ].join('\n');
+}
+
+export function buildUnvalidatedCallFlagMessage(token: string, server: string, tool: string): string {
+  const argumentName = (token.startsWith('--') ? token.slice(2) : token).split('=', 1)[0];
+  return [
+    `Unable to validate flag '${token}' because ${server}.${tool} did not provide usable tool metadata with an input schema.`,
+    `Use '${argumentName}=<value>' or --args '{"${argumentName}": ...}' to pass this argument without long-flag validation.`,
     "Run 'mcporter call --help' to see available flags.",
   ].join('\n');
 }

--- a/tests/call-arguments.test.ts
+++ b/tests/call-arguments.test.ts
@@ -61,6 +61,12 @@ describe('parseCallArguments', () => {
       limit: 5,
     });
     expect(parsed.schemaStringCoercionCandidates).toEqual({ limit: '5' });
+    expect(parsed.genericLongFlagArguments).toEqual([
+      { key: 'to', token: '--to' },
+      { key: 'subject', token: '--subject' },
+      { key: 'saveToDrafts', token: '--save-to-drafts' },
+      { key: 'limit', token: '--limit=5' },
+    ]);
   });
 
   it('merges --json object payloads as an alias for --args', () => {
@@ -77,6 +83,7 @@ describe('parseCallArguments', () => {
       saveToDrafts: true,
       text: 'Hello',
     });
+    expect(parsed.genericLongFlagArguments).toEqual([{ key: 'text', token: '--text' }]);
   });
 
   it('reads JSON object payloads from stdin when --json - is used', () => {
@@ -144,10 +151,6 @@ describe('parseCallArguments', () => {
     }
   });
 
-  it('throws when generic long flags are missing a value', () => {
-    expect(() => parseCallArguments(['server.tool', '--source'])).toThrow("Flag '--source' requires a value.");
-  });
-
   it('treats values after -- as literal positional arguments', () => {
     const parsed = parseCallArguments(['server.tool', '--', '--source', 'import', '--raw=true']);
     expect(parsed.selector).toBe('server.tool');
@@ -158,6 +161,10 @@ describe('parseCallArguments', () => {
     expect(() => parseCallArguments(['--server', 'linear', 'cursor.list_documents(limit:1)'])).toThrow(
       /Conflicting server names/
     );
+  });
+
+  it('throws when generic long flags are missing a value', () => {
+    expect(() => parseCallArguments(['server.tool', '--source'])).toThrow("Flag '--source' requires a value.");
   });
 
   it('treats key:=value as an alias for key=value without keeping a trailing colon', () => {
@@ -240,6 +247,7 @@ describe('parseCallArguments', () => {
   it.each([
     ['--save-images', /--save-images requires a directory path/],
     ['--args', /--args requires a JSON value/],
+    ['--params', /--params requires a JSON value/],
   ] as const)('throws when %s is missing a value', (flag, expectedError) => {
     expect(() => parseCallArguments([flag])).toThrow(expectedError);
   });

--- a/tests/cli-call-args.test.ts
+++ b/tests/cli-call-args.test.ts
@@ -97,6 +97,8 @@ describe('CLI call argument parsing', () => {
   it('reports invalid JSON argument payloads and malformed long flags', async () => {
     const { parseCallArguments } = await cliModulePromise;
     expect(() => parseCallArguments(['linear.search', '--args', '{bad'])).toThrow('Unable to parse --args');
+    expect(() => parseCallArguments(['linear.search', '--params', '{bad'])).toThrow('Unable to parse --params');
+    expect(() => parseCallArguments(['linear.search', '--params', '[]'])).toThrow('--params must be a JSON object');
     expect(() => parseCallArguments(['linear.search', '--json', '[]'])).toThrow('--json must be a JSON object');
     expect(() => parseCallArguments(['linear.search', '---bad', 'value'])).toThrow(CliUsageError);
   });

--- a/tests/cli-call-execution.test.ts
+++ b/tests/cli-call-execution.test.ts
@@ -131,7 +131,34 @@ describe('CLI call execution behavior', () => {
     logSpy.mockRestore();
   });
 
-  it('does not load schemas for numeric values supplied via --args JSON', async () => {
+  it('rejects undeclared long flags after metadata lookup without dispatching a tool call', async () => {
+    const { handleCall } = await cliModulePromise;
+    const { runtime, callTool, listTools } = createRuntimeStub({
+      email: [
+        {
+          name: 'send_email',
+          inputSchema: {
+            type: 'object',
+            properties: { subject: { type: 'string' } },
+          },
+        },
+      ],
+    });
+
+    await expect(handleCall(runtime, ['email.send_email', '--bogus', 'Test'])).rejects.toThrow(
+      "Unknown flag '--bogus' passed to call command."
+    );
+
+    expect(listTools).toHaveBeenCalledWith('email', {
+      autoAuthorize: true,
+      includeSchema: true,
+      allowCachedAuth: true,
+      disableOAuth: undefined,
+    });
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it.each(['--args', '--params'] as const)('forwards JSON arguments supplied via %s', async (flag) => {
     const { handleCall } = await cliModulePromise;
     const { runtime, callTool, listTools } = createRuntimeStub({
       linear: [
@@ -148,7 +175,7 @@ describe('CLI call execution behavior', () => {
     });
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await handleCall(runtime, ['linear.list_issues', '--args', '{"limit":5}']);
+    await handleCall(runtime, ['linear.list_issues', flag, '{"limit":5}']);
 
     expect(callTool).toHaveBeenCalledWith('linear', 'list_issues', expect.objectContaining({ args: { limit: 5 } }));
     expect(listTools).not.toHaveBeenCalled();

--- a/tests/cli-call-validation.test.ts
+++ b/tests/cli-call-validation.test.ts
@@ -120,6 +120,15 @@ describe('CLI call positional and schema validation', () => {
     );
   });
 
+  it('rejects long tool flags when metadata cannot establish a declared option', async () => {
+    const { runtime, callTool } = runtimeWith(() => Promise.reject(new Error('discovery failed')));
+
+    await expect(handleCall(runtime, ['linear.update', '--label', 'bug'])).rejects.toThrow(
+      "Unable to validate flag '--label' because linear.update did not provide usable tool metadata"
+    );
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
   it('reports STDIO process exits with code and signal details', async () => {
     const { runtime, callTool } = runtimeWith([]);
     callTool.mockRejectedValue(new Error('STDIO transport exited with code 2 (signal SIGTERM)'));

--- a/tests/cli-daemon-fast-path.test.ts
+++ b/tests/cli-daemon-fast-path.test.ts
@@ -89,6 +89,51 @@ describe('daemon call fast path', () => {
     );
   });
 
+  it('uses normal call handling to schema-validate generic long tool flags', async () => {
+    mocks.daemonListTools.mockResolvedValue([
+      {
+        name: 'list_pages',
+        inputSchema: { type: 'object', properties: { includeHidden: { type: 'boolean' } } },
+      },
+    ]);
+    const { runCli } = await import('../src/cli.js');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runCli(['call', 'chrome-devtools.list_pages', '--include-hidden', 'true', '--output', 'json']);
+
+    expect(mocks.daemonListTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        server: 'chrome-devtools',
+        includeSchema: true,
+        autoAuthorize: true,
+        allowCachedAuth: true,
+      })
+    );
+    expect(mocks.daemonCallTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        server: 'chrome-devtools',
+        tool: 'list_pages',
+        args: { includeHidden: true },
+      })
+    );
+  });
+
+  it('keeps --params JSON calls on the simple daemon fast path', async () => {
+    const { runCli } = await import('../src/cli.js');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runCli(['call', 'chrome-devtools.list_pages', '--params', '{"limit":5}', '--output', 'json']);
+
+    expect(mocks.daemonListTools).not.toHaveBeenCalled();
+    expect(mocks.daemonCallTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        server: 'chrome-devtools',
+        tool: 'list_pages',
+        args: { limit: 5 },
+      })
+    );
+  });
+
   it('leaves CloudBase calls on the config-aware runtime path', async () => {
     mocks.createRuntime.mockRejectedValue(new Error('runtime path used'));
     const { runCli } = await import('../src/cli.js');


### PR DESCRIPTION
## Summary

- Accept `--params` as a first-class alias for `--args`.
- Preserve schema-declared generic long tool flags while rejecting undeclared ones before dispatch.
- Prevent the daemon fast path from bypassing validation.
- Add CLI, docs, and changelog regressions.

## Tests

- `pnpm check`
- `pnpm test`
- `pnpm exec vitest run tests/call-arguments.test.ts tests/cli-call-args.test.ts tests/cli-call-execution.test.ts tests/cli-call-validation.test.ts tests/cli-daemon-fast-path.test.ts`
