### PR TITLE
test(oauth): deflake callback shutdown coverage

### DIFF
--- a/tests/oauth-session.test.ts
+++ b/tests/oauth-session.test.ts
@@ -538,6 +538,15 @@ describe('FileOAuthClientProvider session lifecycle', () => {
   it('closes the callback server when interactive stale-client reads have I/O errors', async () => {
     const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
     tempDirs.push(tokenCacheDir);
+    const clientPath = path.join(tokenCacheDir, 'client.json');
+    await fs.writeFile(
+      clientPath,
+      JSON.stringify({
+        client_id: 'stale-client',
+        redirect_uris: ['http://127.0.0.1:9999/callback'],
+      }),
+      'utf8'
+    );
     const definition: ServerDefinition = {
       name: 'test-oauth-read-failure',
       description: 'Test OAuth server',
@@ -552,6 +561,7 @@ describe('FileOAuthClientProvider session lifecycle', () => {
     };
 
     const readError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    const originalReadFile = fs.readFile.bind(fs);
     const originalCreateServer = http.createServer.bind(http);
     const createdServers: http.Server[] = [];
     const createServerSpy = vi.spyOn(http, 'createServer').mockImplementation((...args) => {
@@ -559,18 +569,25 @@ describe('FileOAuthClientProvider session lifecycle', () => {
       createdServers.push(server);
       return server;
     });
+    let session: Awaited<ReturnType<typeof createOAuthSession>> | undefined;
 
     try {
-      const session = await createOAuthSession(definition, logger);
-      const readFileSpy = vi.spyOn(fs, 'readFile').mockRejectedValueOnce(readError);
+      session = await createOAuthSession(definition, logger);
+      const readFileSpy = vi.spyOn(fs, 'readFile').mockImplementation((file, ...args) => {
+        if (file === clientPath) {
+          return Promise.reject(readError);
+        }
+        return originalReadFile(file, ...args);
+      });
       await expect(
         session.provider.redirectToAuthorization(new URL('https://auth.example.com/authorize'))
       ).rejects.toMatchObject({ code: 'EACCES' });
+      expect(readFileSpy).toHaveBeenCalledWith(clientPath, 'utf8');
       readFileSpy.mockRestore();
-      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(createdServers).toHaveLength(1);
       expect(createdServers[0]?.listening).toBe(false);
     } finally {
+      await session?.close();
       createServerSpy.mockRestore();
     }
   });


### PR DESCRIPTION
## Summary

The callback-shutdown coverage used a one-shot `fs.readFile` rejection while composite/file persistence starts several cache reads concurrently. The rejected call therefore depended on scheduling, and the test could miss the intended `client.json` failure path.

This change seeds a stale client and rejects only the exact `client.json` read, asserting that the targeted call occurred. It also removes the zero-delay timing sleep and checks `server.listening` immediately, matching the production guarantee that `close()` is awaited before the read error is rethrown.

## Proof

- Focused regression: 1 passed, 31 skipped
- `tests/oauth-session.test.ts`: 32/32 passed
- 24 concurrent threaded focused runs: all passed
- `pnpm check`: passed
- `pnpm test`: 191 files passed, 4 skipped; 1600 tests passed, 26 skipped (1626 total)
- `git diff --check`: clean

Test-only change; no changelog entry needed.
