### PR TITLE
test(live): track context7 protocol-era move to 2026-07-28

### DIFF
--- a/tests/live/protocol-era-conformance.test.ts
+++ b/tests/live/protocol-era-conformance.test.ts
@@ -38,7 +38,7 @@ const ERA_TARGETS: readonly EraTarget[] = [
   { name: 'javadocs', url: 'https://www.javadocs.dev/mcp', expectedVersion: '2026-07-28', expectedEra: 'modern' },
   { name: 'hf', url: 'https://huggingface.co/mcp', expectedVersion: '2026-07-28', expectedEra: 'modern' },
   { name: 'cfdocs', url: 'https://docs.mcp.cloudflare.com/mcp', expectedVersion: '2026-07-28', expectedEra: 'modern' },
-  { name: 'context7', url: 'https://mcp.context7.com/mcp', expectedVersion: '2025-11-25', expectedEra: 'legacy' },
+  { name: 'context7', url: 'https://mcp.context7.com/mcp', expectedVersion: '2026-07-28', expectedEra: 'modern' },
   { name: 'mslearn', url: 'https://learn.microsoft.com/api/mcp', expectedVersion: '2025-06-18', expectedEra: 'legacy' },
   { name: 'gitmcp', url: 'https://gitmcp.io/docs', expectedVersion: '2025-03-26', expectedEra: 'legacy' },
 ];
@@ -52,7 +52,7 @@ const ERA_CALLS: readonly EraCall[] = [
   },
   {
     server: 'context7',
-    revision: '2025-11-25',
+    revision: '2026-07-28',
     toolNames: ['resolve-library-id'],
     args: { query: 'testing', libraryName: 'vitest' },
   },


### PR DESCRIPTION
The scheduled Live conformance run failed exactly as designed:

```
AssertionError: context7 changed its advertised protocol revision:
expected '2026-07-28' to be '2025-11-25'
```

context7 upgraded from the legacy era to the modern protocol revision. This
updates its target entry (`expectedVersion: '2026-07-28'`,
`expectedEra: 'modern'`) and the paired era-call expectation.

Verified against the real servers, not just the fixture:

```
$ MCP_LIVE_TESTS=1 pnpm exec vitest run tests/live/protocol-era-conformance.test.ts
Test Files  1 passed (1)
Tests  12 passed (12)
```

That includes the live `resolve-library-id` tool call against context7 on the
new revision — mcporter negotiates and operates correctly on 2026-07-28, so
this is a fixture update reflecting real vendor drift, not a loosened gate.
