### PR TITLE
fix(http): stop SSE fallback from masking primary transport errors

### DIFF
--- a/src/runtime/http-transport.ts
+++ b/src/runtime/http-transport.ts
@@ -156,21 +156,6 @@ function shouldAbortSseFallback(error: unknown): boolean {
   return !isLegacySseTransportMismatch(error);
 }
 
-/**
- * Prefer the primary Streamable HTTP error when SSE fallback also fails.
- * Attaches the SSE failure as `cause` so diagnostics stay available without
- * replacing a network timeout with a misleading legacy-SSE 405.
- */
-function preferPrimaryTransportError(primaryError: unknown, sseError: unknown): unknown {
-  if (primaryError instanceof Error) {
-    if (sseError instanceof Error && primaryError.cause === undefined) {
-      primaryError.cause = sseError;
-    }
-    return primaryError;
-  }
-  return sseError;
-}
-
 function isEraNegotiationFailure(error: unknown): boolean {
   return !!error && typeof error === 'object' && 'code' in error && error.code === SdkErrorCode.EraNegotiationFailed;
 }
@@ -283,8 +268,7 @@ async function attemptHttpClientContext(
         logger,
         options,
         wrapRecordTransport,
-        clientFactory,
-        primaryError
+        clientFactory
       ),
     };
   }
@@ -328,8 +312,7 @@ async function connectSseFallbackTransport(
   logger: Logger,
   options: CreateClientContextOptions,
   wrapRecordTransport: WrapRecordTransport,
-  clientFactory: HttpClientFactory,
-  primaryError?: unknown
+  clientFactory: HttpClientFactory
 ): Promise<ClientContext> {
   const createSseTransport = () =>
     wrapRecordTransport(new SSEClientTransport(command.url, transportOptions), definition, options);
@@ -355,16 +338,10 @@ async function connectSseFallbackTransport(
       // Auth challenges from SSE (including ad-hoc HTTP discovery) stay authoritative.
       throw sseError;
     }
-    // Prefer primary so a failed SSE GET (often 405 on streamable-only) never erases
-    // the Streamable HTTP fault that triggered the fallback (#310).
-    if (primaryError !== undefined) throw preferPrimaryTransportError(primaryError, sseError);
     throw sseError;
   }
 }
 
 export const __test = {
   waitForStandaloneSseStart,
-  isLegacySseTransportMismatch,
-  shouldAbortSseFallback,
-  preferPrimaryTransportError,
 };

--- a/src/runtime/http-transport.ts
+++ b/src/runtime/http-transport.ts
@@ -144,8 +144,31 @@ async function closeOAuthSession(oauthSession?: OAuthSession): Promise<void> {
 }
 
 function shouldAbortSseFallback(error: unknown): boolean {
+  // After a completed Streamable auth challenge: only fall back on 404/405
+  // transport-mismatch signals (legacy SSE servers), not on other post-auth faults.
   if (isPostAuthConnectError(error)) return !isLegacySseTransportMismatch(error);
-  return isOAuthFlowError(error) || error instanceof OAuthTimeoutError;
+  if (isOAuthFlowError(error) || error instanceof OAuthTimeoutError) return true;
+  // 401/auth still needs the promote + SSE paths below; do not short-circuit them.
+  if (isUnauthorizedError(error)) return false;
+  // Ordinary path: only attempt SSE when primary failure looks like a legacy-SSE
+  // transport mismatch. Generic network errors on streamable-HTTP-only servers
+  // must not fall through to a GET that 405s and masks the real cause (#310).
+  return !isLegacySseTransportMismatch(error);
+}
+
+/**
+ * Prefer the primary Streamable HTTP error when SSE fallback also fails.
+ * Attaches the SSE failure as `cause` so diagnostics stay available without
+ * replacing a network timeout with a misleading legacy-SSE 405.
+ */
+function preferPrimaryTransportError(primaryError: unknown, sseError: unknown): unknown {
+  if (primaryError instanceof Error) {
+    if (sseError instanceof Error && primaryError.cause === undefined) {
+      primaryError.cause = sseError;
+    }
+    return primaryError;
+  }
+  return sseError;
 }
 
 function isEraNegotiationFailure(error: unknown): boolean {
@@ -260,7 +283,8 @@ async function attemptHttpClientContext(
         logger,
         options,
         wrapRecordTransport,
-        clientFactory
+        clientFactory,
+        primaryError
       ),
     };
   }
