### PR TITLE
fix(oauth): serialize the refresh transaction across processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [0.13.4] - Unreleased
 
+### OAuth
+
+- Serialize the whole OAuth refresh transaction across processes so a rotating refresh token is redeemed once. Concurrent mcporter processes sharing a credential vault could each read the same expired access token and redeem the same refresh token; providers that detect replay answer with `invalid_grant` and revoke the entire token family, leaving no cached credentials. A dedicated per-credential refresh lock now covers the re-read, redemption, and persist as one transaction, and a caller that finds another process already refreshed adopts that result instead of redeeming again. Token endpoint and discovery requests made under the lock carry a cancellation deadline so a stalled endpoint cannot starve other processes. The guarantee is per host: hosts sharing one credential directory over a network filesystem cannot arbitrate each other's locks, and every long-lived daemon or generated CLI has to be upgraded before a fleet is fully protected. One known gap remains by design — the MCP SDK's internal 401-driven refresh has no interception point, so a 401 reaching two processes at the same instant can still redeem concurrently, where the existing rejected-refresh recovery remains the backstop. (Issue #305, thanks @feniix)
+- Recognize the OAuth error code the MCP SDK reports on its error objects, so a genuinely rejected refresh grant reaches the recovery that clears dead credentials instead of being retried as a transient failure. (Issue #305, thanks @feniix)
+
 ## [0.13.3] - 2026-08-09
 
 ### CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## [0.13.4] - Unreleased
 
-### OAuth
-
-- Serialize the whole OAuth refresh transaction across processes so a rotating refresh token is redeemed once. Concurrent mcporter processes sharing a credential vault could each read the same expired access token and redeem the same refresh token; providers that detect replay answer with `invalid_grant` and revoke the entire token family, leaving no cached credentials. A dedicated per-credential refresh lock now covers the re-read, redemption, and persist as one transaction, and a caller that finds another process already refreshed adopts that result instead of redeeming again. Token endpoint and discovery requests made under the lock carry a cancellation deadline so a stalled endpoint cannot starve other processes. The guarantee is per host: hosts sharing one credential directory over a network filesystem cannot arbitrate each other's locks, and every long-lived daemon or generated CLI has to be upgraded before a fleet is fully protected. One known gap remains by design — the MCP SDK's internal 401-driven refresh has no interception point, so a 401 reaching two processes at the same instant can still redeem concurrently, where the existing rejected-refresh recovery remains the backstop. (Issue #305, thanks @feniix)
-- Recognize the OAuth error code the MCP SDK reports on its error objects, so a genuinely rejected refresh grant reaches the recovery that clears dead credentials instead of being retried as a transient failure. (Issue #305, thanks @feniix)
-
 ## [0.13.3] - 2026-08-09
 
 ### CLI

--- a/src/fs-json.ts
+++ b/src/fs-json.ts
@@ -11,6 +11,23 @@ const MAX_SYMLINK_DEPTH = 40;
 const DEFAULT_ATOMIC_FILE_MODE = 0o600;
 const localLockTails = new Map<string, Promise<void>>();
 
+// Callers that degrade on contention (the OAuth refresh lock returns a stale
+// token instead of redeeming unlocked) must tell a timeout apart from a real
+// filesystem failure. Message matching would misroute either direction.
+export class FileLockTimeoutError extends Error {
+  readonly lockPath: string;
+
+  constructor(lockPath: string, options?: ErrorOptions) {
+    super(`Timed out waiting for file lock ${lockPath}`, options);
+    this.name = 'FileLockTimeoutError';
+    this.lockPath = lockPath;
+  }
+}
+
+export function isFileLockTimeoutError(error: unknown): error is FileLockTimeoutError {
+  return error instanceof FileLockTimeoutError;
+}
+
 // readJsonFile reads a JSON file and returns undefined when the file does not exist.
 export async function readJsonFile<T = unknown>(filePath: string): Promise<T | undefined> {
   try {
@@ -95,7 +112,7 @@ export async function withFileLock<T>(
           continue;
         }
         if (Date.now() - startedAt > timeoutMs) {
-          throw new Error(`Timed out waiting for file lock ${lockPath}`, { cause: error });
+          throw new FileLockTimeoutError(lockPath, { cause: error });
         }
         await sleep(LOCK_POLL_MS);
       }
@@ -149,10 +166,7 @@ async function waitForLocalLock(previous: Promise<void>, timeoutMs: number, key:
     await Promise.race([
       previous,
       new Promise<never>((_, reject) => {
-        timer = setTimeout(
-          () => reject(new Error(`Timed out waiting for file lock ${key}.lock`)),
-          Math.max(0, timeoutMs)
-        );
+        timer = setTimeout(() => reject(new FileLockTimeoutError(`${key}.lock`)), Math.max(0, timeoutMs));
       }),
     ]);
   } finally {
@@ -176,6 +190,12 @@ async function resolveAtomicWriteTarget(filePath: string): Promise<{ path: strin
     }
     throw error;
   }
+}
+
+// Resolves a path to its real location so two spellings of one file (relative,
+// absolute, or symlinked) cannot be treated as separate identities.
+export async function canonicalizeFilePath(filePath: string): Promise<string> {
+  return await resolvePathFollowingSymlinks(path.resolve(filePath));
 }
 
 async function resolvePathFollowingSymlinks(filePath: string): Promise<string> {

--- a/src/oauth-persistence-stores.ts
+++ b/src/oauth-persistence-stores.ts
@@ -507,6 +507,11 @@ export class CompositePersistence implements OAuthPersistence {
     return result.value;
   }
 
+  async readTokensPerStore(): Promise<OAuthTokens[]> {
+    const perStore = await Promise.all(this.stores.map((store) => store.readTokens()));
+    return perStore.filter((tokens): tokens is OAuthTokens => tokens !== undefined);
+  }
+
   async saveTokens(tokens: OAuthTokens): Promise<void> {
     // Compute the absolute expiry once so every backing store records the same
     // generation value even at a wall-clock second boundary.

--- a/src/oauth-persistence.ts
+++ b/src/oauth-persistence.ts
@@ -27,6 +27,12 @@ export interface OAuthPersistence {
   describe(): string;
   readSnapshot(): Promise<OAuthPersistenceSnapshot>;
   readTokens(): Promise<StoredOAuthTokens | undefined>;
+  // Every backing store's own view of the tokens. readTokens() returns the
+  // first store that has any, which hides divergence: a partial save can leave
+  // a spent generation in the higher-priority store while a newer one sits
+  // behind it. Refresh reconciles across these before redeeming. Only the
+  // composite needs it; a single store's readTokens() is already its own view.
+  readTokensPerStore?(): Promise<OAuthTokens[]>;
   saveTokens(tokens: StoredOAuthTokens): Promise<void>;
   readClientInfo(): Promise<StoredOAuthClientInformation | undefined>;
   saveClientInfo(info: StoredOAuthClientInformation): Promise<void>;

--- a/src/oauth-refresh-lock.ts
+++ b/src/oauth-refresh-lock.ts
@@ -1,0 +1,123 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import crypto from 'node:crypto';
+import path from 'node:path';
+import type { ServerDefinition } from './config.js';
+import { canonicalizeFilePath, withFileLock } from './fs-json.js';
+import { vaultKeyForDefinition } from './oauth-vault.js';
+import { mcporterDir } from './paths.js';
+
+/**
+ * Serializes the whole OAuth refresh transaction — re-read, redeem, persist —
+ * across processes, per credential identity.
+ *
+ * The vault write lock cannot do this job: the locked section calls saveTokens,
+ * which takes that lock itself. Without a separate transaction lock, two
+ * processes read the same expired token and redeem the same rotating refresh
+ * token; providers that detect replay revoke the whole token family.
+ */
+
+const REFRESH_LOCK_DIR = 'refresh-locks';
+const LOCK_LABEL_MAX = 40;
+const IDENTITY_HASH_LENGTH = 16;
+
+// Test-only: lets the multi-process suite construct a waiter-timeout case
+// inside its budgets. This is not the deferred user-facing setting.
+const TIMEOUT_OVERRIDE_ENV = 'MCPORTER_TEST_REFRESH_LOCK_TIMEOUT_MS';
+
+// Lock paths held by the current call chain. The MCP SDK's auth() reads tokens
+// through the provider while an outer wrapper already holds the lock, and
+// withFileLock is not re-entrant per key, so a nested acquisition would queue
+// behind its own holder until the acquisition timeout.
+const heldLockPaths = new AsyncLocalStorage<ReadonlySet<string>>();
+
+export interface RefreshLockOptions {
+  /** Overrides the acquisition timeout. Test-only; see TIMEOUT_OVERRIDE_ENV. */
+  timeoutMs?: number;
+}
+
+export function refreshLockDir(): string {
+  return path.join(mcporterDir('data'), REFRESH_LOCK_DIR);
+}
+
+/**
+ * Derives the lock file paths for a credential, in acquisition order.
+ *
+ * A credential reachable through more than one store must serialize as one
+ * identity. The composite persistence writes every store and falls back to the
+ * vault on reads, so a server configured with a token cache directory shares
+ * its vault-persisted token with the same server configured without one. Both
+ * targets are therefore locked, always in this order, so two configurations
+ * cannot invert it and deadlock.
+ */
+export async function refreshLockPaths(definition: ServerDefinition): Promise<string[]> {
+  const paths: string[] = [];
+  if (definition.tokenCacheDir) {
+    const tokenPath = await canonicalizeFilePath(path.join(definition.tokenCacheDir, 'tokens.json'));
+    paths.push(lockPathFor(path.basename(path.dirname(tokenPath)), `dir:${tokenPath}`));
+  }
+  paths.push(lockPathFor(definition.name, `vault:${vaultKeyForDefinition(definition)}`));
+  return paths;
+}
+
+export async function withRefreshLock<T>(
+  definition: ServerDefinition,
+  task: () => Promise<T>,
+  options: RefreshLockOptions = {}
+): Promise<T> {
+  const lockPaths = await refreshLockPaths(definition);
+  return await acquireAll(lockPaths, task, resolveTimeoutMs(options.timeoutMs));
+}
+
+async function acquireAll<T>(lockPaths: string[], task: () => Promise<T>, timeoutMs?: number): Promise<T> {
+  const held = heldLockPaths.getStore();
+  const pending = held ? lockPaths.filter((lockPath) => !held.has(lockPath)) : lockPaths;
+  if (pending.length === 0) {
+    return await task();
+  }
+
+  const nextHeld = new Set([...(held ?? []), ...pending]);
+  return await heldLockPaths.run(nextHeld, async () => {
+    // Compose inner-to-outer so the first pending path is the outermost lock.
+    let run = task;
+    for (const lockPath of pending.toReversed()) {
+      const inner = run;
+      run = async () => await withFileLock(lockPath, inner, timeoutMs === undefined ? {} : { timeoutMs });
+    }
+    return await run();
+  });
+}
+
+function resolveTimeoutMs(explicit?: number): number | undefined {
+  if (explicit !== undefined) {
+    return explicit;
+  }
+  const raw = process.env[TIMEOUT_OVERRIDE_ENV];
+  if (raw === undefined || raw.trim().length === 0) {
+    return undefined;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+/**
+ * Hashes the identity into the filename. The identity can embed a filesystem
+ * path and a user-chosen server name, so it carries separators, drive colons,
+ * and the vault key's '|' — none of which may reach a filename.
+ *
+ * The label is only a debugging aid, but it must be derived from the identity
+ * rather than from the calling definition: two definitions that share one token
+ * store have to land on the same filename, or they would take separate locks
+ * and could still redeem the same refresh token concurrently.
+ */
+function lockPathFor(label: string, identity: string): string {
+  const digest = crypto.createHash('sha256').update(identity).digest('hex').slice(0, IDENTITY_HASH_LENGTH);
+  const safeLabel = filenameSafeLabel(label);
+  return path.join(refreshLockDir(), safeLabel.length > 0 ? `${safeLabel}-${digest}` : digest);
+}
+
+function filenameSafeLabel(value: string): string {
+  return value
+    .replace(/[^A-Za-z0-9._-]+/g, '_')
+    .replace(/^[._-]+/, '')
+    .slice(0, LOCK_LABEL_MAX);
+}

--- a/src/oauth-refresh-lock.ts
+++ b/src/oauth-refresh-lock.ts
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 import path from 'node:path';
 import type { ServerDefinition } from './config.js';
 import { canonicalizeFilePath, withFileLock } from './fs-json.js';
-import { vaultKeyForDefinition } from './oauth-vault.js';
+import { vaultCredentialKeys } from './oauth-vault.js';
 import { mcporterDir } from './paths.js';
 
 /**
@@ -42,12 +42,19 @@ export function refreshLockDir(): string {
 /**
  * Derives the lock file paths for a credential, in acquisition order.
  *
- * A credential reachable through more than one store must serialize as one
- * identity. The composite persistence writes every store and falls back to the
- * vault on reads, so a server configured with a token cache directory shares
- * its vault-persisted token with the same server configured without one. Both
- * targets are therefore locked, always in this order, so two configurations
- * cannot invert it and deadlock.
+ * A credential reachable through more than one place must serialize as one
+ * identity, and there are two such axes. The composite persistence writes every
+ * store and falls back to the vault on reads, so a server configured with a
+ * token cache directory shares its vault-persisted token with the same server
+ * configured without one. Separately, a renamed server inherits the credentials
+ * of its legacy `<name>-oauth` vault entry, so both configurations can resolve
+ * to one refresh token under different vault keys.
+ *
+ * Every reachable target is locked, and the set is sorted so that all
+ * configurations acquire shared targets in the same order. Two definitions need
+ * not derive identical sets — they only have to overlap on the target holding
+ * the credential they share — but a total order is what keeps overlapping sets
+ * from inverting into a deadlock.
  */
 export async function refreshLockPaths(definition: ServerDefinition): Promise<string[]> {
   const paths: string[] = [];
@@ -55,8 +62,13 @@ export async function refreshLockPaths(definition: ServerDefinition): Promise<st
     const tokenPath = await canonicalizeFilePath(path.join(definition.tokenCacheDir, 'tokens.json'));
     paths.push(lockPathFor(path.basename(path.dirname(tokenPath)), `dir:${tokenPath}`));
   }
-  paths.push(lockPathFor(definition.name, `vault:${vaultKeyForDefinition(definition)}`));
-  return paths;
+  for (const vaultKey of await vaultCredentialKeys(definition)) {
+    // Label from the key's own server name, never the calling definition's: a
+    // renamed server and its legacy entry must land on one filename for the key
+    // they share, or they would take separate locks over one refresh token.
+    paths.push(lockPathFor(vaultKey.split('|')[0] ?? '', `vault:${vaultKey}`));
+  }
+  return [...new Set(paths)].toSorted();
 }
 
 export async function withRefreshLock<T>(

--- a/src/oauth-token-refresh.ts
+++ b/src/oauth-token-refresh.ts
@@ -13,10 +13,12 @@ import {
   resourceUrlFromServerUrl,
 } from '@modelcontextprotocol/client';
 import type { ServerDefinition } from './config.js';
+import { isFileLockTimeoutError } from './fs-json.js';
 import type { Logger } from './logging.js';
 import { buildStaticClientInformation, resolveOAuthClientSecret } from './oauth-client-info.js';
 import { clearLegacyOAuthArtifacts } from './oauth-persistence-stores.js';
 import type { OAuthPersistence } from './oauth-persistence.js';
+import { withRefreshLock } from './oauth-refresh-lock.js';
 import { sameOAuthTokenGeneration } from './oauth-token-generation.js';
 
 type CachedOAuthTokens = OAuthTokens & {
@@ -26,7 +28,68 @@ type CachedOAuthTokens = OAuthTokens & {
 
 const TOKEN_EXPIRY_SKEW_SECONDS = 60;
 
+// Bounds how long a redemption can hold the refresh lock. A live-but-stalled
+// holder is invisible to the lock's pid-based staleness check, so an unbounded
+// request would starve every waiter for its full acquisition budget.
+const TOKEN_REQUEST_TIMEOUT_MS = 10_000;
+
 class OAuthIssuerMismatchError extends Error {}
+
+/**
+ * What the transaction should do after re-reading persisted tokens under the
+ * refresh lock. Another process may have rotated the token while this caller
+ * waited, in which case redeeming again would replay a spent refresh token.
+ */
+type LockedTokenDecision =
+  | { kind: 'gone' }
+  | { kind: 'use'; accessToken: string; adopted: boolean }
+  | { kind: 'unrefreshable'; accessToken: string }
+  | { kind: 'redeem'; tokens: OAuthTokens; refreshToken: string };
+
+function decideUnderRefreshLock(
+  original: OAuthTokens,
+  latest: OAuthTokens | undefined,
+  skewSeconds: number
+): LockedTokenDecision {
+  if (!latest || typeof latest.access_token !== 'string' || latest.access_token.trim().length === 0) {
+    return { kind: 'gone' };
+  }
+  const adopted = cachedTokensChanged(original, latest);
+  if (!shouldRefreshCachedToken(latest, skewSeconds)) {
+    return { kind: 'use', accessToken: latest.access_token, adopted };
+  }
+  if (typeof latest.refresh_token !== 'string' || latest.refresh_token.trim().length === 0) {
+    // A winner that carries no refresh token is still the best available token.
+    return adopted
+      ? { kind: 'use', accessToken: latest.access_token, adopted }
+      : { kind: 'unrefreshable', accessToken: latest.access_token };
+  }
+  return { kind: 'redeem', tokens: latest, refreshToken: latest.refresh_token };
+}
+
+/**
+ * Never redeem outside the lock: a waiter that gave up would be exactly the
+ * concurrent redemption the lock exists to prevent. Returning a possibly
+ * expired token degrades to a 401, which the debug line makes traceable.
+ */
+async function accessTokenAfterLockTimeout(
+  definition: ServerDefinition,
+  persistence: OAuthPersistence,
+  tokenKind: 'OAuth' | 'bearer',
+  logger?: Logger
+): Promise<string | undefined> {
+  const latest = await persistence.readTokens();
+  const accessToken =
+    typeof latest?.access_token === 'string' && latest.access_token.trim().length > 0 ? latest.access_token : undefined;
+  logger?.debug?.(
+    `Timed out waiting for the ${tokenKind} refresh lock for '${definition.name}'; ${
+      accessToken
+        ? 'returning the persisted access token, which may already be expired.'
+        : 'no persisted access token remains.'
+    }`
+  );
+  return accessToken;
+}
 
 function tokenExpirySeconds(tokens: OAuthTokens): number | undefined {
   const stored = tokens as CachedOAuthTokens;
@@ -155,6 +218,46 @@ export async function readCachedAccessTokenWithPersistence(
   if (typeof tokens.refresh_token !== 'string' || tokens.refresh_token.trim().length === 0) {
     return tokens.access_token;
   }
+  if (definition.command.kind !== 'http') {
+    return tokens.access_token;
+  }
+  try {
+    return await withRefreshLock(
+      definition,
+      async () => await refreshCachedOAuthTokenUnderLock(definition, persistence, tokens, logger)
+    );
+  } catch (error) {
+    if (isFileLockTimeoutError(error)) {
+      return await accessTokenAfterLockTimeout(definition, persistence, 'OAuth', logger);
+    }
+    throw error;
+  }
+}
+
+// Runs the whole transaction — re-read, redeem, persist — while holding the
+// refresh lock, so a rotating refresh token is redeemed exactly once.
+async function refreshCachedOAuthTokenUnderLock(
+  definition: ServerDefinition,
+  persistence: OAuthPersistence,
+  original: OAuthTokens,
+  logger?: Logger
+): Promise<string | undefined> {
+  const decision = decideUnderRefreshLock(original, await persistence.readTokens(), TOKEN_EXPIRY_SKEW_SECONDS);
+  if (decision.kind === 'gone') {
+    logger?.debug?.(`Cached OAuth token for '${definition.name}' was cleared before its refresh could run.`);
+    return undefined;
+  }
+  if (decision.kind === 'unrefreshable') {
+    return decision.accessToken;
+  }
+  if (decision.kind === 'use') {
+    if (decision.adopted) {
+      logger?.debug?.(`Adopted the OAuth access token another refresh persisted first for '${definition.name}'.`);
+    }
+    return decision.accessToken;
+  }
+
+  const tokens = decision.tokens;
   let persistedClientInformation: OAuthClientInformationMixed | undefined;
   try {
     const staticClientInformation = buildStaticClientInformation(definition);
@@ -169,11 +272,11 @@ export async function readCachedAccessTokenWithPersistence(
     if (definition.command.kind !== 'http') {
       return tokens.access_token;
     }
-    const serverInfo = await discoverOAuthServerInfo(definition.command.url);
+    const serverInfo = await discoverOAuthServerInfo(definition.command.url, { fetchFn: boundedRefreshFetch });
     await assertRefreshIssuerBinding(
       definition,
       persistence,
-      tokens,
+      tokens as StoredOAuthTokens,
       clientInformation,
       serverInfo.authorizationServerUrl
     );
@@ -181,7 +284,8 @@ export async function readCachedAccessTokenWithPersistence(
     const refreshed = await refreshAuthorization(serverInfo.authorizationServerUrl, {
       metadata: serverInfo.authorizationServerMetadata,
       clientInformation,
-      refreshToken: tokens.refresh_token,
+      refreshToken: decision.refreshToken,
+      fetchFn: boundedRefreshFetch,
       ...(resource ? { resource } : {}),
     });
     await persistence.saveTokens({ ...refreshed, issuer: serverInfo.authorizationServerUrl });
@@ -210,6 +314,11 @@ export async function readCachedAccessTokenWithPersistence(
     }
     return tokens.access_token;
   }
+}
+
+// Every request issued while the refresh lock is held carries a deadline.
+export function boundedRefreshFetch(input: string | URL, init?: RequestInit): Promise<Response> {
+  return fetch(input, { ...init, signal: init?.signal ?? AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS) });
 }
 
 /**
@@ -272,7 +381,49 @@ async function readExplicitRefreshableBearerToken(
     throw new Error(`Cached bearer token for '${definition.name}' is expired, but no refresh_token is available.`);
   }
   try {
-    const refreshed = await refreshBearerToken(definition, tokens.refresh_token);
+    return await withRefreshLock(
+      definition,
+      async () => await refreshBearerTokenUnderLock(definition, persistence, tokens, skewSeconds, logger)
+    );
+  } catch (error) {
+    if (!isFileLockTimeoutError(error)) {
+      throw error;
+    }
+    const persisted = await accessTokenAfterLockTimeout(definition, persistence, 'bearer', logger);
+    if (persisted) {
+      return persisted;
+    }
+    throw new Error(
+      `Failed to refresh cached bearer token for '${definition.name}': timed out waiting for the refresh lock.`,
+      { cause: error }
+    );
+  }
+}
+
+async function refreshBearerTokenUnderLock(
+  definition: ServerDefinition,
+  persistence: OAuthPersistence,
+  original: OAuthTokens,
+  skewSeconds: number,
+  logger?: Logger
+): Promise<string> {
+  const decision = decideUnderRefreshLock(original, await persistence.readTokens(), skewSeconds);
+  if (decision.kind === 'gone') {
+    throw new Error(`Cached bearer token for '${definition.name}' was cleared before its refresh could run.`);
+  }
+  if (decision.kind === 'unrefreshable') {
+    throw new Error(`Cached bearer token for '${definition.name}' is expired, but no refresh_token is available.`);
+  }
+  if (decision.kind === 'use') {
+    if (decision.adopted) {
+      logger?.debug?.(`Adopted the bearer access token another refresh persisted first for '${definition.name}'.`);
+    }
+    return decision.accessToken;
+  }
+
+  const tokens = decision.tokens;
+  try {
+    const refreshed = await refreshBearerToken(definition, decision.refreshToken);
     await persistence.saveTokens(refreshed);
     logger?.debug?.(`Refreshed bearer access token for '${definition.name}' (non-interactive).`);
     return refreshed.access_token;
@@ -342,7 +493,7 @@ async function refreshBearerToken(definition: ServerDefinition, refreshToken: st
     ).toString('base64')}`;
   }
 
-  const response = await fetch(refresh.tokenEndpoint, {
+  const response = await boundedRefreshFetch(refresh.tokenEndpoint, {
     method: 'POST',
     headers,
     body,

--- a/src/oauth-token-refresh.ts
+++ b/src/oauth-token-refresh.ts
@@ -181,9 +181,15 @@ function oauthErrorCode(error: unknown): string | undefined {
   if (!error || typeof error !== 'object') {
     return undefined;
   }
-  const { errorCode, name } = error as { errorCode?: unknown; name?: unknown };
-  if (typeof errorCode === 'string' && errorCode.length > 0) {
-    return errorCode.toLowerCase();
+  // `code` is where the MCP SDK's OAuthError carries the OAuth error code, so
+  // without it a real rejected grant would skip recovery and be replayed.
+  // Unrelated codes (an errno such as ECONNREFUSED) fall out of the caller's
+  // allowlist, which is what keeps a transport failure recoverable.
+  const { errorCode, code, name } = error as { errorCode?: unknown; code?: unknown; name?: unknown };
+  for (const candidate of [errorCode, code]) {
+    if (typeof candidate === 'string' && candidate.length > 0) {
+      return candidate.toLowerCase();
+    }
   }
   if (typeof name === 'string') {
     const normalized = name.toLowerCase();

--- a/src/oauth-token-refresh.ts
+++ b/src/oauth-token-refresh.ts
@@ -108,6 +108,17 @@ function cachedTokensChanged(original: OAuthTokens, current: OAuthTokens | undef
   return !sameOAuthTokenGeneration(current, original);
 }
 
+/**
+ * Whether a persisted token is close enough to expiry that a refresh is due.
+ *
+ * The OAuth provider needs this to enforce that it never hands the MCP SDK an
+ * expired-but-refreshable token: the SDK would redeem it outside the refresh
+ * lock, which is the replay this module exists to prevent.
+ */
+export function oauthAccessTokenNeedsRefresh(tokens: OAuthTokens): boolean {
+  return shouldRefreshCachedToken(tokens);
+}
+
 function shouldRefreshCachedToken(tokens: OAuthTokens, skewSeconds = TOKEN_EXPIRY_SKEW_SECONDS): boolean {
   const expiresAt = tokenExpirySeconds(tokens);
   if (expiresAt !== undefined) {

--- a/src/oauth-token-refresh.ts
+++ b/src/oauth-token-refresh.ts
@@ -68,6 +68,71 @@ function decideUnderRefreshLock(
 }
 
 /**
+ * Chooses which store's generation to redeem when the stores disagree.
+ *
+ * The composite read returns the first store holding any tokens, so a save that
+ * only partly landed can leave a spent generation in the higher-priority store
+ * while a newer one sits behind it. Redeeming the spent one is a replay, which
+ * revokes the family — the loss the lock exists to prevent, reached through
+ * storage rather than concurrency.
+ *
+ * Two deliberate limits keep this from breaking rejected-credential recovery:
+ *
+ * - It only overrides store priority when the stores hold *different* refresh
+ *   tokens. Stores commonly differ in generation marker or expiry spelling while
+ *   holding the same refresh token; redeeming either is identical, and that
+ *   per-store divergence is what lets recovery tell a rejected generation apart
+ *   from a concurrent winner.
+ * - It never writes the winner back to the other stores. Flattening them to one
+ *   generation would make recovery clear every copy, discarding a generation
+ *   that should have survived. Divergence resolves on its own: the next
+ *   successful refresh saves to every store.
+ */
+async function reconcilePersistedTokens(
+  definition: ServerDefinition,
+  persistence: OAuthPersistence,
+  logger?: Logger
+): Promise<OAuthTokens | undefined> {
+  const perStore = await persistence.readTokensPerStore?.();
+  if (!perStore || perStore.length <= 1) {
+    return await persistence.readTokens();
+  }
+  const candidates = perStore.filter(
+    (candidate) => typeof candidate.access_token === 'string' && candidate.access_token.trim().length > 0
+  );
+  const distinctRefreshTokens = new Set(
+    candidates.map((candidate) => (typeof candidate.refresh_token === 'string' ? candidate.refresh_token : ''))
+  );
+  if (candidates.length <= 1 || distinctRefreshTokens.size <= 1) {
+    return await persistence.readTokens();
+  }
+
+  let selected = candidates[0];
+  for (const candidate of candidates.slice(1)) {
+    if (selected === undefined || outranksForRedemption(candidate, selected)) {
+      selected = candidate;
+    }
+  }
+  logger?.debug?.(
+    `Persisted OAuth stores for '${definition.name}' hold different refresh tokens; redeeming the newest.`
+  );
+  return selected;
+}
+
+// A generation that still works cannot be one another process already spent.
+// Failing that, the later expiry is the best evidence of which was issued last,
+// since generation markers are opaque and carry no ordering.
+function outranksForRedemption(candidate: OAuthTokens, incumbent: OAuthTokens): boolean {
+  const candidateDue = shouldRefreshCachedToken(candidate);
+  if (candidateDue !== shouldRefreshCachedToken(incumbent)) {
+    return !candidateDue;
+  }
+  const candidateExpiry = tokenExpirySeconds(candidate) ?? Number.NEGATIVE_INFINITY;
+  const incumbentExpiry = tokenExpirySeconds(incumbent) ?? Number.NEGATIVE_INFINITY;
+  return candidateExpiry > incumbentExpiry;
+}
+
+/**
  * Never redeem outside the lock: a waiter that gave up would be exactly the
  * concurrent redemption the lock exists to prevent. Returning a possibly
  * expired token degrades to a 401, which the debug line makes traceable.
@@ -259,7 +324,8 @@ async function refreshCachedOAuthTokenUnderLock(
   original: OAuthTokens,
   logger?: Logger
 ): Promise<string | undefined> {
-  const decision = decideUnderRefreshLock(original, await persistence.readTokens(), TOKEN_EXPIRY_SKEW_SECONDS);
+  const latest = await reconcilePersistedTokens(definition, persistence, logger);
+  const decision = decideUnderRefreshLock(original, latest, TOKEN_EXPIRY_SKEW_SECONDS);
   if (decision.kind === 'gone') {
     logger?.debug?.(`Cached OAuth token for '${definition.name}' was cleared before its refresh could run.`);
     return undefined;
@@ -424,7 +490,8 @@ async function refreshBearerTokenUnderLock(
   skewSeconds: number,
   logger?: Logger
 ): Promise<string> {
-  const decision = decideUnderRefreshLock(original, await persistence.readTokens(), skewSeconds);
+  const latest = await reconcilePersistedTokens(definition, persistence, logger);
+  const decision = decideUnderRefreshLock(original, latest, skewSeconds);
   if (decision.kind === 'gone') {
     throw new Error(`Cached bearer token for '${definition.name}' was cleared before its refresh could run.`);
   }

--- a/src/oauth-vault.ts
+++ b/src/oauth-vault.ts
@@ -159,6 +159,26 @@ function stringRecord(value: unknown): Record<string, string> {
   );
 }
 
+/**
+ * Every vault key whose credentials this definition can end up using: its own,
+ * plus any same-URL legacy `<name>-oauth` entry it inherits from.
+ *
+ * Refresh locking needs the whole set. A renamed definition and its legacy entry
+ * resolve to one shared refresh token (see resolveVaultEntry), so locking only
+ * the exact key would let them redeem that token concurrently and lose the
+ * family. Deliberately the broader rename-candidate set rather than the entry
+ * that inheritance would pick right now: over-locking costs a little
+ * serialization, under-locking costs the credential.
+ */
+export async function vaultCredentialKeys(definition: ServerDefinition): Promise<VaultKey[]> {
+  const key = vaultKeyForDefinition(definition);
+  if (definition.command.kind !== 'http') {
+    return [key];
+  }
+  const vault = await readVault();
+  return [...new Set([key, ...legacyOAuthRenameKeys(vault, definition, key)])];
+}
+
 export async function loadVaultEntry(definition: ServerDefinition): Promise<VaultEntry | undefined> {
   const vault = await readVault();
   return externalVaultEntry(resolveVaultEntry(vault, definition));

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -314,6 +314,19 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
       this.logger.info(`Discarded OAuth client registration for ${this.definition.name} after issuer changed.`);
       return undefined;
     }
+    if (!stored) {
+      const tokens = await this.persistence.readTokens();
+      if (tokens && typeof tokens.refresh_token === 'string' && oauthAccessTokenNeedsRefresh(tokens)) {
+        // The SDK asks for client information before tokens. Clear an expired
+        // orphan here so the DCR that follows cannot redeem its old refresh
+        // token outside the transaction lock; provider.tokens() then returns
+        // undefined and the SDK continues to interactive authorization.
+        await this.persistence.clear('tokens');
+        this.logger.info(
+          `Discarded expired OAuth tokens for ${this.definition.name} because no client registration is available.`
+        );
+      }
+    }
     return stored;
   }
 

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -327,6 +327,16 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
    *
    * The locked transaction is re-entrant per call chain, so an SDK auth() flow
    * that already holds the lock does not deadlock on this read.
+   *
+   * Known and accepted limit (issue #305): this covers the proactive connect
+   * path, not the SDK's internal 401-driven auth(). That branch runs inside the
+   * SDK's own fetch handling with no seam to wrap, it redeems whenever this
+   * method returns any refresh token — it never checks expiry — and it
+   * re-persists this method's return value when `issuer` is unset, so
+   * withholding the refresh token here would destroy it instead of protecting
+   * it. Two processes taking a 401 at the same instant can therefore still
+   * redeem concurrently; the rejected-refresh recovery in oauth-token-refresh.ts
+   * remains the backstop for that case.
    */
   private async refreshedTokens(stored: StoredOAuthTokens | undefined): Promise<StoredOAuthTokens | undefined> {
     if (!stored || this.definition.auth === 'refreshable_bearer') {

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -16,6 +16,7 @@ import { suppressBrowserLaunchFromEnv } from './oauth-browser-suppression.js';
 import { buildStaticClientInformation } from './oauth-client-info.js';
 import type { OAuthPersistence, OAuthPersistenceSnapshot } from './oauth-persistence.js';
 import { buildOAuthPersistence } from './oauth-persistence.js';
+import { readCachedAccessTokenWithPersistence } from './oauth-token-refresh.js';
 
 const CALLBACK_HOST = '127.0.0.1';
 const CALLBACK_PATH = '/callback';
@@ -310,7 +311,39 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
       this.logger.info(`Discarded OAuth tokens for ${this.definition.name} after issuer changed.`);
       return undefined;
     }
-    return stored;
+    return await this.refreshedTokens(stored);
+  }
+
+  /**
+   * Refreshes an expiring token under the cross-process refresh lock before the
+   * SDK sees it.
+   *
+   * This is the interception point for SDK-driven refresh. The SDK redeems a
+   * rotating refresh token itself whenever tokens() hands it an expired one —
+   * proactively before connect and internally on a 401 — and neither call site
+   * is wrappable from here. Returning an already-refreshed token starves that
+   * branch, so the redemption happens once, under the lock, instead of racing
+   * every other process that shares the credential.
+   *
+   * The locked transaction is re-entrant per call chain, so an SDK auth() flow
+   * that already holds the lock does not deadlock on this read.
+   */
+  private async refreshedTokens(stored: StoredOAuthTokens | undefined): Promise<StoredOAuthTokens | undefined> {
+    if (!stored || this.definition.auth === 'refreshable_bearer') {
+      return stored;
+    }
+    try {
+      await readCachedAccessTokenWithPersistence(this.definition, this.persistence);
+    } catch (error) {
+      // A refresh that discarded credentials (issuer change, rejected grant)
+      // must surface as "no tokens" so the SDK reauthorizes interactively.
+      this.logger.warn(
+        `Could not refresh OAuth tokens for ${this.definition.name}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+    return await this.persistence.readTokens();
   }
 
   async saveTokens(tokens: StoredOAuthTokens): Promise<void> {

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -16,7 +16,7 @@ import { suppressBrowserLaunchFromEnv } from './oauth-browser-suppression.js';
 import { buildStaticClientInformation } from './oauth-client-info.js';
 import type { OAuthPersistence, OAuthPersistenceSnapshot } from './oauth-persistence.js';
 import { buildOAuthPersistence } from './oauth-persistence.js';
-import { readCachedAccessTokenWithPersistence } from './oauth-token-refresh.js';
+import { oauthAccessTokenNeedsRefresh, readCachedAccessTokenWithPersistence } from './oauth-token-refresh.js';
 
 const CALLBACK_HOST = '127.0.0.1';
 const CALLBACK_PATH = '/callback';
@@ -37,6 +37,23 @@ export interface OAuthAuthorizationResponse {
 export interface OAuthSessionOptions {
   suppressBrowserLaunch?: boolean;
   onAuthorizationUrl?: (request: OAuthAuthorizationRequest) => void | Promise<void>;
+}
+
+// Thrown when a refresh was due but could not complete, so the only tokens left
+// to hand the MCP SDK are expired ones that still carry a refresh token. The SDK
+// would redeem those outside the refresh lock — the replay that revokes a
+// rotating token family — so the connect fails and is retried instead.
+export class OAuthRefreshUnavailableError extends Error {
+  readonly serverName: string;
+  constructor(serverName: string, options?: ErrorOptions) {
+    super(
+      `Could not refresh OAuth credentials for '${serverName}'. Another process may be refreshing them, ` +
+        `or the token endpoint is unreachable. Retry shortly; run 'mcporter auth ${serverName}' if it persists.`,
+      options
+    );
+    this.name = 'OAuthRefreshUnavailableError';
+    this.serverName = serverName;
+  }
 }
 
 // Thrown when interactive authorization is needed but browser launch is suppressed
@@ -328,14 +345,18 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
    * The locked transaction is re-entrant per call chain, so an SDK auth() flow
    * that already holds the lock does not deadlock on this read.
    *
-   * Known and accepted limit (issue #305): this covers the proactive connect
-   * path, not the SDK's internal 401-driven auth(). That branch runs inside the
-   * SDK's own fetch handling with no seam to wrap, it redeems whenever this
-   * method returns any refresh token — it never checks expiry — and it
-   * re-persists this method's return value when `issuer` is unset, so
-   * withholding the refresh token here would destroy it instead of protecting
-   * it. Two processes taking a 401 at the same instant can therefore still
-   * redeem concurrently; the rejected-refresh recovery in oauth-token-refresh.ts
+   * Returning an expired token that still carries a refresh token is never
+   * safe here: the SDK redeems whenever this method yields a refresh token — it
+   * never checks expiry — so the redemption would land outside the lock. That
+   * cannot be avoided by withholding the refresh token either, because the SDK
+   * re-persists this method's return value when `issuer` is unset and would
+   * destroy the token instead. So when a due refresh does not produce a usable
+   * token, this fails the connect rather than offering a redeemable stale one.
+   *
+   * Known and accepted limit (issue #305): a 401 makes the SDK redeem the token
+   * this method returns even when it is fresh, and that call site has no seam to
+   * wrap. Two processes taking a 401 at the same instant can still redeem
+   * concurrently; the rejected-refresh recovery in oauth-token-refresh.ts
    * remains the backstop for that case.
    */
   private async refreshedTokens(stored: StoredOAuthTokens | undefined): Promise<StoredOAuthTokens | undefined> {
@@ -353,7 +374,14 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
         }`
       );
     }
-    return await this.persistence.readTokens();
+    const latest = await this.persistence.readTokens();
+    if (latest && typeof latest.refresh_token === 'string' && oauthAccessTokenNeedsRefresh(latest)) {
+      // The refresh was due and did not land: the lock is held by a live
+      // refresher, or the token endpoint failed. Either way this token must not
+      // reach the SDK's refresh branch.
+      throw new OAuthRefreshUnavailableError(this.definition.name);
+    }
+    return latest;
   }
 
   async saveTokens(tokens: StoredOAuthTokens): Promise<void> {

--- a/tests/fixtures/oauth-refresh-process.mjs
+++ b/tests/fixtures/oauth-refresh-process.mjs
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { buildOAuthPersistence, readCachedAccessToken } from '../../dist/oauth-persistence.js';
+import { withRefreshLock } from '../../dist/oauth-refresh-lock.js';
 import { createOAuthSession } from '../../dist/oauth.js';
 import { connectWithAuth } from '../../dist/runtime/oauth.js';
 
@@ -131,6 +132,11 @@ if (action === 'seed') {
     }),
   });
   emit({ redeemed: response.ok, persistSkipped: true });
+} else if (action === 'hold-refresh-lock') {
+  await withRefreshLock(definition, async () => {
+    emit({ holding: true });
+    await new Promise(() => {});
+  });
 } else {
   throw new Error(`Unknown action '${action}'.`);
 }

--- a/tests/fixtures/oauth-refresh-process.mjs
+++ b/tests/fixtures/oauth-refresh-process.mjs
@@ -90,14 +90,29 @@ if (action === 'seed') {
       authorizationPrompts += 1;
     },
   });
-  await connectWithAuth({ connect: async () => {} }, { close: async () => {} }, session, logger, {
-    serverName: definition.name,
-    serverUrl: endpoint,
-    fetchFn: fetch,
-  });
+  let refreshUnavailable = false;
+  try {
+    await connectWithAuth({ connect: async () => {} }, { close: async () => {} }, session, logger, {
+      serverName: definition.name,
+      serverUrl: endpoint,
+      fetchFn: fetch,
+    });
+  } catch (error) {
+    // The provider refuses to hand the SDK a redeemable stale token when a due
+    // refresh could not land, so the connect fails instead of replaying it.
+    if (!/Could not refresh OAuth credentials/.test(String(error?.message ?? error))) {
+      throw error;
+    }
+    refreshUnavailable = true;
+  } finally {
+    // connectWithAuth only closes the session on its success path, and the
+    // callback server would otherwise keep this fixture process alive.
+    await session.close().catch(() => {});
+  }
   const stored = await snapshot();
   emit({
     authorizationPrompts,
+    refreshUnavailable,
     persistedAccessMarker: marker(stored.tokens?.access_token),
     persistedRefreshMarker: marker(stored.tokens?.refresh_token),
   });

--- a/tests/fixtures/oauth-refresh-process.mjs
+++ b/tests/fixtures/oauth-refresh-process.mjs
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { buildOAuthPersistence, readCachedAccessToken } from '../../dist/oauth-persistence.js';
 import { createOAuthSession } from '../../dist/oauth.js';
 import { connectWithAuth } from '../../dist/runtime/oauth.js';
@@ -9,13 +10,32 @@ if (!action || !endpoint || !tokenCacheDir) {
   throw new Error('Expected action, MCPORTER_TEST_OAUTH_ENDPOINT, and MCPORTER_TEST_OAUTH_CACHE_DIR.');
 }
 
+const serverName = process.env.MCPORTER_TEST_OAUTH_SERVER_NAME ?? 'oauth-refresh-process';
+const seedRefreshToken = process.env.MCPORTER_TEST_OAUTH_SEED_REFRESH ?? 'fresh-process-refresh-token';
+
 const definition = {
-  name: 'oauth-refresh-process',
+  name: serverName,
   command: { kind: 'http', url: new URL(endpoint) },
   auth: 'oauth',
   tokenCacheDir,
 };
 const logger = { info() {}, warn() {}, error() {}, debug() {} };
+
+// Credential values must never reach stdout, CI logs, or failure artifacts, so
+// callers compare opaque markers instead of tokens.
+function marker(value) {
+  return typeof value === 'string' && value.length > 0
+    ? createHash('sha256').update(value).digest('hex').slice(0, 12)
+    : null;
+}
+
+function emit(payload) {
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+async function snapshot() {
+  return await (await buildOAuthPersistence(definition, logger)).readSnapshot();
+}
 
 if (action === 'seed') {
   const persistence = await buildOAuthPersistence(definition, logger);
@@ -27,10 +47,10 @@ if (action === 'seed') {
   await persistence.saveTokens({
     access_token: 'expired-process-token',
     token_type: 'Bearer',
-    refresh_token: 'fresh-process-refresh-token',
+    refresh_token: seedRefreshToken,
     expires_at: 1,
   });
-  process.stdout.write('seeded\n');
+  emit({ seeded: true, refreshMarker: marker(seedRefreshToken) });
 } else if (action === 'refresh') {
   const accessToken = await readCachedAccessToken(definition, logger);
   let authorizationPrompts = 0;
@@ -45,15 +65,57 @@ if (action === 'seed') {
     serverUrl: endpoint,
     fetchFn: fetch,
   });
-  const snapshot = await (await buildOAuthPersistence(definition, logger)).readSnapshot();
-  process.stdout.write(
-    `${JSON.stringify({
-      accessToken,
-      authorizationPrompts,
-      clientId: snapshot.clientInfo?.client_id,
-      refreshToken: snapshot.tokens?.refresh_token,
-    })}\n`
-  );
+  const stored = await snapshot();
+  emit({
+    accessToken,
+    authorizationPrompts,
+    clientId: stored.clientInfo?.client_id,
+    refreshToken: stored.tokens?.refresh_token,
+  });
+} else if (action === 'refresh-cached') {
+  // The cached-read path: the header-injection route every connect takes.
+  const accessToken = await readCachedAccessToken(definition, logger);
+  const stored = await snapshot();
+  emit({
+    accessMarker: marker(accessToken),
+    persistedAccessMarker: marker(stored.tokens?.access_token),
+    persistedRefreshMarker: marker(stored.tokens?.refresh_token),
+  });
+} else if (action === 'refresh-connect') {
+  // The provider path: proactive authorization before an oauth connect.
+  let authorizationPrompts = 0;
+  const session = await createOAuthSession(definition, logger, {
+    suppressBrowserLaunch: true,
+    onAuthorizationUrl: () => {
+      authorizationPrompts += 1;
+    },
+  });
+  await connectWithAuth({ connect: async () => {} }, { close: async () => {} }, session, logger, {
+    serverName: definition.name,
+    serverUrl: endpoint,
+    fetchFn: fetch,
+  });
+  const stored = await snapshot();
+  emit({
+    authorizationPrompts,
+    persistedAccessMarker: marker(stored.tokens?.access_token),
+    persistedRefreshMarker: marker(stored.tokens?.refresh_token),
+  });
+} else if (action === 'redeem-without-persisting') {
+  // Simulates a process killed between the token response and the persist: the
+  // provider has rotated the refresh token, local state still holds the spent
+  // one. The next caller replays it, which is what the recovery must absorb.
+  const stored = await snapshot();
+  const response = await fetch(new URL('/token', endpoint), {
+    method: 'POST',
+    headers: { accept: 'application/json', 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: stored.tokens?.refresh_token ?? '',
+      client_id: stored.clientInfo?.client_id ?? '',
+    }),
+  });
+  emit({ redeemed: response.ok, persistSkipped: true });
 } else {
   throw new Error(`Unknown action '${action}'.`);
 }

--- a/tests/fs-json.test.ts
+++ b/tests/fs-json.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { readJsonFile, withFileLock, writeJsonFile } from '../src/fs-json.js';
+import { isFileLockTimeoutError, readJsonFile, withFileLock, writeJsonFile } from '../src/fs-json.js';
 
 describe('fs-json helpers', () => {
   let tempDir: string;
@@ -254,9 +254,9 @@ describe('fs-json helpers', () => {
     });
     await entered;
 
-    await expect(withFileLock(lockTarget, async () => {}, { timeoutMs: 50 })).rejects.toThrow(
-      /Timed out waiting for file lock/
-    );
+    const timedOut = withFileLock(lockTarget, async () => {}, { timeoutMs: 50 });
+    await expect(timedOut).rejects.toThrow(/Timed out waiting for file lock/);
+    await expect(timedOut).rejects.toSatisfy(isFileLockTimeoutError);
 
     let followerEntered = false;
     const follower = withFileLock(lockTarget, async () => {

--- a/tests/oauth-persistence.test.ts
+++ b/tests/oauth-persistence.test.ts
@@ -2285,6 +2285,97 @@ describe('oauth persistence', () => {
       await holder;
     });
 
+    it('prefers a newer vault generation over a stale token cache before redeeming', async () => {
+      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-divergent-'));
+      tempRoots.push(tmp);
+      homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmp);
+      hasSpy = true;
+
+      const cacheDir = path.join(tmp, 'cache');
+      await fs.mkdir(cacheDir, { recursive: true });
+      const definition = mkDef('divergent-stores', cacheDir);
+
+      // A save that only partly landed: the cache kept the spent generation
+      // while the vault took the rotated one. The cache is read first.
+      await fs.writeFile(
+        path.join(cacheDir, 'tokens.json'),
+        JSON.stringify({
+          access_token: 'spent-access',
+          token_type: 'Bearer',
+          refresh_token: 'spent-refresh',
+          expires_at: Math.floor(Date.now() / 1000) - 120,
+        })
+      );
+      await saveVaultEntry(definition, {
+        tokens: {
+          access_token: 'rotated-access',
+          token_type: 'Bearer',
+          refresh_token: 'rotated-refresh',
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+        } as OAuthTokens,
+      });
+
+      // Redeeming the cache's spent refresh token here would replay it and
+      // revoke the family, so the newer vault generation has to win.
+      await expect(readCachedAccessToken(definition)).resolves.toBe('rotated-access');
+      expect(authMocks.refreshAuthorization).not.toHaveBeenCalled();
+
+      // The stale store is deliberately left alone. Flattening every store to
+      // the winner would make rejected-credential recovery clear all copies,
+      // discarding a generation that should survive; the next successful refresh
+      // converges them instead.
+      const cached = (await readJsonFile(path.join(cacheDir, 'tokens.json'))) as { access_token?: string } | undefined;
+      expect(cached?.access_token).toBe('spent-access');
+    });
+
+    it('redeems the newer generation when both stores are expired but divergent', async () => {
+      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-divergent-expired-'));
+      tempRoots.push(tmp);
+      homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmp);
+      hasSpy = true;
+
+      const cacheDir = path.join(tmp, 'cache');
+      await fs.mkdir(cacheDir, { recursive: true });
+      const definition = mkDef('divergent-expired', cacheDir);
+
+      await fs.writeFile(
+        path.join(cacheDir, 'tokens.json'),
+        JSON.stringify({
+          access_token: 'spent-access',
+          token_type: 'Bearer',
+          refresh_token: 'spent-refresh',
+          expires_at: Math.floor(Date.now() / 1000) - 600,
+        })
+      );
+      await saveVaultEntry(definition, {
+        clientInfo: { client_id: 'divergent-client', redirect_uris: ['http://127.0.0.1/callback'] },
+        tokens: {
+          access_token: 'newer-access',
+          token_type: 'Bearer',
+          refresh_token: 'newer-refresh',
+          expires_at: Math.floor(Date.now() / 1000) - 30,
+        } as OAuthTokens,
+      });
+
+      authMocks.discoverOAuthServerInfo.mockResolvedValue({
+        authorizationServerUrl: 'https://auth.example.com',
+        authorizationServerMetadata: { issuer: 'https://auth.example.com' },
+        resourceMetadata: undefined,
+      });
+      authMocks.refreshAuthorization.mockResolvedValue({
+        access_token: 'refreshed-access',
+        token_type: 'Bearer',
+        refresh_token: 'refreshed-refresh',
+        expires_in: 3600,
+      });
+
+      await expect(readCachedAccessToken(definition)).resolves.toBe('refreshed-access');
+
+      // The spent cache token must never be the one presented to the provider.
+      expect(authMocks.refreshAuthorization).toHaveBeenCalledTimes(1);
+      expect(authMocks.refreshAuthorization.mock.calls[0]?.[1]).toMatchObject({ refreshToken: 'newer-refresh' });
+    });
+
     it('honors a custom refresh skew when adopting a concurrently persisted token', async () => {
       const { cacheDir } = await seedExpiredCache('bearer-skew');
       const fetchMock = vi.fn(async (_input: string | URL, _init?: RequestInit) =>

--- a/tests/oauth-persistence.test.ts
+++ b/tests/oauth-persistence.test.ts
@@ -7,6 +7,7 @@ import type { OAuthTokens } from '@modelcontextprotocol/client';
 import type { ServerDefinition } from '../src/config.js';
 import { readJsonFile } from '../src/fs-json.js';
 import { buildOAuthPersistence, clearOAuthCaches, readCachedAccessToken } from '../src/oauth-persistence.js';
+import { withRefreshLock } from '../src/oauth-refresh-lock.js';
 import { clearVaultEntry, loadVaultEntry, saveVaultEntry, vaultKeyForDefinition } from '../src/oauth-vault.js';
 
 const authMocks = vi.hoisted(() => ({
@@ -32,6 +33,14 @@ const withUrl = (definition: ServerDefinition, url: string): ServerDefinition =>
   ...definition,
   command: { kind: 'http', url: new URL(url) },
 });
+
+function held(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
 
 describe('oauth persistence', () => {
   const originalEnv = { ...process.env };
@@ -2108,5 +2117,208 @@ describe('oauth persistence', () => {
     const definition = mkDef('current-service', cacheDir);
     await expect(readCachedAccessToken(definition)).resolves.toBe('current-token');
     expect(authMocks.refreshAuthorization).not.toHaveBeenCalled();
+  });
+
+  describe('refresh transaction serialization', () => {
+    const expiredAt = Math.floor(Date.now() / 1000) - 60;
+
+    async function seedExpiredCache(prefix: string): Promise<{ cacheDir: string; tmp: string }> {
+      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), `mcporter-${prefix}-`));
+      tempRoots.push(tmp);
+      homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmp);
+      hasSpy = true;
+      const cacheDir = path.join(tmp, 'cache');
+      await fs.mkdir(cacheDir, { recursive: true });
+      await fs.writeFile(
+        path.join(cacheDir, 'tokens.json'),
+        JSON.stringify({
+          access_token: 'stale-token',
+          token_type: 'Bearer',
+          refresh_token: 'stale-refresh',
+          expires_at: expiredAt,
+        })
+      );
+      return { cacheDir, tmp };
+    }
+
+    it('returns the persisted token without redeeming when the refresh lock stays held', async () => {
+      const { cacheDir } = await seedExpiredCache('oauth-lock-timeout');
+      const definition = mkDef('lock-timeout', cacheDir);
+      process.env.MCPORTER_TEST_REFRESH_LOCK_TIMEOUT_MS = '50';
+
+      const holding = held();
+      const release = held();
+      const holder = withRefreshLock(definition, async () => {
+        holding.resolve();
+        await release.promise;
+      });
+      await holding.promise;
+
+      // Redeeming here would be the concurrent redemption the lock prevents.
+      await expect(readCachedAccessToken(definition)).resolves.toBe('stale-token');
+      expect(authMocks.refreshAuthorization).not.toHaveBeenCalled();
+
+      release.resolve();
+      await holder;
+    });
+
+    it('adopts a token another refresh persisted while this caller waited', async () => {
+      const { cacheDir } = await seedExpiredCache('oauth-adopt-winner');
+      const definition = mkDef('adopt-winner', cacheDir);
+
+      const holding = held();
+      const release = held();
+      const holder = withRefreshLock(definition, async () => {
+        holding.resolve();
+        await release.promise;
+      });
+      await holding.promise;
+
+      const caller = readCachedAccessToken(definition);
+      // Let the caller finish its pre-lock read and start waiting on the lock.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const winner = await buildOAuthPersistence(definition);
+      await winner.saveTokens({
+        access_token: 'winner-token',
+        token_type: 'Bearer',
+        refresh_token: 'winner-refresh',
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      } as OAuthTokens);
+
+      release.resolve();
+      await holder;
+
+      await expect(caller).resolves.toBe('winner-token');
+      expect(authMocks.refreshAuthorization).not.toHaveBeenCalled();
+    });
+
+    it('bounds the bearer token request so a stalled endpoint cannot hold the lock', async () => {
+      const { cacheDir } = await seedExpiredCache('bearer-bound');
+      const fetchMock = vi.fn(async () =>
+        Response.json({ access_token: 'fresh-bearer', token_type: 'Bearer', expires_in: 3600 })
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const definition: ServerDefinition = {
+        name: 'bearer-bound',
+        command: { kind: 'stdio', command: 'node', args: ['server.js'], cwd: process.cwd() },
+        auth: 'refreshable_bearer',
+        tokenCacheDir: cacheDir,
+        refresh: {
+          tokenEndpoint: 'https://auth.example.com/token',
+          clientAuthMethod: 'none',
+          accessTokenEnv: 'EXAMPLE_ACCESS_TOKEN',
+        },
+      };
+
+      await expect(readCachedAccessToken(definition)).resolves.toBe('fresh-bearer');
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://auth.example.com/token',
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+    });
+
+    it('treats an aborted bearer token request as recoverable, not a rejected grant', async () => {
+      const { cacheDir } = await seedExpiredCache('bearer-abort');
+      const abortError = new Error('The operation was aborted due to timeout');
+      abortError.name = 'TimeoutError';
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => {
+          throw abortError;
+        })
+      );
+
+      const definition: ServerDefinition = {
+        name: 'bearer-abort',
+        command: { kind: 'stdio', command: 'node', args: ['server.js'], cwd: process.cwd() },
+        auth: 'refreshable_bearer',
+        tokenCacheDir: cacheDir,
+        refresh: {
+          tokenEndpoint: 'https://auth.example.com/token',
+          clientAuthMethod: 'none',
+          accessTokenEnv: 'EXAMPLE_ACCESS_TOKEN',
+        },
+      };
+
+      await expect(readCachedAccessToken(definition)).rejects.toThrow(/Failed to refresh cached bearer token/);
+      // A timeout must not be mistaken for invalid_grant, which would clear the family.
+      const persisted = (await readJsonFile(path.join(cacheDir, 'tokens.json'))) as
+        | { refresh_token?: string }
+        | undefined;
+      expect(persisted?.refresh_token).toBe('stale-refresh');
+    });
+
+    it('returns the persisted bearer token instead of throwing when the refresh lock stays held', async () => {
+      const { cacheDir } = await seedExpiredCache('bearer-lock-timeout');
+      process.env.MCPORTER_TEST_REFRESH_LOCK_TIMEOUT_MS = '50';
+      const fetchMock = vi.fn(async () =>
+        Response.json({ access_token: 'should-not-run', token_type: 'Bearer', expires_in: 3600 })
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const definition: ServerDefinition = {
+        name: 'bearer-lock-timeout',
+        command: { kind: 'stdio', command: 'node', args: ['server.js'], cwd: process.cwd() },
+        auth: 'refreshable_bearer',
+        tokenCacheDir: cacheDir,
+        refresh: {
+          tokenEndpoint: 'https://auth.example.com/token',
+          clientAuthMethod: 'none',
+          accessTokenEnv: 'EXAMPLE_ACCESS_TOKEN',
+        },
+      };
+
+      const holding = held();
+      const release = held();
+      const holder = withRefreshLock(definition, async () => {
+        holding.resolve();
+        await release.promise;
+      });
+      await holding.promise;
+
+      await expect(readCachedAccessToken(definition)).resolves.toBe('stale-token');
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      release.resolve();
+      await holder;
+    });
+
+    it('honors a custom refresh skew when adopting a concurrently persisted token', async () => {
+      const { cacheDir } = await seedExpiredCache('bearer-skew');
+      const fetchMock = vi.fn(async (_input: string | URL, _init?: RequestInit) =>
+        Response.json({ access_token: 'redeemed-token', token_type: 'Bearer', expires_in: 3600 })
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const definition: ServerDefinition = {
+        name: 'bearer-skew',
+        command: { kind: 'stdio', command: 'node', args: ['server.js'], cwd: process.cwd() },
+        auth: 'refreshable_bearer',
+        tokenCacheDir: cacheDir,
+        refresh: {
+          tokenEndpoint: 'https://auth.example.com/token',
+          clientAuthMethod: 'none',
+          accessTokenEnv: 'EXAMPLE_ACCESS_TOKEN',
+          // A token expiring in 10 minutes is fresh at the 60s default but stale here.
+          refreshSkewSeconds: 1_800,
+        },
+      };
+
+      const persistence = await buildOAuthPersistence(definition);
+      await persistence.saveTokens({
+        access_token: 'not-fresh-enough',
+        token_type: 'Bearer',
+        refresh_token: 'winner-refresh',
+        expires_at: Math.floor(Date.now() / 1000) + 600,
+      } as OAuthTokens);
+
+      // The configured skew still considers the persisted token stale, so the
+      // transaction redeems its refresh token rather than adopting it.
+      await expect(readCachedAccessToken(definition)).resolves.toBe('redeemed-token');
+      const request = fetchMock.mock.calls[0]?.[1] as { body?: URLSearchParams } | undefined;
+      expect(request?.body?.toString()).toContain('refresh_token=winner-refresh');
+    });
   });
 });

--- a/tests/oauth-refresh-lock.test.ts
+++ b/tests/oauth-refresh-lock.test.ts
@@ -6,6 +6,7 @@ import type { ServerDefinition } from '../src/config.js';
 import { isFileLockTimeoutError } from '../src/fs-json.js';
 import { buildOAuthPersistence } from '../src/oauth-persistence.js';
 import { refreshLockDir, refreshLockPaths, withRefreshLock } from '../src/oauth-refresh-lock.js';
+import { saveVaultEntry } from '../src/oauth-vault.js';
 
 function httpDefinition(name: string, extra: Partial<ServerDefinition> = {}): ServerDefinition {
   return {
@@ -141,6 +142,61 @@ describe('oauth refresh lock', () => {
     releaseCached.resolve();
     await Promise.all([cachedRun, uncachedRun]);
     expect(order).toEqual(['cached:enter', 'cached:exit', 'uncached:enter']);
+  });
+
+  it('shares a lock between a renamed server and the legacy entry it inherits', async () => {
+    const url = new URL('https://mcp.example.com/inherited');
+    const renamed = { name: 'inherited', command: { kind: 'http', url } } as ServerDefinition;
+    const legacy = { name: 'inherited-oauth', command: { kind: 'http', url } } as ServerDefinition;
+
+    // The legacy entry holds the credentials the renamed definition inherits.
+    await saveVaultEntry(legacy, {
+      tokens: { access_token: 'inherited-access', token_type: 'Bearer', refresh_token: 'inherited-refresh' },
+    });
+
+    const renamedLocks = await refreshLockPaths(renamed);
+    const legacyLocks = await refreshLockPaths(legacy);
+
+    // The sets need not match; they must overlap on the shared credential's key.
+    expect(legacyLocks).toHaveLength(1);
+    expect(renamedLocks).toContain(legacyLocks[0]);
+    expect(renamedLocks.length).toBeGreaterThan(1);
+
+    const order: string[] = [];
+    const holding = deferred();
+    const release = deferred();
+    const holder = withRefreshLock(renamed, async () => {
+      order.push('renamed:enter');
+      holding.resolve();
+      await release.promise;
+      order.push('renamed:exit');
+    });
+    await holding.promise;
+
+    const waiter = withRefreshLock(legacy, async () => {
+      order.push('legacy:enter');
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    // Redeeming here would replay the refresh token the other config is rotating.
+    expect(order).toEqual(['renamed:enter']);
+
+    release.resolve();
+    await Promise.all([holder, waiter]);
+    expect(order).toEqual(['renamed:enter', 'renamed:exit', 'legacy:enter']);
+  });
+
+  it('sorts lock targets so overlapping sets cannot invert', async () => {
+    const url = new URL('https://mcp.example.com/ordering');
+    const cacheDir = path.join(tempDir, 'ordering-cache');
+    await fs.mkdir(cacheDir, { recursive: true });
+    const renamed = { name: 'ordering', command: { kind: 'http', url }, tokenCacheDir: cacheDir } as ServerDefinition;
+    await saveVaultEntry({ name: 'ordering-oauth', command: { kind: 'http', url } } as ServerDefinition, {
+      tokens: { access_token: 'a', token_type: 'Bearer' },
+    });
+
+    const locks = await refreshLockPaths(renamed);
+    expect(locks).toHaveLength(3);
+    expect(locks).toEqual(locks.toSorted());
   });
 
   it('resolves relative and absolute spellings of one token path to one identity', async () => {

--- a/tests/oauth-refresh-lock.test.ts
+++ b/tests/oauth-refresh-lock.test.ts
@@ -1,0 +1,254 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ServerDefinition } from '../src/config.js';
+import { isFileLockTimeoutError } from '../src/fs-json.js';
+import { buildOAuthPersistence } from '../src/oauth-persistence.js';
+import { refreshLockDir, refreshLockPaths, withRefreshLock } from '../src/oauth-refresh-lock.js';
+
+function httpDefinition(name: string, extra: Partial<ServerDefinition> = {}): ServerDefinition {
+  return {
+    name,
+    command: { kind: 'http', url: new URL(`https://mcp.example.com/${name}`) },
+    ...extra,
+  } as ServerDefinition;
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('oauth refresh lock', () => {
+  let tempDir: string;
+  let previousDataHome: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-refresh-lock-'));
+    previousDataHome = process.env.XDG_DATA_HOME;
+    process.env.XDG_DATA_HOME = path.join(tempDir, 'data');
+  });
+
+  afterEach(async () => {
+    if (previousDataHome === undefined) {
+      delete process.env.XDG_DATA_HOME;
+    } else {
+      process.env.XDG_DATA_HOME = previousDataHome;
+    }
+    delete process.env.MCPORTER_TEST_REFRESH_LOCK_TIMEOUT_MS;
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('serializes concurrent transactions for the same definition', async () => {
+    const definition = httpDefinition('serialize');
+    const order: string[] = [];
+    const firstHolding = deferred();
+    const releaseFirst = deferred();
+
+    const first = withRefreshLock(definition, async () => {
+      order.push('first:enter');
+      firstHolding.resolve();
+      await releaseFirst.promise;
+      order.push('first:exit');
+    });
+
+    await firstHolding.promise;
+    const second = withRefreshLock(definition, async () => {
+      order.push('second:enter');
+    });
+
+    // The waiter must not enter while the holder is inside its transaction.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(order).toEqual(['first:enter']);
+
+    releaseFirst.resolve();
+    await Promise.all([first, second]);
+    expect(order).toEqual(['first:enter', 'first:exit', 'second:enter']);
+  });
+
+  it('does not serialize unrelated credential identities', async () => {
+    const first = httpDefinition('identity-a');
+    const second = httpDefinition('identity-b');
+    const firstHolding = deferred();
+    const releaseFirst = deferred();
+    const secondEntered = deferred();
+
+    const firstRun = withRefreshLock(first, async () => {
+      firstHolding.resolve();
+      await releaseFirst.promise;
+    });
+
+    await firstHolding.promise;
+    const secondRun = withRefreshLock(second, async () => {
+      secondEntered.resolve();
+    });
+
+    // Resolves only if the second identity acquired while the first was held.
+    await secondEntered.promise;
+    releaseFirst.resolve();
+    await Promise.all([firstRun, secondRun]);
+  });
+
+  it('maps two definitions sharing a token cache directory to one identity', async () => {
+    const cacheDir = path.join(tempDir, 'shared-cache');
+    await fs.mkdir(cacheDir, { recursive: true });
+    const first = httpDefinition('shared-one', { tokenCacheDir: cacheDir });
+    const second = httpDefinition('shared-two', { tokenCacheDir: cacheDir });
+
+    const [firstDirLock] = await refreshLockPaths(first);
+    const [secondDirLock] = await refreshLockPaths(second);
+    expect(firstDirLock).toBe(secondDirLock);
+  });
+
+  it('still serializes one definition configured with and without a token cache directory', async () => {
+    const cacheDir = path.join(tempDir, 'mixed-cache');
+    await fs.mkdir(cacheDir, { recursive: true });
+    const cached = httpDefinition('mixed', { tokenCacheDir: cacheDir });
+    const uncached = httpDefinition('mixed');
+
+    const cachedLocks = await refreshLockPaths(cached);
+    const uncachedLocks = await refreshLockPaths(uncached);
+
+    // The cached configuration also holds the vault-key lock, which is the
+    // shared token source the uncached configuration reads.
+    expect(cachedLocks).toHaveLength(2);
+    expect(uncachedLocks).toHaveLength(1);
+    expect(cachedLocks).toContain(uncachedLocks[0]);
+
+    const order: string[] = [];
+    const cachedHolding = deferred();
+    const releaseCached = deferred();
+
+    const cachedRun = withRefreshLock(cached, async () => {
+      order.push('cached:enter');
+      cachedHolding.resolve();
+      await releaseCached.promise;
+      order.push('cached:exit');
+    });
+
+    await cachedHolding.promise;
+    const uncachedRun = withRefreshLock(uncached, async () => {
+      order.push('uncached:enter');
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(order).toEqual(['cached:enter']);
+
+    releaseCached.resolve();
+    await Promise.all([cachedRun, uncachedRun]);
+    expect(order).toEqual(['cached:enter', 'cached:exit', 'uncached:enter']);
+  });
+
+  it('resolves relative and absolute spellings of one token path to one identity', async () => {
+    const cacheDir = path.join(tempDir, 'spelling-cache');
+    await fs.mkdir(cacheDir, { recursive: true });
+    const absolute = httpDefinition('spelling', { tokenCacheDir: cacheDir });
+    const indirect = httpDefinition('spelling', { tokenCacheDir: path.join(cacheDir, '..', 'spelling-cache') });
+
+    expect(await refreshLockPaths(indirect)).toEqual(await refreshLockPaths(absolute));
+  });
+
+  it.runIf(process.platform !== 'win32')('resolves a symlinked token path to one identity', async () => {
+    const realDir = path.join(tempDir, 'real-cache');
+    const linkDir = path.join(tempDir, 'linked-cache');
+    await fs.mkdir(realDir, { recursive: true });
+    await fs.symlink(realDir, linkDir);
+
+    const direct = httpDefinition('symlinked', { tokenCacheDir: realDir });
+    const viaLink = httpDefinition('symlinked', { tokenCacheDir: linkDir });
+
+    expect(await refreshLockPaths(viaLink)).toEqual(await refreshLockPaths(direct));
+  });
+
+  it('keeps lock filenames free of separators and credential material', async () => {
+    const definition = httpDefinition('../../weird name:with|chars');
+    const lockPaths = await refreshLockPaths(definition);
+    const lockPath = lockPaths[0] ?? '';
+    const basename = path.basename(lockPath);
+
+    expect(path.dirname(lockPath)).toBe(refreshLockDir());
+    expect(basename).not.toContain('|');
+    expect(basename).not.toContain(':');
+    expect(basename).not.toContain('/');
+    expect(basename).not.toContain('\\');
+    expect(basename).not.toMatch(/^\.\./);
+    expect(basename).not.toContain('mcp.example.com');
+    expect(path.resolve(refreshLockDir(), basename)).toBe(lockPath);
+  });
+
+  it('derives a stable identity across calls', async () => {
+    const definition = httpDefinition('stable');
+    expect(await refreshLockPaths(definition)).toEqual(await refreshLockPaths(definition));
+  });
+
+  it('throws a recognizable timeout error when acquisition exceeds its budget', async () => {
+    const definition = httpDefinition('timeout');
+    const holding = deferred();
+    const release = deferred();
+
+    const holder = withRefreshLock(definition, async () => {
+      holding.resolve();
+      await release.promise;
+    });
+
+    await holding.promise;
+    const waiter = withRefreshLock(definition, async () => 'never', { timeoutMs: 50 });
+    await expect(waiter).rejects.toSatisfy(isFileLockTimeoutError);
+
+    release.resolve();
+    await holder;
+  });
+
+  it('does not classify unrelated failures as lock timeouts', () => {
+    expect(isFileLockTimeoutError(new Error('ENOSPC: no space left on device'))).toBe(false);
+    expect(isFileLockTimeoutError(undefined)).toBe(false);
+  });
+
+  it('honors the test-only timeout override from the environment', async () => {
+    process.env.MCPORTER_TEST_REFRESH_LOCK_TIMEOUT_MS = '40';
+    const definition = httpDefinition('env-timeout');
+    const holding = deferred();
+    const release = deferred();
+
+    const holder = withRefreshLock(definition, async () => {
+      holding.resolve();
+      await release.promise;
+    });
+
+    await holding.promise;
+    const startedAt = Date.now();
+    await expect(withRefreshLock(definition, async () => 'never')).rejects.toSatisfy(isFileLockTimeoutError);
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+
+    release.resolve();
+    await holder;
+  });
+
+  it('treats a nested acquisition of a held identity as a passthrough', async () => {
+    const definition = httpDefinition('reentrant');
+
+    const result = await withRefreshLock(definition, async () => {
+      // Mirrors the SDK reading tokens through the provider while the outer
+      // wrapper holds the lock. Without passthrough this waits for the timeout.
+      return await withRefreshLock(definition, async () => 'inner-ran', { timeoutMs: 250 });
+    });
+
+    expect(result).toBe('inner-ran');
+  });
+
+  it('allows persistence writes inside the transaction without deadlocking', async () => {
+    const definition = httpDefinition('persist-inside-lock');
+    const persistence = await buildOAuthPersistence(definition);
+
+    await withRefreshLock(definition, async () => {
+      await persistence.saveTokens({ access_token: 'inside-lock', token_type: 'Bearer' });
+    });
+
+    const tokens = await persistence.readTokens();
+    expect(tokens?.access_token).toBe('inside-lock');
+  });
+});

--- a/tests/oauth-refresh-process.integration.test.ts
+++ b/tests/oauth-refresh-process.integration.test.ts
@@ -269,6 +269,30 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
     budget(30_000)
   );
 
+  async function holdRefreshLock(
+    name: string,
+    env: NodeJS.ProcessEnv
+  ): Promise<{ release: () => void; settled: Promise<void> }> {
+    const previousDataHome = process.env.XDG_DATA_HOME;
+    process.env.XDG_DATA_HOME = env.XDG_DATA_HOME;
+    const lockPaths = await refreshLockPaths({
+      name,
+      command: { kind: 'http', url: new URL(endpoint) },
+      auth: 'oauth',
+      tokenCacheDir: env.MCPORTER_TEST_OAUTH_CACHE_DIR,
+    });
+    process.env.XDG_DATA_HOME = previousDataHome;
+
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const settled = withFileLock(lockPaths[0] ?? '', async () => {
+      await held;
+    });
+    return { release, settled };
+  }
+
   it(
     'returns the persisted token without redeeming when another process holds the lock',
     async () => {
@@ -276,36 +300,45 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
       registerSeed(seed, 'held');
       const env = await freshEnv('lock-held', seed);
       await runFixture('seed', env);
-
-      const previousDataHome = process.env.XDG_DATA_HOME;
-      process.env.XDG_DATA_HOME = env.XDG_DATA_HOME;
-      const lockPaths = await refreshLockPaths({
-        name: 'lock-held',
-        command: { kind: 'http', url: new URL(endpoint) },
-        auth: 'oauth',
-        tokenCacheDir: env.MCPORTER_TEST_OAUTH_CACHE_DIR,
-      });
-      process.env.XDG_DATA_HOME = previousDataHome;
-
-      let releaseHolder!: () => void;
-      const holderRelease = new Promise<void>((resolve) => {
-        releaseHolder = resolve;
-      });
-      const holder = withFileLock(lockPaths[0] ?? '', async () => {
-        await holderRelease;
-      });
+      const holder = await holdRefreshLock('lock-held', env);
 
       const waiter = JSON.parse(
         await runFixture('refresh-cached', { ...env, MCPORTER_TEST_REFRESH_LOCK_TIMEOUT_MS: '400' })
       ) as { accessMarker: string };
-      releaseHolder();
-      await holder;
+      holder.release();
+      await holder.settled;
 
       // The waiter keeps the seeded (expired) token rather than redeeming it
       // outside the lock, which is what would replay against the provider.
       expect(waiter.accessMarker).toBe(marker('expired-process-token'));
       expect(tokenRequests).toHaveLength(0);
       expect(replays).toHaveLength(0);
+    },
+    budget(30_000)
+  );
+
+  it(
+    'refuses to let the provider path redeem after the lock times out',
+    async () => {
+      const seed = 'held-connect-seed';
+      registerSeed(seed, 'held-connect');
+      const env = await freshEnv('lock-held-connect', seed);
+      await runFixture('seed', env);
+      const holder = await holdRefreshLock('lock-held-connect', env);
+
+      const result = JSON.parse(
+        await runFixture('refresh-connect', { ...env, MCPORTER_TEST_REFRESH_LOCK_TIMEOUT_MS: '400' })
+      ) as { refreshUnavailable: boolean; authorizationPrompts: number };
+      holder.release();
+      await holder.settled;
+
+      // Handing the SDK the expired-but-refreshable token would let it redeem
+      // the spent generation outside the lock and revoke the family.
+      expect(result.refreshUnavailable).toBe(true);
+      expect(tokenRequests).toHaveLength(0);
+      expect(replays).toHaveLength(0);
+      // Failing beats prompting: the credentials are valid and being refreshed.
+      expect(result.authorizationPrompts).toBe(0);
     },
     budget(30_000)
   );

--- a/tests/oauth-refresh-process.integration.test.ts
+++ b/tests/oauth-refresh-process.integration.test.ts
@@ -8,6 +8,11 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+// The child processes exercise the built artifact; this parent only needs the
+// same lock-path derivation, so it imports source rather than requiring dist to
+// exist at typecheck time.
+import { withFileLock } from '../src/fs-json.js';
+import { refreshLockPaths } from '../src/oauth-refresh-lock.js';
 import { ensureDistBuilt } from './helpers/dist.js';
 import { budget } from './helpers/timing.js';
 
@@ -272,8 +277,6 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
       const env = await freshEnv('lock-held', seed);
       await runFixture('seed', env);
 
-      const { refreshLockPaths } = await import('../dist/oauth-refresh-lock.js');
-      const { withFileLock } = await import('../dist/fs-json.js');
       const previousDataHome = process.env.XDG_DATA_HOME;
       process.env.XDG_DATA_HOME = env.XDG_DATA_HOME;
       const lockPaths = await refreshLockPaths({
@@ -315,7 +318,6 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
       const env = await freshEnv('stale-lock', seed);
       await runFixture('seed', env);
 
-      const { refreshLockPaths } = await import('../dist/oauth-refresh-lock.js');
       const previousDataHome = process.env.XDG_DATA_HOME;
       process.env.XDG_DATA_HOME = env.XDG_DATA_HOME;
       const lockPaths = await refreshLockPaths({

--- a/tests/oauth-refresh-process.integration.test.ts
+++ b/tests/oauth-refresh-process.integration.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
@@ -6,19 +7,45 @@ import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { ensureDistBuilt } from './helpers/dist.js';
 import { budget } from './helpers/timing.js';
 
 const CLI_ENTRY = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
 const PROCESS_FIXTURE = fileURLToPath(new URL('./fixtures/oauth-refresh-process.mjs', import.meta.url));
 
+/**
+ * A refresh token generation belonging to a rotation family. Redeeming a spent
+ * generation is a replay, which providers such as Notion treat as a stolen-token
+ * signal and answer by revoking the whole family (RFC 9700 4.14.2).
+ */
+interface Generation {
+  family: string;
+  spent: boolean;
+}
+
+function marker(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
 describe('OAuth refresh across fresh built-artifact processes', () => {
   let server: Server;
   let endpoint: string;
   let authOrigin: string;
   let tempDir: string;
-  const tokenRequests: URLSearchParams[] = [];
+
+  let tokenRequests: URLSearchParams[] = [];
+  let generations: Map<string, Generation>;
+  let revokedFamilies: Set<string>;
+  let replays: URLSearchParams[] = [];
+  let issuedByFamily: Map<string, number>;
+  // Set to hold the first token request open until a second family arrives, so
+  // "unrelated identities refresh concurrently" is proven by overlap.
+  let overlapBarrier: { arrived: Map<string, () => void>; release: Promise<void> } | undefined;
+
+  function registerSeed(refreshToken: string, family: string): void {
+    generations.set(refreshToken, { family, spent: false });
+  }
 
   beforeAll(async () => {
     await ensureDistBuilt(CLI_ENTRY);
@@ -27,10 +54,7 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
       const base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
       const url = new URL(request.url ?? '/', base);
       if (url.pathname.includes('.well-known/oauth-protected-resource')) {
-        return sendJson(response, {
-          resource: endpoint,
-          authorization_servers: [authOrigin],
-        });
+        return sendJson(response, { resource: endpoint, authorization_servers: [authOrigin] });
       }
       if (
         url.pathname.includes('.well-known/oauth-authorization-server') ||
@@ -48,12 +72,35 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
         });
       }
       if (url.pathname === '/token' && request.method === 'POST') {
-        const body = await readBody(request);
-        tokenRequests.push(new URLSearchParams(body));
+        const params = new URLSearchParams(await readBody(request));
+        tokenRequests.push(params);
+        const presented = params.get('refresh_token') ?? '';
+        const generation = generations.get(presented);
+
+        if (!generation || revokedFamilies.has(generation.family)) {
+          return sendError(response, 'invalid_grant');
+        }
+        if (generation.spent) {
+          replays.push(params);
+          revokedFamilies.add(generation.family);
+          return sendError(response, 'invalid_grant');
+        }
+
+        if (overlapBarrier) {
+          overlapBarrier.arrived.get(generation.family)?.();
+          await overlapBarrier.release;
+        }
+
+        generation.spent = true;
+        // Per family, so one identity's rotations do not renumber another's.
+        const issued = (issuedByFamily.get(generation.family) ?? 0) + 1;
+        issuedByFamily.set(generation.family, issued);
+        const rotated = `rotated-${generation.family}-${issued}`;
+        generations.set(rotated, { family: generation.family, spent: false });
         return sendJson(response, {
-          access_token: 'fresh-process-access-token',
+          access_token: `access-${generation.family}-${issued}`,
           token_type: 'Bearer',
-          refresh_token: 'rotated-process-refresh-token',
+          refresh_token: rotated,
           expires_in: 3600,
         });
       }
@@ -73,19 +120,41 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
+  beforeEach(() => {
+    tokenRequests = [];
+    replays = [];
+    generations = new Map();
+    revokedFamilies = new Set();
+    issuedByFamily = new Map();
+    overlapBarrier = undefined;
+  });
+
+  afterEach(() => {
+    overlapBarrier = undefined;
+  });
+
+  async function freshEnv(name: string, seedRefresh: string): Promise<NodeJS.ProcessEnv> {
+    const root = await fs.mkdtemp(path.join(tempDir, `${name}-`));
+    return {
+      ...process.env,
+      HOME: path.join(root, 'home'),
+      XDG_CONFIG_HOME: path.join(root, 'config'),
+      XDG_DATA_HOME: path.join(root, 'data'),
+      XDG_CACHE_HOME: path.join(root, 'cache'),
+      XDG_STATE_HOME: path.join(root, 'state'),
+      MCPORTER_TEST_OAUTH_ENDPOINT: endpoint,
+      MCPORTER_TEST_OAUTH_CACHE_DIR: path.join(root, 'oauth-cache'),
+      MCPORTER_TEST_OAUTH_SERVER_NAME: name,
+      MCPORTER_TEST_OAUTH_SEED_REFRESH: seedRefresh,
+    };
+  }
+
   it(
     'keeps the dynamic client identity after a silent refresh in a new process',
     async () => {
-      const env = {
-        ...process.env,
-        HOME: path.join(tempDir, 'home'),
-        XDG_CONFIG_HOME: path.join(tempDir, 'config'),
-        XDG_DATA_HOME: path.join(tempDir, 'data'),
-        XDG_CACHE_HOME: path.join(tempDir, 'cache'),
-        XDG_STATE_HOME: path.join(tempDir, 'state'),
-        MCPORTER_TEST_OAUTH_ENDPOINT: endpoint,
-        MCPORTER_TEST_OAUTH_CACHE_DIR: path.join(tempDir, 'oauth-cache'),
-      };
+      const seed = 'legacy-seed-refresh';
+      registerSeed(seed, 'legacy');
+      const env = await freshEnv('oauth-refresh-process', seed);
 
       await runFixture('seed', env);
       const result = JSON.parse(await runFixture('refresh', env)) as {
@@ -95,18 +164,206 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
         refreshToken: string;
       };
 
-      expect(result).toEqual({
-        accessToken: 'fresh-process-access-token',
-        authorizationPrompts: 0,
-        clientId: 'fresh-process-client',
-        refreshToken: 'rotated-process-refresh-token',
-      });
+      expect(result.authorizationPrompts).toBe(0);
+      expect(result.clientId).toBe('fresh-process-client');
+      expect(result.accessToken).toBe('access-legacy-1');
+      expect(result.refreshToken).toBe('rotated-legacy-1');
       expect(tokenRequests).toHaveLength(1);
       expect(tokenRequests[0]?.get('grant_type')).toBe('refresh_token');
-      expect(tokenRequests[0]?.get('refresh_token')).toBe('fresh-process-refresh-token');
+      expect(tokenRequests[0]?.get('refresh_token')).toBe(seed);
       expect(tokenRequests[0]?.get('client_id')).toBe('fresh-process-client');
     },
     budget(20_000)
+  );
+
+  for (const variant of [
+    { action: 'refresh-cached', label: 'cached-read path' },
+    { action: 'refresh-connect', label: 'provider path' },
+  ] as const) {
+    it(
+      `redeems a rotating refresh token exactly once across concurrent processes (${variant.label})`,
+      async () => {
+        const seed = `wave-seed-${variant.action}`;
+        registerSeed(seed, 'wave');
+        const env = await freshEnv(`wave-${variant.action}`, seed);
+        await runFixture('seed', env);
+
+        // Twelve callers, matching the reproduction in issue #305.
+        const outputs = await Promise.all(
+          Array.from({ length: 12 }, () => runFixture(variant.action, env).then((raw) => JSON.parse(raw)))
+        );
+
+        const seededRedemptions = tokenRequests.filter((request) => request.get('refresh_token') === seed);
+        expect(seededRedemptions).toHaveLength(1);
+        expect(replays).toHaveLength(0);
+        expect(revokedFamilies.has('wave')).toBe(false);
+
+        // Every caller converges on the one generation the winner persisted.
+        const winnerMarker = marker('access-wave-1');
+        const persisted = new Set(outputs.map((output) => output.persistedAccessMarker));
+        expect([...persisted]).toEqual([winnerMarker]);
+        for (const output of outputs) {
+          expect(output.persistedRefreshMarker).toBe(marker('rotated-wave-1'));
+          if (variant.action === 'refresh-cached') {
+            expect(output.accessMarker).toBe(winnerMarker);
+          } else {
+            expect(output.authorizationPrompts).toBe(0);
+          }
+          expect(JSON.stringify(output)).not.toContain('access-wave-1');
+          expect(JSON.stringify(output)).not.toContain('rotated-wave-1');
+        }
+
+        // The rotated generation still refreshes normally afterwards.
+        await fs.writeFile(
+          path.join(env.MCPORTER_TEST_OAUTH_CACHE_DIR ?? '', 'tokens.json'),
+          JSON.stringify({
+            access_token: 'access-wave-1',
+            token_type: 'Bearer',
+            refresh_token: 'rotated-wave-1',
+            expires_at: 1,
+          })
+        );
+        const later = JSON.parse(await runFixture('refresh-cached', env)) as { accessMarker: string };
+        expect(later.accessMarker).toBe(marker('access-wave-2'));
+        expect(replays).toHaveLength(0);
+        expect(revokedFamilies.has('wave')).toBe(false);
+      },
+      budget(60_000)
+    );
+  }
+
+  it(
+    'lets unrelated credential identities refresh at the same time',
+    async () => {
+      registerSeed('alpha-seed', 'alpha');
+      registerSeed('beta-seed', 'beta');
+      const alphaEnv = await freshEnv('identity-alpha', 'alpha-seed');
+      const betaEnv = await freshEnv('identity-beta', 'beta-seed');
+      await Promise.all([runFixture('seed', alphaEnv), runFixture('seed', betaEnv)]);
+
+      // Both requests must be in flight before either completes; a lock that
+      // serialized unrelated identities would deadlock this barrier.
+      let releaseBoth!: () => void;
+      const release = new Promise<void>((resolve) => {
+        releaseBoth = resolve;
+      });
+      const arrivals = new Map<string, () => void>();
+      const alphaArrived = new Promise<void>((resolve) => arrivals.set('alpha', resolve));
+      const betaArrived = new Promise<void>((resolve) => arrivals.set('beta', resolve));
+      overlapBarrier = { arrived: arrivals, release };
+
+      const runs = Promise.all([runFixture('refresh-cached', alphaEnv), runFixture('refresh-cached', betaEnv)]);
+      await Promise.all([alphaArrived, betaArrived]);
+      releaseBoth();
+
+      const [alpha, beta] = (await runs).map((raw) => JSON.parse(raw) as { accessMarker: string });
+      expect(alpha?.accessMarker).toBe(marker('access-alpha-1'));
+      expect(beta?.accessMarker).toBe(marker('access-beta-1'));
+      expect(replays).toHaveLength(0);
+    },
+    budget(30_000)
+  );
+
+  it(
+    'returns the persisted token without redeeming when another process holds the lock',
+    async () => {
+      const seed = 'held-seed';
+      registerSeed(seed, 'held');
+      const env = await freshEnv('lock-held', seed);
+      await runFixture('seed', env);
+
+      const { refreshLockPaths } = await import('../dist/oauth-refresh-lock.js');
+      const { withFileLock } = await import('../dist/fs-json.js');
+      const previousDataHome = process.env.XDG_DATA_HOME;
+      process.env.XDG_DATA_HOME = env.XDG_DATA_HOME;
+      const lockPaths = await refreshLockPaths({
+        name: 'lock-held',
+        command: { kind: 'http', url: new URL(endpoint) },
+        auth: 'oauth',
+        tokenCacheDir: env.MCPORTER_TEST_OAUTH_CACHE_DIR,
+      });
+      process.env.XDG_DATA_HOME = previousDataHome;
+
+      let releaseHolder!: () => void;
+      const holderRelease = new Promise<void>((resolve) => {
+        releaseHolder = resolve;
+      });
+      const holder = withFileLock(lockPaths[0] ?? '', async () => {
+        await holderRelease;
+      });
+
+      const waiter = JSON.parse(
+        await runFixture('refresh-cached', { ...env, MCPORTER_TEST_REFRESH_LOCK_TIMEOUT_MS: '400' })
+      ) as { accessMarker: string };
+      releaseHolder();
+      await holder;
+
+      // The waiter keeps the seeded (expired) token rather than redeeming it
+      // outside the lock, which is what would replay against the provider.
+      expect(waiter.accessMarker).toBe(marker('expired-process-token'));
+      expect(tokenRequests).toHaveLength(0);
+      expect(replays).toHaveLength(0);
+    },
+    budget(30_000)
+  );
+
+  it(
+    'breaks a lock left behind by a dead process',
+    async () => {
+      const seed = 'stale-seed';
+      registerSeed(seed, 'stale');
+      const env = await freshEnv('stale-lock', seed);
+      await runFixture('seed', env);
+
+      const { refreshLockPaths } = await import('../dist/oauth-refresh-lock.js');
+      const previousDataHome = process.env.XDG_DATA_HOME;
+      process.env.XDG_DATA_HOME = env.XDG_DATA_HOME;
+      const lockPaths = await refreshLockPaths({
+        name: 'stale-lock',
+        command: { kind: 'http', url: new URL(endpoint) },
+        auth: 'oauth',
+        tokenCacheDir: env.MCPORTER_TEST_OAUTH_CACHE_DIR,
+      });
+      process.env.XDG_DATA_HOME = previousDataHome;
+
+      const lockFile = `${lockPaths[0]}.lock`;
+      await fs.mkdir(path.dirname(lockFile), { recursive: true });
+      // A pid that is not running: the holder died mid-transaction.
+      await fs.writeFile(lockFile, `2147483646\n${new Date().toISOString()}\n`);
+
+      const result = JSON.parse(await runFixture('refresh-cached', env)) as { accessMarker: string };
+      expect(result.accessMarker).toBe(marker('access-stale-1'));
+      expect(replays).toHaveLength(0);
+    },
+    budget(30_000)
+  );
+
+  it(
+    'degrades to a clean re-auth when a process dies between redeeming and persisting',
+    async () => {
+      const seed = 'crash-seed';
+      registerSeed(seed, 'crash');
+      const env = await freshEnv('crash-after-redeem', seed);
+      await runFixture('seed', env);
+
+      // The provider rotated; this process never persisted the result.
+      const crashed = JSON.parse(await runFixture('redeem-without-persisting', env)) as { redeemed: boolean };
+      expect(crashed.redeemed).toBe(true);
+
+      // The next caller can only present the spent generation. The replay is
+      // unavoidable here, so the requirement is that recovery leaves a clean
+      // state rather than a corrupt vault or a retry loop.
+      const after = JSON.parse(await runFixture('refresh-cached', env)) as {
+        accessMarker: string | null;
+        persistedAccessMarker: string | null;
+      };
+
+      expect(replays).toHaveLength(1);
+      expect(revokedFamilies.has('crash')).toBe(true);
+      expect(after.accessMarker).toBeNull();
+      expect(after.persistedAccessMarker).toBeNull();
+    },
+    budget(30_000)
   );
 });
 
@@ -115,7 +372,7 @@ function runFixture(action: string, env: NodeJS.ProcessEnv): Promise<string> {
     execFile(
       process.execPath,
       [PROCESS_FIXTURE, action],
-      { env, timeout: budget(15_000), maxBuffer: 1024 * 1024 },
+      { env, timeout: budget(20_000), maxBuffer: 1024 * 1024 },
       (error, stdout, stderr) => {
         if (error) {
           reject(new Error(`${error.message}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`));
@@ -131,6 +388,12 @@ function sendJson(response: import('node:http').ServerResponse, body: unknown): 
   response.statusCode = 200;
   response.setHeader('Content-Type', 'application/json');
   response.end(JSON.stringify(body));
+}
+
+function sendError(response: import('node:http').ServerResponse, error: string): void {
+  response.statusCode = 400;
+  response.setHeader('Content-Type', 'application/json');
+  response.end(JSON.stringify({ error }));
 }
 
 async function readBody(request: import('node:http').IncomingMessage): Promise<string> {

--- a/tests/oauth-refresh-process.integration.test.ts
+++ b/tests/oauth-refresh-process.integration.test.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process';
+import { execFile, spawn, type ChildProcess } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import { createServer, type Server } from 'node:http';
@@ -44,6 +44,7 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
   let revokedFamilies: Set<string>;
   let replays: URLSearchParams[] = [];
   let issuedByFamily: Map<string, number>;
+  let transientFailuresRemaining = 0;
   // Set to hold the first token request open until a second family arrives, so
   // "unrelated identities refresh concurrently" is proven by overlap.
   let overlapBarrier: { arrived: Map<string, () => void>; release: Promise<void> } | undefined;
@@ -79,6 +80,10 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
       if (url.pathname === '/token' && request.method === 'POST') {
         const params = new URLSearchParams(await readBody(request));
         tokenRequests.push(params);
+        if (transientFailuresRemaining > 0) {
+          transientFailuresRemaining -= 1;
+          return sendError(response, 'temporarily_unavailable', 503);
+        }
         const presented = params.get('refresh_token') ?? '';
         const generation = generations.get(presented);
 
@@ -131,6 +136,7 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
     generations = new Map();
     revokedFamilies = new Set();
     issuedByFamily = new Map();
+    transientFailuresRemaining = 0;
     overlapBarrier = undefined;
   });
 
@@ -373,6 +379,48 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
     budget(30_000)
   );
 
+  it.runIf(process.platform !== 'win32')(
+    'recovers after an actual lock holder process is killed',
+    async () => {
+      const seed = 'killed-holder-seed';
+      registerSeed(seed, 'killed-holder');
+      const env = await freshEnv('killed-holder', seed);
+      await runFixture('seed', env);
+
+      const holder = await startLockHolder(env);
+      holder.kill('SIGKILL');
+      await new Promise<void>((resolve) => holder.once('exit', () => resolve()));
+
+      const result = JSON.parse(await runFixture('refresh-cached', env)) as { accessMarker: string };
+      expect(result.accessMarker).toBe(marker('access-killed-holder-1'));
+      expect(tokenRequests).toHaveLength(1);
+      expect(replays).toHaveLength(0);
+      expect(revokedFamilies.has('killed-holder')).toBe(false);
+    },
+    budget(30_000)
+  );
+
+  it(
+    'lets another process refresh after a transient holder failure',
+    async () => {
+      const seed = 'transient-seed';
+      registerSeed(seed, 'transient');
+      const env = await freshEnv('transient-failure', seed);
+      await runFixture('seed', env);
+      transientFailuresRemaining = 1;
+
+      const failed = JSON.parse(await runFixture('refresh-cached', env)) as { accessMarker: string };
+      expect(failed.accessMarker).toBe(marker('expired-process-token'));
+
+      const recovered = JSON.parse(await runFixture('refresh-cached', env)) as { accessMarker: string };
+      expect(recovered.accessMarker).toBe(marker('access-transient-1'));
+      expect(tokenRequests).toHaveLength(2);
+      expect(replays).toHaveLength(0);
+      expect(revokedFamilies.has('transient')).toBe(false);
+    },
+    budget(30_000)
+  );
+
   it(
     'degrades to a clean re-auth when a process dies between redeeming and persisting',
     async () => {
@@ -419,14 +467,39 @@ function runFixture(action: string, env: NodeJS.ProcessEnv): Promise<string> {
   });
 }
 
+function startLockHolder(env: NodeJS.ProcessEnv): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [PROCESS_FIXTURE, 'hold-refresh-lock'], {
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr?.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      reject(new Error(`Lock holder exited before acquiring the lock (code=${code}, signal=${signal}): ${stderr}`));
+    });
+    child.stdout?.once('data', (chunk) => {
+      const message = JSON.parse(String(chunk)) as { holding?: boolean };
+      if (!message.holding) {
+        reject(new Error(`Unexpected lock-holder output: ${String(chunk)}`));
+        return;
+      }
+      resolve(child);
+    });
+  });
+}
+
 function sendJson(response: import('node:http').ServerResponse, body: unknown): void {
   response.statusCode = 200;
   response.setHeader('Content-Type', 'application/json');
   response.end(JSON.stringify(body));
 }
 
-function sendError(response: import('node:http').ServerResponse, error: string): void {
-  response.statusCode = 400;
+function sendError(response: import('node:http').ServerResponse, error: string, status = 400): void {
+  response.statusCode = status;
   response.setHeader('Content-Type', 'application/json');
   response.end(JSON.stringify({ error }));
 }

--- a/tests/oauth-session.test.ts
+++ b/tests/oauth-session.test.ts
@@ -266,6 +266,51 @@ describe('FileOAuthClientProvider session lifecycle', () => {
     await session.close();
   });
 
+  it('lets the SDK reauthorize when expired tokens have no dynamic client registration', async () => {
+    const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
+    tempDirs.push(tokenCacheDir);
+    const oauthServer = await startOAuthMetadataServer(false);
+    await fs.writeFile(
+      path.join(tokenCacheDir, 'tokens.json'),
+      JSON.stringify({
+        access_token: 'expired-token',
+        token_type: 'Bearer',
+        refresh_token: 'orphaned-refresh-token',
+        expires_at: 1,
+      }),
+      'utf8'
+    );
+    const definition: ServerDefinition = {
+      name: 'test-oauth-missing-client',
+      command: { kind: 'http', url: new URL(oauthServer.serverUrl) },
+      auth: 'oauth',
+      tokenCacheDir,
+    };
+    const authorizationRequests: URL[] = [];
+    const session = await createOAuthSession(
+      definition,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      {
+        suppressBrowserLaunch: true,
+        onAuthorizationUrl: ({ authorizationUrl }) => {
+          authorizationRequests.push(new URL(authorizationUrl));
+        },
+      }
+    );
+
+    try {
+      await expect(sdkAuth(session.provider, { serverUrl: oauthServer.serverUrl })).resolves.toBe('REDIRECT');
+      expect(oauthServer.registrationCount()).toBe(1);
+      expect(authorizationRequests).toHaveLength(1);
+      expect(authorizationRequests[0]?.searchParams.get('client_id')).toBe('replacement-dcr-client');
+    } finally {
+      const pending = session.waitForAuthorizationCode().catch(() => undefined);
+      await session.close();
+      await pending;
+      await oauthServer.close();
+    }
+  });
+
   it('preserves refreshable credentials when a new session allocates a different dynamic port', async () => {
     const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
     tempDirs.push(tokenCacheDir);


### PR DESCRIPTION
## Summary

Fixes #305. Concurrent mcporter processes sharing a credential vault could each read the same expired access token and redeem the same rotating refresh token. Providers with replay detection answer `invalid_grant` and revoke the whole token family, leaving no cached credentials.

A per-credential cross-process lock now covers the whole refresh transaction — re-read, redeem, persist — so a rotating token is redeemed once.

## What changed

**The lock.** New `src/oauth-refresh-lock.ts`, built on the existing `withFileLock` (no new dependency), on a target separate from the vault write lock so the locked section can still persist. It is re-entrant per call chain, because the MCP SDK reads tokens through the provider while an outer wrapper holds the lock.

**One credential, one lock.** A credential reachable from more than one place locks every one of them: the token-cache store alongside the vault, and the legacy `<name>-oauth` vault entry a renamed server inherits from. Two configurations need not derive identical lock sets — they must overlap on the target holding the credential they share — and the set is sorted so overlapping sets cannot invert. Identities are canonicalized and hashed, and each filename derives from its own target rather than the calling definition; otherwise two configurations sharing one key hash it into two filenames and take separate locks anyway.

**All three redemption paths** hold it: the cached-read path, the `refreshable_bearer` path, and SDK-driven refresh via the provider's token read.

**Divergent stores.** The composite read returns the first store holding tokens, so a partly-landed save can leave a spent generation shadowing a newer one. The transaction now redeems the newest. Two limits are load-bearing: it overrides store priority *only* when the stores hold different refresh tokens, and it never writes the winner back — flattening the stores to one generation would make rejected-credential recovery clear every copy and discard a generation that should survive.

**Nothing redeemable escapes the lock.** On lock timeout the cached-read path returns its persisted access token, which a caller cannot redeem. The provider path cannot do the same, because the token *object* it returns is redeemable by the SDK, so it fails with a retryable error instead. Withholding just the refresh token is not an option: the SDK re-persists the provider's return value when `issuer` is unset and would destroy it.

**Bounded requests.** Token-endpoint and discovery calls made under the lock carry a cancellation deadline. A live-but-stalled holder is invisible to pid-based stale detection, so an unbounded call would starve every waiter.

**Rejected-grant classification.** The SDK reports OAuth error codes on `code`, which the classifier did not read — so a genuinely rejected grant was treated as transient and never reached the recovery that clears dead credentials.

## Proof

**Deterministic.** A mock provider that rotates on redemption and revokes the family on replay. Twelve concurrent processes against one seeded expired generation, on both the cached-read and provider paths: exactly one redemption, zero replays, family intact, and a later sequential refresh still succeeding. Run three times per path. Unpatched 0.13.3 produced 4/6/12 redemptions with 3/5/11 replays across the same waves and revoked the family every time.

Also covered: unrelated identities refreshing concurrently (proven by holding both token requests open until each has arrived, not by ordering), a held lock, a lock left by a dead process, and a crash between redeeming and persisting.

**Live.** A disposable Notion account on a real host, using this PR's build at `8fdb6d8`. Twelve concurrent processes: 12/12 succeeded, no `invalid_grant`, generation rotated A → B with both tokens still present. Generation B was then forced due and refreshed to C — Notion accepted the refresh token the concurrent wave had persisted, which is what separates a wave that worked from one that silently left a revoked family. Generations are labelled A/B/C; the capture contains no token, authorization header, client identifier, secret, workspace identifier, or endpoint.

Boundaries on the live trace: both rotations were forced via the refresh skew rather than waiting out a natural token lifetime; it carries no provider-side request logs, so redemption counts come from the deterministic test rather than this capture; and it predates the divergent-store and lock-identity commits, whose code paths that single-store scenario does not exercise.

<details>
<summary>Redacted live capture (full trace, commit <code>8fdb6d8</code>)</summary>

Captured: 2026-08-10T18:06:15Z · Tested commit: `8fdb6d81f0369629a169e3c302cfb848df7396fb`

**Environment**

- Provisioned host: Darwin 25.5.0 arm64
- Node.js: `v24.18.0`, pnpm: `10.34.5`
- Account: disposable Notion OAuth account `notion:refresh-test`

The PR was built locally and its `dist/cli.js` was run against the provisioned host's real mcporter credential vault. A temporary copy of the mcporter config increased `refresh.refreshSkewSeconds` for this account so refresh was due immediately. The provisioned config itself was not modified.

**Redaction policy:** no access token, refresh token, authorization header, OAuth client identifier, client secret, tenant/workspace identifier, endpoint URL, or raw tool response appears below. Credential generations are represented as A, B, and C. Process output is reduced to exit code, status counts, and error classification.

**Preflight** — at `2026-08-10T18:02:32.732Z` the live vault held one credential entry:

```json
{
  "generation": "A",
  "expiresAt": "2026-08-11T02:02:32Z",
  "hasAccessToken": true,
  "hasRefreshToken": true,
  "hasFullDynamicClientMetadata": true
}
```

A sequential status probe before forcing expiry returned `status: "ok"`.

**Concurrent live refresh wave** — twelve fresh PR-built processes started concurrently, each equivalent to:

```sh
HOME=<agent-home> \
MCPORTER_CONFIG=<temporary-forced-refresh-config> \
<pr-306-build>/dist/cli.js \
  list notion:refresh-test --status --json --no-oauth
```

```json
{
  "callers": 12,
  "successfulCallers": 12,
  "failedCallers": 0,
  "invalidGrantObservations": 0,
  "statuses": [{ "status": "ok", "count": 12 }],
  "perCaller": ["1:ok","2:ok","3:ok","4:ok","5:ok","6:ok","7:ok","8:ok","9:ok","10:ok","11:ok","12:ok"]
}
```

After the wave, the live vault showed:

```json
{
  "updatedAt": "2026-08-10T18:05:36.911Z",
  "generationTransition": "A -> B",
  "expiresAt": "2026-08-11T02:05:36Z",
  "expiryAdvanced": true,
  "hasAccessToken": true,
  "hasRefreshToken": true
}
```

No process emitted stderr. No output contained `invalid_grant`, `no cached access token`, or an unauthenticated status.

**Subsequent rotated-generation refresh** — the temporary config was adjusted so generation B was immediately due, then one fresh process ran the same status probe:

```json
{
  "exitCode": 0,
  "okCount": 1,
  "authCount": 0,
  "errorCount": 0,
  "serverStatus": "ok",
  "invalidGrant": false
}
```

```json
{
  "updatedAt": "2026-08-10T18:06:03.380Z",
  "generationTransition": "B -> C",
  "expiresAt": "2026-08-11T02:06:03Z",
  "expiryAdvanced": true,
  "hasAccessToken": true,
  "hasRefreshToken": true
}
```

This second rotation is the grant-health check: Notion accepted the refresh token persisted by the concurrent wave and returned another usable generation, so the wave did not leave a replay-revoked family or purge the cached credentials.

Full capture also posted as a [PR comment](https://github.com/openclaw/mcporter/pull/306#issuecomment-5246819744).

</details>

## Known limitation

A 401 makes the SDK redeem whatever the provider's token read returns, even a token that was just refreshed, and that call site has no seam to wrap. Two processes taking a 401 at the same instant can still redeem concurrently; the rejected-refresh recovery remains the backstop. This is documented in the provider code. The missing expiry check is worth reporting upstream, since it also burns a token rotation on every `auth()` call.

Two operational notes for adopters: the guarantee is per host, because pid-based stale detection cannot arbitrate between hosts sharing one credential directory over a network filesystem; and a mixed-version fleet is only fully protected once every long-lived daemon and generated CLI is upgraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

