### PR TITLE
fix(list): keep the array shape for enum-typed array parameters

### DIFF
--- a/src/cli/generate/tools.ts
+++ b/src/cli/generate/tools.ts
@@ -167,7 +167,10 @@ export function buildPlaceholder(
 ): string {
   const normalized = property.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`).replace(/_/g, '-');
   if (enumValues && enumValues.length > 0) {
-    return `<${normalized}:${enumValues.join('|')}>`;
+    // Enum members can describe an array's items, and the generated parser splits those
+    // flags on commas, so keep the multi-value hint next to the choices.
+    const suffix = type === 'array' ? ',...' : '';
+    return `<${normalized}:${enumValues.join('|')}${suffix}>`;
   }
   switch (type) {
     case 'number':

--- a/src/cli/list-signature.ts
+++ b/src/cli/list-signature.ts
@@ -181,7 +181,10 @@ function inferSchemaDisplayType(descriptor: Record<string, unknown>): string {
 function formatTypeAnnotation(option: GeneratedOption, colorize: boolean): string {
   let baseType: string;
   if (option.enumValues && option.enumValues.length > 0) {
-    baseType = option.enumValues.map((value) => JSON.stringify(value)).join(' | ');
+    const union = option.enumValues.map((value) => JSON.stringify(value)).join(' | ');
+    // Enum members can come from an array's items, so keep the array shape instead of
+    // rendering the union alone.
+    baseType = option.type === 'array' ? formatEnumArrayType(union, option.enumValues.length) : union;
   } else {
     switch (option.type) {
       case 'number':
@@ -218,6 +221,10 @@ function formatTypeAnnotation(option: GeneratedOption, colorize: boolean): strin
     return `${base} ${tint(`/* ${option.formatHint} */`)}`;
   }
   return base;
+}
+
+function formatEnumArrayType(union: string, memberCount: number): string {
+  return memberCount > 1 ? `(${union})[]` : `${union}[]`;
 }
 
 function formatArrayItemType(type: GeneratedOption['arrayItemType']): string {

--- a/tests/generate-cli-helpers.test.ts
+++ b/tests/generate-cli-helpers.test.ts
@@ -120,6 +120,7 @@ describe('generate helpers', () => {
     expect(getDescriptorDefault(null)).toBeUndefined();
 
     expect(buildPlaceholder('myPath', 'string', ['s1', 's2'])).toBe('<my-path:s1|s2>');
+    expect(buildPlaceholder('sources', 'array', ['web', 'news'])).toBe('<sources:web|news,...>');
     expect(buildPlaceholder('createdAt', 'string', undefined, 'iso-8601')).toBe('<created-at:iso-8601>');
     expect(buildPlaceholder('fields', 'object')).toBe('<fields:json>');
     expect(buildExampleValue('itemId', 'string', undefined, undefined)).toBe('example-id');

--- a/tests/list-detail-helpers.test.ts
+++ b/tests/list-detail-helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { GeneratedOption } from '../src/cli/generate/tools.js';
+import { extractOptions } from '../src/cli/generate/tools.js';
 import { buildToolDoc, selectDisplayOptions } from '../src/cli/list-detail-helpers.js';
 import { buildDocComment, wrapCommentText } from '../src/cli/list-doc-comments.js';
 import {
@@ -113,6 +114,41 @@ describe('formatFunctionSignature', () => {
     expect(signature).toBe(
       'function filter_docs(names: string[], scores: number[], enabled: boolean[], metadata: Record<string, unknown>[], unknownItems: unknown[], missingItems: unknown[]);'
     );
+  });
+
+  it('keeps the array shape when enum members come from array items', () => {
+    const signature = formatFunctionSignature(
+      'search_docs',
+      [
+        baseOption({ property: 'sources', type: 'array', arrayItemType: 'string', enumValues: ['web', 'news'] }),
+        baseOption({ property: 'tags', type: 'array', arrayItemType: 'string', enumValues: ['stable'] }),
+        baseOption({ property: 'mode', type: 'string', enumValues: ['fast', 'deep'] }),
+      ],
+      undefined,
+      { colorize: false }
+    );
+
+    expect(signature).toBe(
+      'function search_docs(sources: ("web" | "news")[], tags: "stable"[], mode: "fast" | "deep");'
+    );
+  });
+
+  it('agrees with the call example it renders for the same schema', () => {
+    const options = extractOptions({
+      name: 'search_docs',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sources: { type: 'array', items: { type: 'string', enum: ['web', 'news'] } },
+        },
+        required: ['sources'],
+      },
+    });
+    const signature = formatFunctionSignature('search_docs', options, undefined, { colorize: false });
+    const example = formatCallExpressionExample('docs', 'search_docs', options);
+
+    expect(signature).toBe('function search_docs(sources: ("web" | "news")[]);');
+    expect(example).toBe('mcporter call docs.search_docs(sources: ["web"])');
   });
 
   it('normalizes integer item output schemas to number arrays', () => {


### PR DESCRIPTION
## Summary

When a tool declares an array whose items carry an enum, `mcporter list` prints the union on its own and the array shape disappears from the signature. The call example rendered directly underneath still shows an array, so the two lines of the same tool card disagree about the parameter type.

Repro with a stdio server exposing `sources: z.array(z.enum(['web', 'news', 'images']))` and `tags: z.array(z.enum(['stable']))`:

```
$ mcporter list --stdio node --stdio-arg enum-array-server.mjs --name enum-array-demo
enum-array-demo

  /**
   * Search documentation across the selected sources
   [doc comment trimmed]
   */
  function search_docs(query: string, sources: "web" | "news" | "images", tags?: "stable", levels?: number[], mode?: "fast" | "deep");

  Examples:
    mcporter call enum-array-demo.search_docs(query: "value", sources: ["web"], ...)

  1 tool · 3400ms · STDIO node enum-array-server.mjs
```

`levels` (an array of plain numbers) renders correctly, and so does the scalar `mode`; only arrays whose items are string enums lose their shape, because `getEnumValues` collects string members only.

### Root cause

`formatTypeAnnotation` (`src/cli/list-signature.ts:181`) tests `enumValues` before it reaches the type switch, so the `array` case never runs:

```ts
if (option.enumValues && option.enumValues.length > 0) {
  baseType = option.enumValues.map((value) => JSON.stringify(value)).join(' | ');
} else {
  switch (option.type) {
    case 'array':
      baseType = `${formatArrayItemType(option.arrayItemType)}[]`;
```

The metadata itself is right: `extractOptions` sets both `type: 'array'` and `enumValues` for these descriptors (`src/cli/generate/tools.ts:105`), and `pickExampleLiteral` already special-cases the pair to emit `["web"]`. Only the signature drops the array.

Same shape as #221: `938594c` taught this function to read `items.type`, but the enum branch sits in front of the switch and still shadows it.

## Fix

Wrap the union when the option is an array. A multi-member union gets parentheses, a single member does not, and both stay valid TypeScript:

```
$ mcporter list --stdio node --stdio-arg enum-array-server.mjs --name enum-array-demo

  function search_docs(query: string, sources: ("web" | "news" | "images")[], tags?: "stable"[], levels?: number[], mode?: "fast" | "deep");

  Examples:
    mcporter call enum-array-demo.search_docs(query: "value", sources: ["web"], ...)
```

Arrays without an enum are untouched, and scalar enums still render as a plain union.

### Separate: the same ordering in `buildPlaceholder` (second commit, drop it if you would rather not take it)

`buildPlaceholder` checks the enum first for the same reason, so a generated CLI advertises an enum array as a single-value flag while the parser emitted next to it splits the value on commas:

```
# before
.option("--sources <sources:web|news|images>", "...", (value) => parseArrayOption(value, 'string'))
.option("--levels <levels:value1,value2>", "...", (value) => parseArrayOption(value, 'number'))

# after
.option("--sources <sources:web|news|images,...>", "...", (value) => parseArrayOption(value, 'string'))
.option("--levels <levels:value1,value2>", "...", (value) => parseArrayOption(value, 'number'))
```

The choices are still listed in the option description, so nothing is lost if you prefer the shorter placeholder. That commit is three lines in `src/cli/generate/tools.ts` plus one assertion.

## Behavior proof

Both transcripts above are real CLI runs (`tsx src/cli.ts list ...` and `tsx src/cli.ts generate-cli ...`) against an ad-hoc stdio MCP server, so they exercise the discovery path rather than the formatter alone. The fixture server was a throwaway and is not part of this diff.

## Tests

Added to the existing files:

- `tests/list-detail-helpers.test.ts`: array-of-enum unions, a single-member enum array, and a scalar enum that must not change; plus a case that feeds a real JSON Schema through `extractOptions` and asserts the signature and the call example agree.
- `tests/generate-cli-helpers.test.ts`: one assertion for the array placeholder.

Against unpatched `main` the signature cases fail 2/2 and the placeholder assertion fails 1/1.

## Gates

`pnpm lint:oxlint` and `pnpm typecheck` are clean. `oxfmt --check` on the four changed files is clean. Over the whole tree `pnpm format:check` reports `tests/cli-list-stdio-logs.test.ts` and `tests/list-inline-stdio.test.ts`, but both are already reported on an unmodified `main` here, so I left them alone.

`pnpm test`: 7 failed / 1525 passed / 92 skipped, all failures in `tests/chrome-devtools-relay-handoff.test.ts` and `tests/runtime-chrome-relay-handoff.test.ts`. My machine runs Node 22.20 while the repo asks for `>=24`, and the same two files fail on a clean `main` here (8 failures there, the extra one being `tests/e2e-fixture-servers.test.ts`, which is flaky across runs on both branches). Nothing in the changed area fails.