@@ -304,7 +328,8 @@ async function connectSseFallbackTransport(
   logger: Logger,
   options: CreateClientContextOptions,
   wrapRecordTransport: WrapRecordTransport,
-  clientFactory: HttpClientFactory
+  clientFactory: HttpClientFactory,
+  primaryError?: unknown
 ): Promise<ClientContext> {
   const createSseTransport = () =>
     wrapRecordTransport(new SSEClientTransport(command.url, transportOptions), definition, options);
@@ -327,10 +352,19 @@ async function connectSseFallbackTransport(
         options.onDefinitionPromoted?.(promoted);
         return createHttpClientContext(promoted, logger, options, wrapRecordTransport, clientFactory);
       }
-      if (definition.auth) throw sseError;
+      // Auth challenges from SSE (including ad-hoc HTTP discovery) stay authoritative.
+      throw sseError;
     }
+    // Prefer primary so a failed SSE GET (often 405 on streamable-only) never erases
+    // the Streamable HTTP fault that triggered the fallback (#310).
+    if (primaryError !== undefined) throw preferPrimaryTransportError(primaryError, sseError);
     throw sseError;
   }
 }
 
-export const __test = { waitForStandaloneSseStart };
+export const __test = {
+  waitForStandaloneSseStart,
+  isLegacySseTransportMismatch,
+  shouldAbortSseFallback,
+  preferPrimaryTransportError,
+};

