### PR TITLE
fix(oauth): serialize SDK post-401 refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.13.6] - Unreleased
 
+### OAuth
+
+- Keep the SDK's automatic post-401 token redemption inside the cross-process refresh lock, so simultaneous rejected requests adopt one rotated token generation instead of replaying and revoking the shared token family. (Issue #307)
+
 ## [0.13.5] - 2026-08-13
 
 ### CLI

--- a/patches/@modelcontextprotocol__client@2.0.0.patch
+++ b/patches/@modelcontextprotocol__client@2.0.0.patch
@@ -1,0 +1,334 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index 635f1c0134274c89e7efbcae2adf3d9ecba575ee..0a6c4876c6109eeb8eb5ddec0ece3956575b2089 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -245,16 +245,23 @@ function isOAuthClientProvider(provider) {
+ * `WWW-Authenticate` parameters from the 401 response and runs {@linkcode auth}.
+ * Used by {@linkcode adaptOAuthProvider} to bridge `OAuthClientProvider` to `AuthProvider`.
+ */
+-async function handleOAuthUnauthorized(provider, ctx, extraAuthOptions) {
++async function handleOAuthUnauthorized(provider, ctx, extraAuthOptions, options) {
+ 	const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(ctx.response);
+ 	if (await auth(provider, {
+ 		serverUrl: ctx.serverUrl,
+ 		resourceMetadataUrl,
+ 		scope,
+-		fetchFn: ctx.fetchFn,
++		fetchFn: options?.fetchFn ?? ctx.fetchFn,
+ 		...extraAuthOptions
+ 	}) !== "AUTHORIZED") throw new UnauthorizedError();
+ }
++
++function presentedBearerToken(headers, requestInit) {
++	if (new Headers(requestInit?.headers).has("authorization")) return void 0;
++	const authorization = headers.get("authorization");
++	const match = authorization?.match(/^Bearer\s+(.+)$/i);
++	return match?.[1];
++}
+ /**
+ * Adapts an `OAuthClientProvider` to the minimal `AuthProvider` interface that
+ * transports consume. Called once at transport construction — the transport stores
+@@ -271,11 +278,33 @@ async function handleOAuthUnauthorized(provider, ctx, extraAuthOptions) {
+ * the token was minted for); providers that round-trip a single blob need no change.
+ */
+ function adaptOAuthProvider(provider, extraAuthOptions) {
++	const tokensByAccessToken = /* @__PURE__ */ new Map();
+ 	return {
+ 		token: async () => {
+-			return (await provider.tokens())?.access_token;
++			const tokens = await provider.tokens();
++			if (tokens?.access_token) {
++				if (!tokensByAccessToken.has(tokens.access_token) && tokensByAccessToken.size >= 8) {
++					tokensByAccessToken.delete(tokensByAccessToken.keys().next().value);
++				}
++				tokensByAccessToken.set(tokens.access_token, tokens);
++			}
++			return tokens?.access_token;
+ 		},
+-		onUnauthorized: async (ctx) => handleOAuthUnauthorized(provider, ctx, extraAuthOptions)
++		onUnauthorized: async (ctx) => {
++			const presentedTokens = ctx.presentedToken ? tokensByAccessToken.get(ctx.presentedToken) : void 0;
++			if (ctx.presentedToken) tokensByAccessToken.delete(ctx.presentedToken);
++			const continueDefault = async (options) => handleOAuthUnauthorized(provider, ctx, extraAuthOptions, options);
++			if (provider.onOAuthUnauthorized) {
++				await provider.onOAuthUnauthorized({
++					response: ctx.response,
++					serverUrl: ctx.serverUrl,
++					fetchFn: ctx.fetchFn,
++					presentedTokens
++				}, continueDefault);
++				return;
++			}
++			await continueDefault();
++		}
+ 	};
+ }
+ var UnauthorizedError = class extends Error {
+@@ -4707,6 +4736,7 @@ var SSEClientTransport = class {
+ 		this._fetchWithInit = require_src.createFetchWithInit(opts?.fetch, opts?.requestInit);
+ 	}
+ 	_last401Response;
++	_last401PresentedToken;
+ 	async _commonHeaders() {
+ 		const headers = {};
+ 		let token;
+@@ -4737,6 +4767,7 @@ var SSEClientTransport = class {
+ 					});
+ 					if (response.status === 401) {
+ 						this._last401Response = response;
++						this._last401PresentedToken = presentedBearerToken(headers, this._requestInit);
+ 						if (response.headers.has("www-authenticate")) {
+ 							const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response);
+ 							this._resourceMetadataUrl = resourceMetadataUrl;
+@@ -4751,12 +4782,15 @@ var SSEClientTransport = class {
+ 				if (event.code === 401 && this._authProvider) {
+ 					if (this._authProvider.onUnauthorized && this._last401Response) {
+ 						const response = this._last401Response;
++						const presentedToken = this._last401PresentedToken;
+ 						this._last401Response = void 0;
++						this._last401PresentedToken = void 0;
+ 						this._eventSource?.close();
+ 						this._authProvider.onUnauthorized({
+ 							response,
+ 							serverUrl: this._url,
+-							fetchFn: this._fetchWithInit
++							fetchFn: this._fetchWithInit,
++							presentedToken
+ 						}).then(() => this._startOrAuth().then(resolve, reject), (error$2) => {
+ 							markAuthSeamEscape(error$2);
+ 							this.onerror?.(error$2);
+@@ -4853,7 +4887,8 @@ var SSEClientTransport = class {
+ 							await this._authProvider.onUnauthorized({
+ 								response,
+ 								serverUrl: this._url,
+-								fetchFn: this._fetchWithInit
++								fetchFn: this._fetchWithInit,
++								presentedToken: presentedBearerToken(headers, this._requestInit)
+ 							});
+ 						} catch (error) {
+ 							throw markAuthSeamEscape(error);
+@@ -5108,7 +5143,8 @@ var StreamableHTTPClientTransport = class {
+ 							await this._authProvider.onUnauthorized({
+ 								response,
+ 								serverUrl: this._url,
+-								fetchFn: this._fetchWithInit
++								fetchFn: this._fetchWithInit,
++								presentedToken: presentedBearerToken(headers, this._requestInit)
+ 							});
+ 						} catch (error) {
+ 							throw markAuthSeamEscape(error);
+@@ -5345,7 +5381,8 @@ var StreamableHTTPClientTransport = class {
+ 							await this._authProvider.onUnauthorized({
+ 								response,
+ 								serverUrl: this._url,
+-								fetchFn: this._fetchWithInit
++								fetchFn: this._fetchWithInit,
++								presentedToken: presentedBearerToken(headers, this._requestInit)
+ 							});
+ 						} catch (error) {
+ 							throw markAuthSeamEscape(error);
+diff --git a/dist/index.d.cts b/dist/index.d.cts
+index 2d74180d5402a97f7460305726d8dc7da6105dcf..a717b50cf6efc6fb74b4c1394c3e3f3ff7342254 100644
+--- a/dist/index.d.cts
++++ b/dist/index.d.cts
+@@ -167,6 +167,13 @@ interface UnauthorizedContext {
+   /** Fetch function configured with the transport's `requestInit`, for making auth requests. */
+   fetchFn: FetchLike;
+ }
++/** Context for an OAuth provider's request-correlated 401 hook. */
++interface OAuthUnauthorizedContext extends UnauthorizedContext {
++  /** Exact token set used by the rejected request. Never log it. */
++  readonly presentedTokens?: Readonly<StoredOAuthTokens>;
++}
++/** Runs the SDK's existing OAuth 401 flow through token persistence. */
++type ContinueOAuthUnauthorized = (options?: { fetchFn?: FetchLike }) => Promise<void>;
+ /**
+  * Minimal interface for authenticating MCP client transports with bearer tokens.
+  *
+@@ -288,6 +295,11 @@ interface OAuthClientProvider {
+    *   keyed by `ctx.issuer`.
+    */
+   saveTokens(tokens: StoredOAuthTokens, ctx?: OAuthClientInformationContext): void | Promise<void>;
++  /**
++   * Optional request-correlated hook around the SDK's default post-401 OAuth flow.
++   * Calling `continueDefault()` performs discovery, refresh, and `saveTokens()`.
++   */
++  onOAuthUnauthorized?(context: OAuthUnauthorizedContext, continueDefault: ContinueOAuthUnauthorized): Promise<void>;
+   /**
+    * Invoked to redirect the user agent to the given URL to begin the authorization flow.
+    */
+@@ -2895,6 +2907,7 @@ declare class SSEClientTransport implements Transport {
+   onmessage?: (message: JSONRPCMessage) => void;
+   constructor(url: URL, opts?: SSEClientTransportOptions);
+   private _last401Response?;
++  private _last401PresentedToken?;
+   private _commonHeaders;
+   private _startOrAuth;
+   start(): Promise<void>;
+diff --git a/dist/index.d.mts b/dist/index.d.mts
+index d54447a08f0aa9876dacfe37f50ec1a48a77c132..10474dd36d463127d74243ead9137e770a4fa886 100644
+--- a/dist/index.d.mts
++++ b/dist/index.d.mts
+@@ -167,6 +167,13 @@ interface UnauthorizedContext {
+   /** Fetch function configured with the transport's `requestInit`, for making auth requests. */
+   fetchFn: FetchLike;
+ }
++/** Context for an OAuth provider's request-correlated 401 hook. */
++interface OAuthUnauthorizedContext extends UnauthorizedContext {
++  /** Exact token set used by the rejected request. Never log it. */
++  readonly presentedTokens?: Readonly<StoredOAuthTokens>;
++}
++/** Runs the SDK's existing OAuth 401 flow through token persistence. */
++type ContinueOAuthUnauthorized = (options?: { fetchFn?: FetchLike }) => Promise<void>;
+ /**
+  * Minimal interface for authenticating MCP client transports with bearer tokens.
+  *
+@@ -288,6 +295,11 @@ interface OAuthClientProvider {
+    *   keyed by `ctx.issuer`.
+    */
+   saveTokens(tokens: StoredOAuthTokens, ctx?: OAuthClientInformationContext): void | Promise<void>;
++  /**
++   * Optional request-correlated hook around the SDK's default post-401 OAuth flow.
++   * Calling `continueDefault()` performs discovery, refresh, and `saveTokens()`.
++   */
++  onOAuthUnauthorized?(context: OAuthUnauthorizedContext, continueDefault: ContinueOAuthUnauthorized): Promise<void>;
+   /**
+    * Invoked to redirect the user agent to the given URL to begin the authorization flow.
+    */
+@@ -2895,6 +2907,7 @@ declare class SSEClientTransport implements Transport {
+   onmessage?: (message: JSONRPCMessage) => void;
+   constructor(url: URL, opts?: SSEClientTransportOptions);
+   private _last401Response?;
++  private _last401PresentedToken?;
+   private _commonHeaders;
+   private _startOrAuth;
+   start(): Promise<void>;
+diff --git a/dist/index.mjs b/dist/index.mjs
+index f02ce3ca394e826fc27c9848dbe9a214bf6ba7a9..1c7496403ea92057e0f6fa4020d3d979a30cfebb 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -242,16 +242,23 @@ function isOAuthClientProvider(provider) {
+ * `WWW-Authenticate` parameters from the 401 response and runs {@linkcode auth}.
+ * Used by {@linkcode adaptOAuthProvider} to bridge `OAuthClientProvider` to `AuthProvider`.
+ */
+-async function handleOAuthUnauthorized(provider, ctx, extraAuthOptions) {
++async function handleOAuthUnauthorized(provider, ctx, extraAuthOptions, options) {
+ 	const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(ctx.response);
+ 	if (await auth(provider, {
+ 		serverUrl: ctx.serverUrl,
+ 		resourceMetadataUrl,
+ 		scope,
+-		fetchFn: ctx.fetchFn,
++		fetchFn: options?.fetchFn ?? ctx.fetchFn,
+ 		...extraAuthOptions
+ 	}) !== "AUTHORIZED") throw new UnauthorizedError();
+ }
++
++function presentedBearerToken(headers, requestInit) {
++	if (new Headers(requestInit?.headers).has("authorization")) return void 0;
++	const authorization = headers.get("authorization");
++	const match = authorization?.match(/^Bearer\s+(.+)$/i);
++	return match?.[1];
++}
+ /**
+ * Adapts an `OAuthClientProvider` to the minimal `AuthProvider` interface that
+ * transports consume. Called once at transport construction — the transport stores
+@@ -268,11 +275,33 @@ async function handleOAuthUnauthorized(provider, ctx, extraAuthOptions) {
+ * the token was minted for); providers that round-trip a single blob need no change.
+ */
+ function adaptOAuthProvider(provider, extraAuthOptions) {
++	const tokensByAccessToken = /* @__PURE__ */ new Map();
+ 	return {
+ 		token: async () => {
+-			return (await provider.tokens())?.access_token;
++			const tokens = await provider.tokens();
++			if (tokens?.access_token) {
++				if (!tokensByAccessToken.has(tokens.access_token) && tokensByAccessToken.size >= 8) {
++					tokensByAccessToken.delete(tokensByAccessToken.keys().next().value);
++				}
++				tokensByAccessToken.set(tokens.access_token, tokens);
++			}
++			return tokens?.access_token;
+ 		},
+-		onUnauthorized: async (ctx) => handleOAuthUnauthorized(provider, ctx, extraAuthOptions)
++		onUnauthorized: async (ctx) => {
++			const presentedTokens = ctx.presentedToken ? tokensByAccessToken.get(ctx.presentedToken) : void 0;
++			if (ctx.presentedToken) tokensByAccessToken.delete(ctx.presentedToken);
++			const continueDefault = async (options) => handleOAuthUnauthorized(provider, ctx, extraAuthOptions, options);
++			if (provider.onOAuthUnauthorized) {
++				await provider.onOAuthUnauthorized({
++					response: ctx.response,
++					serverUrl: ctx.serverUrl,
++					fetchFn: ctx.fetchFn,
++					presentedTokens
++				}, continueDefault);
++				return;
++			}
++			await continueDefault();
++		}
+ 	};
+ }
+ var UnauthorizedError = class extends Error {
+@@ -4704,6 +4733,7 @@ var SSEClientTransport = class {
+ 		this._fetchWithInit = createFetchWithInit(opts?.fetch, opts?.requestInit);
+ 	}
+ 	_last401Response;
++	_last401PresentedToken;
+ 	async _commonHeaders() {
+ 		const headers = {};
+ 		let token;
+@@ -4734,6 +4764,7 @@ var SSEClientTransport = class {
+ 					});
+ 					if (response.status === 401) {
+ 						this._last401Response = response;
++						this._last401PresentedToken = presentedBearerToken(headers, this._requestInit);
+ 						if (response.headers.has("www-authenticate")) {
+ 							const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response);
+ 							this._resourceMetadataUrl = resourceMetadataUrl;
+@@ -4748,12 +4779,15 @@ var SSEClientTransport = class {
+ 				if (event.code === 401 && this._authProvider) {
+ 					if (this._authProvider.onUnauthorized && this._last401Response) {
+ 						const response = this._last401Response;
++						const presentedToken = this._last401PresentedToken;
+ 						this._last401Response = void 0;
++						this._last401PresentedToken = void 0;
+ 						this._eventSource?.close();
+ 						this._authProvider.onUnauthorized({
+ 							response,
+ 							serverUrl: this._url,
+-							fetchFn: this._fetchWithInit
++							fetchFn: this._fetchWithInit,
++							presentedToken
+ 						}).then(() => this._startOrAuth().then(resolve, reject), (error$2) => {
+ 							markAuthSeamEscape(error$2);
+ 							this.onerror?.(error$2);
+@@ -4850,7 +4884,8 @@ var SSEClientTransport = class {
+ 							await this._authProvider.onUnauthorized({
+ 								response,
+ 								serverUrl: this._url,
+-								fetchFn: this._fetchWithInit
++								fetchFn: this._fetchWithInit,
++								presentedToken: presentedBearerToken(headers, this._requestInit)
+ 							});
+ 						} catch (error) {
+ 							throw markAuthSeamEscape(error);
+@@ -5105,7 +5140,8 @@ var StreamableHTTPClientTransport = class {
+ 							await this._authProvider.onUnauthorized({
+ 								response,
+ 								serverUrl: this._url,
+-								fetchFn: this._fetchWithInit
++								fetchFn: this._fetchWithInit,
++								presentedToken: presentedBearerToken(headers, this._requestInit)
+ 							});
+ 						} catch (error) {
+ 							throw markAuthSeamEscape(error);
+@@ -5342,7 +5378,8 @@ var StreamableHTTPClientTransport = class {
+ 							await this._authProvider.onUnauthorized({
+ 								response,
+ 								serverUrl: this._url,
+-								fetchFn: this._fetchWithInit
++								fetchFn: this._fetchWithInit,
++								presentedToken: presentedBearerToken(headers, this._requestInit)
+ 							});
+ 						} catch (error) {
+ 							throw markAuthSeamEscape(error);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,11 @@ overrides:
   qs: 6.15.3
   vite: 8.2.1
 
+patchedDependencies:
+  '@modelcontextprotocol/client@2.0.0':
+    hash: ce74b86bc77b1bbb6d6301bd03172fe109937888de77f7504bbca329848e991d
+    path: patches/@modelcontextprotocol__client@2.0.0.patch
+
 importers:
 
   .:
@@ -24,7 +29,7 @@ importers:
         version: 2.2.5
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
-        version: 2.0.0
+        version: 2.0.0(patch_hash=ce74b86bc77b1bbb6d6301bd03172fe109937888de77f7504bbca329848e991d)
       '@modelcontextprotocol/server':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1851,7 +1856,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@modelcontextprotocol/client@2.0.0':
+  '@modelcontextprotocol/client@2.0.0(patch_hash=ce74b86bc77b1bbb6d6301bd03172fe109937888de77f7504bbca329848e991d)':
     dependencies:
       '@modelcontextprotocol/core': 2.0.0
       cross-spawn: 7.0.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+minimumReleaseAge: 2880
 onlyBuiltDependencies:
   - esbuild
 overrides:
@@ -10,5 +11,5 @@ overrides:
   nanoid: 3.3.17
   qs: 6.15.3
   vite: 8.2.1
-
-minimumReleaseAge: 2880
+patchedDependencies:
+  '@modelcontextprotocol/client@2.0.0': patches/@modelcontextprotocol__client@2.0.0.patch

--- a/src/oauth-token-refresh.ts
+++ b/src/oauth-token-refresh.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'node:buffer';
 import type {
+  FetchLike,
   OAuthClientInformationMixed,
   OAuthProtectedResourceMetadata,
   OAuthTokens,
@@ -88,7 +89,7 @@ function decideUnderRefreshLock(
  *   that should have survived. Divergence resolves on its own: the next
  *   successful refresh saves to every store.
  */
-async function reconcilePersistedTokens(
+export async function reconcilePersistedTokens(
   definition: ServerDefinition,
   persistence: OAuthPersistence,
   logger?: Logger
@@ -401,7 +402,13 @@ async function refreshCachedOAuthTokenUnderLock(
 
 // Every request issued while the refresh lock is held carries a deadline.
 export function boundedRefreshFetch(input: string | URL, init?: RequestInit): Promise<Response> {
-  return fetch(input, { ...init, signal: init?.signal ?? AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS) });
+  return withRefreshRequestTimeout(fetch)(input, init);
+}
+
+/** Keeps a transport's fetch behavior while bounding requests made under the refresh lock. */
+export function withRefreshRequestTimeout(fetchFn: FetchLike): FetchLike {
+  return async (input, init) =>
+    await fetchFn(input, { ...init, signal: init?.signal ?? AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS) });
 }
 
 /**

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import http from 'node:http';
 import { URL } from 'node:url';
 import type {
+  FetchLike,
   OAuthClientInformationMixed,
   OAuthDiscoveryState,
   OAuthClientMetadata,
@@ -12,11 +13,19 @@ import type {
 } from '@modelcontextprotocol/client';
 import { validateClientMetadataUrl } from '@modelcontextprotocol/client';
 import type { ServerDefinition } from './config.js';
+import { isFileLockTimeoutError } from './fs-json.js';
 import { suppressBrowserLaunchFromEnv } from './oauth-browser-suppression.js';
 import { buildStaticClientInformation } from './oauth-client-info.js';
 import type { OAuthPersistence, OAuthPersistenceSnapshot } from './oauth-persistence.js';
 import { buildOAuthPersistence } from './oauth-persistence.js';
-import { oauthAccessTokenNeedsRefresh, readCachedAccessTokenWithPersistence } from './oauth-token-refresh.js';
+import { withRefreshLock } from './oauth-refresh-lock.js';
+import { sameOAuthTokenGeneration } from './oauth-token-generation.js';
+import {
+  oauthAccessTokenNeedsRefresh,
+  readCachedAccessTokenWithPersistence,
+  reconcilePersistedTokens,
+  withRefreshRequestTimeout,
+} from './oauth-token-refresh.js';
 
 const CALLBACK_HOST = '127.0.0.1';
 const CALLBACK_PATH = '/callback';
@@ -38,6 +47,13 @@ export interface OAuthSessionOptions {
   suppressBrowserLaunch?: boolean;
   onAuthorizationUrl?: (request: OAuthAuthorizationRequest) => void | Promise<void>;
 }
+
+interface OAuthUnauthorizedContext {
+  readonly fetchFn: FetchLike;
+  readonly presentedTokens?: Readonly<StoredOAuthTokens>;
+}
+
+type ContinueOAuthUnauthorized = (options?: { fetchFn?: FetchLike }) => Promise<void>;
 
 // Thrown when a refresh was due but could not complete, so the only tokens left
 // to hand the MCP SDK are expired ones that still carry a refresh token. The SDK
@@ -349,11 +365,11 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
    * SDK sees it.
    *
    * This is the interception point for SDK-driven refresh. The SDK redeems a
-   * rotating refresh token itself whenever tokens() hands it an expired one —
-   * proactively before connect and internally on a 401 — and neither call site
-   * is wrappable from here. Returning an already-refreshed token starves that
-   * branch, so the redemption happens once, under the lock, instead of racing
-   * every other process that shares the credential.
+   * rotating refresh token itself whenever tokens() hands it an expired one.
+   * Returning an already-refreshed token starves the proactive branch, so the
+   * redemption happens once under the lock instead of racing every other
+   * process that shares the credential. The distinct fresh-token post-401 path
+   * is wrapped by onOAuthUnauthorized().
    *
    * The locked transaction is re-entrant per call chain, so an SDK auth() flow
    * that already holds the lock does not deadlock on this read.
@@ -365,12 +381,6 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
    * re-persists this method's return value when `issuer` is unset and would
    * destroy the token instead. So when a due refresh does not produce a usable
    * token, this fails the connect rather than offering a redeemable stale one.
-   *
-   * Known and accepted limit (issue #305): a 401 makes the SDK redeem the token
-   * this method returns even when it is fresh, and that call site has no seam to
-   * wrap. Two processes taking a 401 at the same instant can still redeem
-   * concurrently; the rejected-refresh recovery in oauth-token-refresh.ts
-   * remains the backstop for that case.
    */
   private async refreshedTokens(stored: StoredOAuthTokens | undefined): Promise<StoredOAuthTokens | undefined> {
     if (!stored || this.definition.auth === 'refreshable_bearer') {
@@ -400,6 +410,39 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
   async saveTokens(tokens: StoredOAuthTokens): Promise<void> {
     await this.persistence.saveTokens(tokens);
     this.logger.info(`Saved OAuth tokens for ${this.definition.name} (${this.persistence.describe()})`);
+  }
+
+  /**
+   * Keeps the SDK's post-401 refresh transaction inside the same cross-process
+   * lock as proactive refresh. The SDK supplies the exact tokens attached to
+   * the rejected request, so a waiter can distinguish its stale generation
+   * from the winner another process persisted while it waited.
+   */
+  async onOAuthUnauthorized(
+    context: OAuthUnauthorizedContext,
+    continueDefault: ContinueOAuthUnauthorized
+  ): Promise<void> {
+    const rejected = context.presentedTokens;
+    if (!rejected) {
+      throw new OAuthRefreshUnavailableError(this.definition.name);
+    }
+    try {
+      await withRefreshLock(this.definition, async () => {
+        const latest = await reconcilePersistedTokens(this.definition, this.persistence);
+        if (!latest) {
+          throw new OAuthRefreshUnavailableError(this.definition.name);
+        }
+        if (!sameOAuthTokenGeneration(latest, rejected)) {
+          return;
+        }
+        await continueDefault({ fetchFn: withRefreshRequestTimeout(context.fetchFn) });
+      });
+    } catch (error) {
+      if (isFileLockTimeoutError(error)) {
+        throw new OAuthRefreshUnavailableError(this.definition.name, { cause: error });
+      }
+      throw error;
+    }
   }
 
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {

--- a/tests/fixtures/oauth-refresh-process.mjs
+++ b/tests/fixtures/oauth-refresh-process.mjs
@@ -3,6 +3,7 @@ import { buildOAuthPersistence, readCachedAccessToken } from '../../dist/oauth-p
 import { withRefreshLock } from '../../dist/oauth-refresh-lock.js';
 import { createOAuthSession } from '../../dist/oauth.js';
 import { connectWithAuth } from '../../dist/runtime/oauth.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 
 const action = process.argv[2];
 const endpoint = process.env.MCPORTER_TEST_OAUTH_ENDPOINT;
@@ -50,6 +51,20 @@ if (action === 'seed') {
     token_type: 'Bearer',
     refresh_token: seedRefreshToken,
     expires_at: 1,
+  });
+  emit({ seeded: true, refreshMarker: marker(seedRefreshToken) });
+} else if (action === 'seed-post-401') {
+  const persistence = await buildOAuthPersistence(definition, logger);
+  await persistence.saveClientInfo({
+    client_id: 'fresh-process-client',
+    redirect_uris: ['http://127.0.0.1:41000/callback'],
+    token_endpoint_auth_method: 'none',
+  });
+  await persistence.saveTokens({
+    access_token: 'post-401-access',
+    token_type: 'Bearer',
+    refresh_token: seedRefreshToken,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
   });
   emit({ seeded: true, refreshMarker: marker(seedRefreshToken) });
 } else if (action === 'refresh') {
@@ -114,6 +129,25 @@ if (action === 'seed') {
   emit({
     authorizationPrompts,
     refreshUnavailable,
+    persistedAccessMarker: marker(stored.tokens?.access_token),
+    persistedRefreshMarker: marker(stored.tokens?.refresh_token),
+  });
+} else if (action === 'post-401-refresh') {
+  const session = await createOAuthSession(definition, logger, { suppressBrowserLaunch: true });
+  const transport = new StreamableHTTPClientTransport(new URL(endpoint), { authProvider: session.provider });
+  try {
+    await transport.start();
+    await transport.send({
+      jsonrpc: '2.0',
+      method: 'notifications/progress',
+      params: { progressToken: 'post-401', progress: 1 },
+    });
+  } finally {
+    await transport.close().catch(() => {});
+    await session.close().catch(() => {});
+  }
+  const stored = await snapshot();
+  emit({
     persistedAccessMarker: marker(stored.tokens?.access_token),
     persistedRefreshMarker: marker(stored.tokens?.refresh_token),
   });

--- a/tests/oauth-refresh-process.integration.test.ts
+++ b/tests/oauth-refresh-process.integration.test.ts
@@ -45,6 +45,10 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
   let replays: URLSearchParams[] = [];
   let issuedByFamily: Map<string, number>;
   let transientFailuresRemaining = 0;
+  let post401InitialRequests = 0;
+  let post401RetryRequests = 0;
+  let releasePost401Requests: (() => void) | undefined;
+  let post401RequestsArrived: Promise<void> | undefined;
   // Set to hold the first token request open until a second family arrives, so
   // "unrelated identities refresh concurrently" is proven by overlap.
   let overlapBarrier: { arrived: Map<string, () => void>; release: Promise<void> } | undefined;
@@ -114,6 +118,27 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
           expires_in: 3600,
         });
       }
+      if (url.pathname === '/mcp') {
+        const authorization = request.headers.authorization;
+        if (authorization === 'Bearer post-401-access') {
+          post401InitialRequests += 1;
+          if (post401InitialRequests === 2) releasePost401Requests?.();
+          await post401RequestsArrived;
+          response.statusCode = 401;
+          response.setHeader(
+            'WWW-Authenticate',
+            `Bearer resource_metadata="${authOrigin}/.well-known/oauth-protected-resource"`
+          );
+          response.end('unauthorized');
+          return;
+        }
+        if (authorization === 'Bearer access-post-401-1') {
+          post401RetryRequests += 1;
+          response.statusCode = 202;
+          response.end();
+          return;
+        }
+      }
       response.statusCode = 404;
       response.end('not found');
     });
@@ -137,6 +162,10 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
     revokedFamilies = new Set();
     issuedByFamily = new Map();
     transientFailuresRemaining = 0;
+    post401InitialRequests = 0;
+    post401RetryRequests = 0;
+    releasePost401Requests = undefined;
+    post401RequestsArrived = undefined;
     overlapBarrier = undefined;
   });
 
@@ -242,6 +271,36 @@ describe('OAuth refresh across fresh built-artifact processes', () => {
       budget(60_000)
     );
   }
+
+  it(
+    'redeems exactly once when two processes receive 401 for the same fresh token',
+    async () => {
+      const seed = 'post-401-seed';
+      registerSeed(seed, 'post-401');
+      const env = await freshEnv('post-401-refresh', seed);
+      await runFixture('seed-post-401', env);
+
+      post401RequestsArrived = new Promise<void>((resolve) => {
+        releasePost401Requests = resolve;
+      });
+      const outputs = await Promise.all(
+        Array.from({ length: 2 }, () => runFixture('post-401-refresh', env).then((raw) => JSON.parse(raw)))
+      );
+
+      expect(post401InitialRequests).toBe(2);
+      expect(post401RetryRequests).toBe(2);
+      expect(tokenRequests.filter((request) => request.get('refresh_token') === seed)).toHaveLength(1);
+      expect(replays).toHaveLength(0);
+      expect(revokedFamilies.has('post-401')).toBe(false);
+      for (const output of outputs) {
+        expect(output.persistedAccessMarker).toBe(marker('access-post-401-1'));
+        expect(output.persistedRefreshMarker).toBe(marker('rotated-post-401-1'));
+        expect(JSON.stringify(output)).not.toContain('access-post-401-1');
+        expect(JSON.stringify(output)).not.toContain('rotated-post-401-1');
+      }
+    },
+    budget(30_000)
+  );
 
   it(
     'lets unrelated credential identities refresh at the same time',


### PR DESCRIPTION
## Summary

The 0.13.4 refresh lock covered MCPorter-controlled expired and proactive refreshes, but the SDK's automatic post-401 `auth()` continuation still redeemed a fresh rejected token after `provider.tokens()` returned. Two processes receiving the same 401 could therefore redeem the same rotating refresh token concurrently and trigger provider-side replay revocation.

This change adds the missing request-correlated SDK seam and routes the continuation through MCPorter's existing credential refresh lock:

- The SDK adapter records the exact token set attached to each request and passes it to an optional OAuth unauthorized hook for Streamable HTTP GET/POST and legacy SSE GET/POST.
- Explicit Authorization header overrides carry no provider-token provenance.
- MCPorter acquires the existing per-credential cross-process lock, re-reads reconciled persistence, and compares generations.
- A waiter adopts the winner without redeeming again; an unchanged generation runs the SDK's discovery, redemption, and `saveTokens()` continuation while the lock remains held.
- Lock timeout and missing provenance fail closed, and token/discovery requests preserve the transport fetch implementation with the existing 10-second refresh deadline.

The SDK v2 seam is carried as a pnpm dependency patch so `finishAuth()` and 403 scope step-up continue using the original OAuth provider rather than a local transport replacement.

Closes #307.

## Proof

Built-artifact two-process regression against a rotating-token provider:

- both processes send the same still-fresh rejected access token before either receives 401
- exactly one refresh-token redemption
- zero replay attempts and no family revocation
- both SDK retries use the persisted winner

Standalone live proof against a real local OAuth/MCP HTTP server, outside the test runner:

```text
{"initial401s":2,"retries":2,"redemptions":1,"replays":0,"converged":true}
```

Validation:

```text
pnpm check
# format, type-aware lint, and TypeScript passed

pnpm exec vitest run tests/oauth-refresh-process.integration.test.ts
# 1 file passed, 11 tests passed

pnpm test
# 191 files passed, 4 skipped; 1601 tests passed, 26 skipped

pnpm install --frozen-lockfile
# lockfile up to date; dependency patch reapplies cleanly
```

The known `tests/oauth-session.test.ts` callback-server close flake did not reproduce in either full run. This fix changes the provider's post-401 transaction hook, not callback-server shutdown, so that lifecycle code remains untouched.
