### PR TITLE
fix(vault): describe the accepted clientInfo shape in vault set help

### DIFF
--- a/src/cli/vault-command.ts
+++ b/src/cli/vault-command.ts
@@ -223,6 +223,11 @@ export function printVaultHelp(): void {
     '',
     'Payload:',
     '  { "tokens": { "access_token": "...", "token_type": "Bearer" }, "clientInfo": { "client_id": "..." } }',
+    '',
+    '  clientInfo accepts a full dynamic client registration response, including the',
+    '  redirect_uris, grant_types, response_types and contacts arrays, the',
+    '  client_id_issued_at and client_secret_expires_at timestamps, and provider',
+    '  metadata outside RFC 7591.',
   ];
   console.error(lines.join('\n'));
 }

--- a/tests/cli-vault-help.test.ts
+++ b/tests/cli-vault-help.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+process.env.MCPORTER_DISABLE_AUTORUN = '1';
+const cliModulePromise = import('../src/cli.js');
+
+describe('mcporter vault help shortcut', () => {
+  let previousNoForceExit: string | undefined;
+
+  beforeEach(() => {
+    previousNoForceExit = process.env.MCPORTER_NO_FORCE_EXIT;
+    process.env.MCPORTER_NO_FORCE_EXIT = '1';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+    if (previousNoForceExit === undefined) {
+      delete process.env.MCPORTER_NO_FORCE_EXIT;
+    } else {
+      process.env.MCPORTER_NO_FORCE_EXIT = previousNoForceExit;
+    }
+  });
+
+  it('describes the clientInfo shape the validator accepts', async () => {
+    const { runCli } = await cliModulePromise;
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await runCli(['vault', '--help']);
+
+    const output = errorSpy.mock.calls.map(([message]) => String(message)).join('\n');
+    expect(output).toContain('Usage: mcporter vault');
+    expect(output).toContain('dynamic client registration response');
+    for (const field of ['redirect_uris', 'grant_types', 'response_types', 'contacts']) {
+      expect(output).toContain(field);
+    }
+    expect(output).toContain('client_id_issued_at');
+    expect(output).toContain('client_secret_expires_at');
+    expect(process.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

`mcporter vault set --help` still presents `clientInfo` as `client_id` alone. Since #288 the validator accepts the RFC 7591 dynamic client registration shape — `redirect_uris`, `grant_types`, `response_types` and `contacts` arrays, the `client_id_issued_at` / `client_secret_expires_at` timestamps, and provider metadata outside the spec — so the only place a headless operator looks before writing a payload now under-describes what the command takes.

That gap is not hypothetical. Issue #286 was filed with exactly the expectation this line creates, and the reporter's payload was a full registration response.

### Current output

`src/cli/vault-command.ts:224`

```
Payload:
  { "tokens": { "access_token": "...", "token_type": "Bearer" }, "clientInfo": { "client_id": "..." } }
```

`docs/config.md:259` documents the payload as `{ "tokens": { ... }, "clientInfo": { ... } }` without naming fields, so nothing else in the project contradicts the help text either way.

## Fix

Four lines appended under `Payload:`, naming the field groups the validator now accepts. The existing one-line example is unchanged, so the shortest usable payload still reads first.

```
Payload:
  { "tokens": { "access_token": "...", "token_type": "Bearer" }, "clientInfo": { "client_id": "..." } }

  clientInfo accepts a full dynamic client registration response, including the
  redirect_uris, grant_types, response_types and contacts arrays, the
  client_id_issued_at and client_secret_expires_at timestamps, and provider
  metadata outside RFC 7591.
```

The wording deliberately names field groups rather than restating the whole rule table: `OAUTH_CLIENT_STRING_FIELDS` alone is 15 entries, and a help text that enumerates a validator is a second copy free to drift from it. "Provider metadata outside RFC 7591" is the one behavior a reader cannot infer from the spec — `validateOAuthClientInfo` iterates its own field lists rather than the payload, so `registration_client_uri` and `registration_access_token` reach the vault untouched.

No validator, payload, or persistence behavior changes.

## Behavior proof

Real CLI through `tsx src/cli.ts`.

```
=== BEFORE (main @ e404ed5) ===
Payload:
  { "tokens": { "access_token": "...", "token_type": "Bearer" }, "clientInfo": { "client_id": "..." } }

=== AFTER (this branch) ===
Payload:
  { "tokens": { "access_token": "...", "token_type": "Bearer" }, "clientInfo": { "client_id": "..." } }

  clientInfo accepts a full dynamic client registration response, including the
  redirect_uris, grant_types, response_types and contacts arrays, the
  client_id_issued_at and client_secret_expires_at timestamps, and provider
  metadata outside RFC 7591.
```

## Tests

`tests/cli-vault-help.test.ts` is new, in the shape of the existing `tests/cli-auth-help.test.ts`: it drives `runCli(['vault', '--help'])` and asserts the named field groups reach the output. `vault` had no help coverage before, so this also pins the `Usage:` line and the `exitCode` 0 the help shortcut sets.

Reverting only `src/cli/vault-command.ts` to main and keeping the test fails it on the `dynamic client registration response` assertion — 1 failed of 1.

## Gates

Windows 11, Node 22.20.0, pnpm 10.34.5.

- `pnpm exec vitest run tests/cli-vault-help.test.ts tests/vault-command.test.ts` — 7 passed.
- `oxfmt --check` and `oxlint --type-aware --deny-warnings` on both touched files — clean. `tsc --noEmit` — clean.
- Full `pnpm check` reports formatting in `tests/cli-list-stdio-logs.test.ts` and `tests/list-inline-stdio.test.ts`, which this branch does not touch and which report identically on unmodified `main` at e404ed5 on this machine. This box is below the engine floor the repo declares (`node >=24`); CI settles it.

`CHANGELOG.md` is untouched.
