### PR TITLE
docs(config): drop nonexistent --tag flag from config add reference

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -95,7 +95,7 @@ Use `--scope home|project` with `mcporter config add` to pick the write target e
 - Persists a server into the writable config file. Accepts both positional shortcuts (`mcporter config add sentry https://mcp.sentry.dev/mcp`) and flag-driven definitions:
   - `--transport http|sse|stdio`
   - `--url` or `--command`/`--stdio`
-  - `--env`, `--header`, `--token-cache-dir`, `--description`, `--tag`, `--client-name`, `--oauth-redirect-url`
+  - `--env`, `--header`, `--token-cache-dir`, `--description`, `--client-name`, `--oauth-redirect-url`
   - `--oauth-client-id`, `--oauth-client-secret-env`, `--oauth-token-endpoint-auth-method` for pre-registered OAuth clients.
   - `--copy-from importKind:name` to clone settings from an imported entry before editing.
 - `--dry-run` shows the JSON diff without writing, while `--persist <path>` overrides the destination file.


### PR DESCRIPTION
## Summary

- **Problem:** `docs/config.md` lists `--tag` in the `mcporter config add` flag reference, but no such flag exists in the CLI.
- **Why it matters:** A user following the docs and passing `--tag <value>` gets it silently dropped — `extractAddFlags` routes unknown tokens through its `default:` branch (`index += 1; break;`), so `--tag foo` is skipped with no error and no effect. Silent no-op on a documented flag.
- **What changed:** Remove the `` `--tag` `` token from the flag list in `docs/config.md` (docs-only, +1/−1).
- **What did NOT change (scope boundary):** No parser, schema, help text, or config-shape change — the `--tag` case never existed, so nothing runtime is added or removed. Every other flag on that line (`--env`, `--header`, `--token-cache-dir`, `--description`, `--client-name`, `--oauth-redirect-url`) has a real handler and is left intact.

## Linked context

- Related: N/A — docs-correctness fix found while auditing the `config add` reference against the parser.
- Requested by a maintainer/owner? No — investigated from the docs/source mismatch.

## Evidence

The documented flag list vs. the actual parser cases in `src/cli/config/add.ts` (`extractAddFlags`):

```
$ grep -n "case '--" src/cli/config/add.ts
      case '--transport':
      case '--url':
      case '--command':
      case '--stdio':
      case '--arg':
      case '--args':
      case '--description':
      case '--env':
      case '--header':
      case '--token-cache-dir':
      case '--client-name':
      case '--oauth-client-id':
      case '--oauth-client-secret-env':
      case '--oauth-token-endpoint-auth-method':
      case '--oauth-redirect-url':
      case '--auth':
      case '--copy-from':
      case '--persist':
      case '--scope':
      case '--dry-run':
      case '--':

$ grep -rin "tag" src/cli/config/add.ts src/cli/config/help.ts src/config-schema.ts src/config-normalize.ts src/definition-fields.ts
(no matches)
```

There is no `--tag` case; unknown flags hit the `default:` branch and are silently skipped. The canonical help output (`src/cli/config/help.ts`) omits `--tag`, and no `tag`/`tags` field exists in `config-schema.ts`, `config-normalize.ts`, or `definition-fields.ts`. The only `tag`/`tags` symbols in the tree are unrelated display labels in `src/cli/list-format.ts`.

- **What was not tested:** No behavior change to test — this removes a documentation reference to a flag the CLI never implemented.
- **Proof limitations:** Docs-only diff; correctness verified by source inspection of the parser, help, and schema modules named above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GGRc2QoUMyeKz2H5j8tYvC)_