--- a/tests/runtime-compose.test.ts
+++ b/tests/runtime-compose.test.ts
@@ -568,7 +568,9 @@ describe('mcporter composability', () => {
         ([, cached]) => cached.disableOAuth && cached.allowCachedAuth === true
       )?.[0];
 
-      mocks.connectMock.mockImplementationOnce(throwConnectBoom).mockImplementationOnce(throwConnectBoom);
+      // Generic connect failures no longer fall back to SSE (#310), so only one
+      // Streamable HTTP attempt is made.
+      mocks.connectMock.mockImplementationOnce(throwConnectBoom);
       await expect(runtime.connect('oauth', { disableOAuth: true, allowCachedAuth: false })).rejects.toThrow(
         'connect boom'
       );

--- a/tests/runtime-transport.test.ts
+++ b/tests/runtime-transport.test.ts
@@ -236,7 +236,7 @@ describe('createClientContext (HTTP)', () => {
     expect(clientConnect.mock.calls[0]?.[0]).toBeInstanceOf(StreamableHTTPClientTransport);
   });
 
-  it('surfaces the primary error when SSE fallback also fails', async () => {
+  it('surfaces the SSE error when a transport-mismatch fallback fails', async () => {
     const definition = stubHttpDefinition('https://example.com/mcp');
     const primary = new SdkHttpError(SdkErrorCode.ClientHttpNotImplemented, 'Method Not Allowed', {
       status: 405,
@@ -254,8 +254,7 @@ describe('createClientContext (HTTP)', () => {
         throw sse;
       });
 
-    await expect(createClientContext(definition, logger, clientInfo, { maxOAuthAttempts: 0 })).rejects.toBe(primary);
-    expect(primary.cause).toBe(sse);
+    await expect(createClientContext(definition, logger, clientInfo, { maxOAuthAttempts: 0 })).rejects.toBe(sse);
     expect(clientConnect).toHaveBeenCalledTimes(2);
   });
 

--- a/tests/runtime-transport.test.ts
+++ b/tests/runtime-transport.test.ts
@@ -196,14 +196,14 @@ describe('createClientContext (HTTP)', () => {
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('"reason":"missing-credential"'));
   });
 
-  it('falls back to SSE when primary connect fails', async () => {
+  it('falls back to SSE when primary fails with a legacy transport mismatch (405)', async () => {
     const definition = stubHttpDefinition('https://example.com/mcp');
 
     const clientConnect = vi
       .spyOn(Client.prototype, 'connect')
       .mockImplementationOnce(async (transport) => {
         expect(transport).toBeInstanceOf(StreamableHTTPClientTransport);
-        throw new Error('network down');
+        throw new SdkHttpError(SdkErrorCode.ClientHttpNotImplemented, 'Method Not Allowed', { status: 405 });
       })
       .mockImplementationOnce(async (transport) => {
         expect(transport).toBeInstanceOf(SSEClientTransport);
@@ -215,6 +215,50 @@ describe('createClientContext (HTTP)', () => {
     expect(clientConnect).toHaveBeenCalledTimes(2);
   });
 
+  it('does not fall back to SSE on generic network primary failures', async () => {
+    // #310: streamable-only servers return 405 on the SSE GET; that must not replace
+    // a primary connect timeout / fetch failure.
+    const definition = stubHttpDefinition('https://example.com/mcp');
+    const primary = new Error('network down');
+
+    const clientConnect = vi
+      .spyOn(Client.prototype, 'connect')
+      .mockImplementationOnce(async (transport) => {
+        expect(transport).toBeInstanceOf(StreamableHTTPClientTransport);
+        throw primary;
+      })
+      .mockImplementationOnce(async (transport) => {
+        expect(transport).toBeInstanceOf(SSEClientTransport);
+      });
+
+    await expect(createClientContext(definition, logger, clientInfo, { maxOAuthAttempts: 0 })).rejects.toBe(primary);
+    expect(clientConnect).toHaveBeenCalledTimes(1);
+    expect(clientConnect.mock.calls[0]?.[0]).toBeInstanceOf(StreamableHTTPClientTransport);
+  });
+
+  it('surfaces the primary error when SSE fallback also fails', async () => {
+    const definition = stubHttpDefinition('https://example.com/mcp');
+    const primary = new SdkHttpError(SdkErrorCode.ClientHttpNotImplemented, 'Method Not Allowed', {
+      status: 405,
+    });
+    const sse = new Error('SSE error: Non-200 status code (405)');
+
+    const clientConnect = vi
+      .spyOn(Client.prototype, 'connect')
+      .mockImplementationOnce(async (transport) => {
+        expect(transport).toBeInstanceOf(StreamableHTTPClientTransport);
+        throw primary;
+      })
+      .mockImplementationOnce(async (transport) => {
+        expect(transport).toBeInstanceOf(SSEClientTransport);
+        throw sse;
+      });
+
+    await expect(createClientContext(definition, logger, clientInfo, { maxOAuthAttempts: 0 })).rejects.toBe(primary);
+    expect(primary.cause).toBe(sse);
+    expect(clientConnect).toHaveBeenCalledTimes(2);
+  });
+
   it('uses a newly created legacy client for the SSE fallback', async () => {
     const definition = stubHttpDefinition('https://example.com/legacy-sse');
     const connectedClients: Client[] = [];
@@ -223,7 +267,7 @@ describe('createClientContext (HTTP)', () => {
       .mockImplementationOnce(async (client, transport) => {
         connectedClients.push(client);
         expect(transport).toBeInstanceOf(StreamableHTTPClientTransport);
-        throw new Error('streamable transport unavailable');
+        throw new SdkHttpError(SdkErrorCode.ClientHttpNotImplemented, 'Method Not Allowed', { status: 405 });
       })
       .mockImplementationOnce(async (client, transport) => {
         connectedClients.push(client);


### PR DESCRIPTION
## What Problem This Solves

When Streamable HTTP connect fails for a generic network reason (`fetch failed`, DNS stall, connect timeout), mcporter still fell back to legacy SSE. Against streamable-HTTP-only servers, that fallback GET commonly returns 405 and replaced the real primary error with a misleading SSE failure.

## Summary

Closes #310.

- Ordinary Streamable HTTP errors now surface unchanged and do not trigger legacy SSE.
- Explicit 404/405 transport mismatches still select the legacy SSE transport.
- Existing 401/OAuth promotion and fallback paths remain intact.
- Once a confirmed mismatch selects SSE, a later SSE failure remains the actionable error.

## Real behavior proof

Built from this PR head and exercised against real local HTTP endpoints through the public runtime API:

1. A server that resets the Streamable HTTP POST and would return 405 to a fallback GET:
   - `origin/main`: request trace was `POST /mcp`, then `GET /mcp`; surfaced `SSE error: Non-200 status code (405)`.
   - this PR: request trace was only `POST /mcp`; surfaced the original `TypeError: fetch failed` with native cause `other side closed`.
   - repeated twice with the same POST-only result.
2. A legacy endpoint that returns 405 to Streamable HTTP and 503 to SSE:
   - request trace was `POST /mcp`, then `GET /mcp`;
   - surfaced `SSE error: Non-200 status code (503)`, proving legitimate mismatch fallback remains active and its operational failure is preserved.

## Regression proof

The pending-header and delayed-header proofs from #282 remain green:

```console
$ pnpm exec vitest run tests/cli-idle-sse.integration.test.ts --reporter=verbose
Test Files  1 passed (1)
Tests       2 passed (2)

$ pnpm exec vitest run tests/e2e-fixture-servers.test.ts --reporter=verbose --testTimeout=30000 -t 'headers arrive after the startup grace'
Test Files  1 passed (1)
Tests       1 passed | 14 skipped (15)
```

Focused transport and composability coverage:

```console
$ pnpm exec vitest run tests/runtime-transport.test.ts tests/runtime-compose.test.ts --reporter=verbose
Test Files  2 passed (2)
Tests       63 passed (63)
```

Full repository gates:

```console
$ pnpm check
# format, OXLint, and TypeScript checks passed

$ pnpm test
Test Files  191 passed | 4 skipped (195)
Tests       1598 passed | 26 skipped (1624)
```
