### PR TITLE
fix(daemon): wait for relay discovery startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 ### CLI
 
 - Discover OpenClaw's active Chrome extension relay endpoint automatically, while preserving the explicit environment override and legacy `127.0.0.1:18799` fallback.
+- Report connection failures once at the prepared-call boundary instead of duplicating the same offline diagnostic during auto-correction.
+
+### Daemon
+
+- Allow up to 45 seconds for cold starts in automatic and explicit daemon launches, with one slow-start hint for Chrome relay discovery and actionable foreground logging guidance on timeout.
 
 ## [0.13.4] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [0.13.6] - Unreleased
 
+### CLI
+
+- Report connection failures once at the prepared-call boundary instead of duplicating the same offline diagnostic during auto-correction.
+
+### Daemon
+
+- Allow up to 45 seconds for cold starts in automatic and explicit daemon launches, with one slow-start hint for Chrome relay discovery and actionable foreground logging guidance on timeout.
+
 ### OAuth
 
 - Keep the SDK's automatic post-401 token redemption inside the cross-process refresh lock, so simultaneous rejected requests adopt one rotated token generation instead of replaying and revoking the shared token family. (Issue #307)
@@ -11,11 +19,6 @@
 ### CLI
 
 - Discover OpenClaw's active Chrome extension relay endpoint automatically, while preserving the explicit environment override and legacy `127.0.0.1:18799` fallback.
-- Report connection failures once at the prepared-call boundary instead of duplicating the same offline diagnostic during auto-correction.
-
-### Daemon
-
-- Allow up to 45 seconds for cold starts in automatic and explicit daemon launches, with one slow-start hint for Chrome relay discovery and actionable foreground logging guidance on timeout.
 
 ## [0.13.4] - 2026-08-11
 

--- a/src/cli/call-command.ts
+++ b/src/cli/call-command.ts
@@ -598,7 +598,6 @@ async function attemptCall(
 
     const resolution = await maybeResolveToolName(runtime, server, tool, error, disableOAuth);
     if (!resolution) {
-      maybeReportConnectionIssue(server, tool, error);
       throw error;
     }
 

--- a/src/cli/daemon-command.ts
+++ b/src/cli/daemon-command.ts
@@ -4,6 +4,7 @@ import { DaemonClient, resolveDaemonPaths } from '../daemon/client.js';
 import { runDaemonHost } from '../daemon/host.js';
 import { launchDaemonDetached } from '../daemon/launch.js';
 import { getDaemonLogPath } from '../daemon/paths.js';
+import { waitForDaemonReady } from '../daemon/startup-readiness.js';
 import { expandHome } from '../env.js';
 import { isKeepAliveServer } from '../lifecycle.js';
 import { createRuntime } from '../runtime.js';
@@ -131,10 +132,7 @@ async function handleDaemonStart(args: string[], options: DaemonCliOptions, clie
     socketPath,
     extraArgs: forwardedArgs,
   });
-  const ready = await waitFor(() => client.status(), 10_000, 100);
-  if (!ready) {
-    throw new Error('Failed to start daemon before timeout expired.');
-  }
+  await waitForDaemonReady((timeoutMs) => client.status(timeoutMs));
   console.log(`Daemon started for ${keepAlive.length} server(s).`);
 }
 

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -19,6 +19,7 @@ import {
   resolveProgressInterval,
 } from './protocol.js';
 import { delay } from './request-utils.js';
+import { waitForDaemonReady } from './startup-readiness.js';
 import type {
   CallToolParams,
   CloseServerParams,
@@ -104,8 +105,8 @@ export class DaemonClient {
     await this.invoke('closeServer', params);
   }
 
-  async status(): Promise<StatusResult | null> {
-    return await this.readVerifiedStatus();
+  async status(timeoutMs?: number): Promise<StatusResult | null> {
+    return await this.readVerifiedStatus(timeoutMs);
   }
 
   async stop(): Promise<void> {
@@ -214,14 +215,7 @@ export class DaemonClient {
   }
 
   private async waitForReady(): Promise<void> {
-    const deadline = Date.now() + 10_000;
-    while (Date.now() < deadline) {
-      if (await this.isResponsive()) {
-        return;
-      }
-      await delay(100);
-    }
-    throw new Error('Timeout while waiting for MCPorter daemon to start.');
+    await waitForDaemonReady((timeoutMs) => this.readVerifiedStatus(timeoutMs));
   }
 
   private async isResponsive(timeoutMs?: number): Promise<boolean> {

--- a/src/daemon/startup-readiness.ts
+++ b/src/daemon/startup-readiness.ts
@@ -1,0 +1,63 @@
+export const DAEMON_STARTUP_TIMEOUT_MS = 45_000;
+
+const DAEMON_STARTUP_SLOW_NOTICE_MS = 5_000;
+const DAEMON_STARTUP_POLL_INTERVAL_MS = 100;
+
+export interface DaemonStartupReadinessTiming {
+  readonly now?: () => number;
+  readonly delay?: (ms: number) => Promise<void>;
+  readonly reportSlowStart?: () => void;
+}
+
+export async function waitForDaemonReady<T>(
+  probe: (timeoutMs: number) => Promise<T | null>,
+  timing: DaemonStartupReadinessTiming = {}
+): Promise<T> {
+  const now = timing.now ?? Date.now;
+  const wait = timing.delay ?? delay;
+  const reportSlowStart = timing.reportSlowStart ?? defaultSlowStartReporter;
+  const startedAt = now();
+  const deadline = startedAt + DAEMON_STARTUP_TIMEOUT_MS;
+  let reportedSlowStart = false;
+
+  while (true) {
+    const remainingBeforeProbe = deadline - now();
+    if (remainingBeforeProbe <= 0) {
+      throw daemonStartupTimeoutError();
+    }
+
+    const result = await probe(Math.min(DAEMON_STARTUP_POLL_INTERVAL_MS, remainingBeforeProbe));
+    if (result !== null) {
+      return result;
+    }
+
+    const currentTime = now();
+    if (currentTime >= deadline) {
+      throw daemonStartupTimeoutError();
+    }
+    if (!reportedSlowStart && currentTime - startedAt >= DAEMON_STARTUP_SLOW_NOTICE_MS) {
+      reportedSlowStart = true;
+      reportSlowStart();
+    }
+
+    await wait(Math.min(DAEMON_STARTUP_POLL_INTERVAL_MS, deadline - currentTime));
+  }
+}
+
+function defaultSlowStartReporter(): void {
+  console.error(
+    '[mcporter] Daemon startup is taking longer than usual; Chrome relay discovery can take up to 30 seconds.'
+  );
+}
+
+function daemonStartupTimeoutError(): Error {
+  return new Error(
+    "MCPorter daemon did not become ready within 45 seconds. Run 'mcporter daemon start --foreground --log' to diagnose startup."
+  );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/tests/cli-call-errors.test.ts
+++ b/tests/cli-call-errors.test.ts
@@ -47,4 +47,19 @@ describe('CLI call error reporting', () => {
     logSpy.mockRestore();
     errorSpy.mockRestore();
   });
+
+  it('reports an offline connection failure once', async () => {
+    const { handleCall } = await cliModulePromise;
+    const runtime = {
+      callTool: vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:9000')),
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Awaited<ReturnType<(typeof import('../src/runtime.js'))['createRuntime']>>;
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(handleCall(runtime, ['local.run'])).rejects.toThrow('ECONNREFUSED');
+
+    const offlineDiagnostics = errorSpy.mock.calls.filter((call) => call.join(' ').includes('appears offline'));
+    expect(offlineDiagnostics).toHaveLength(1);
+    errorSpy.mockRestore();
+  });
 });

--- a/tests/daemon-cli-command.test.ts
+++ b/tests/daemon-cli-command.test.ts
@@ -8,6 +8,7 @@ const runDaemonHostMock = vi.fn();
 const createRuntimeMock = vi.fn();
 const isKeepAliveServerMock = vi.fn(() => true);
 const DaemonClientMock = vi.fn();
+const waitForDaemonReadyMock = vi.fn();
 
 vi.mock('node:fs/promises', () => ({
   default: { mkdir: mkdirMock },
@@ -35,6 +36,10 @@ vi.mock('../src/daemon/paths.js', () => ({
   getDaemonLogPath: vi.fn(() => '/tmp/mock-daemon.log'),
 }));
 
+vi.mock('../src/daemon/startup-readiness.js', () => ({
+  waitForDaemonReady: (...args: unknown[]) => waitForDaemonReadyMock(...args),
+}));
+
 vi.mock('../src/env.js', () => ({
   expandHome: (value: string) => value,
 }));
@@ -59,6 +64,10 @@ describe('daemon CLI restart', () => {
     createRuntimeMock.mockReset();
     isKeepAliveServerMock.mockReset();
     DaemonClientMock.mockReset();
+    waitForDaemonReadyMock.mockReset();
+    waitForDaemonReadyMock.mockImplementation(async (probe: (timeoutMs: number) => Promise<unknown>) => {
+      return (await probe(100)) ?? (await probe(100));
+    });
     DaemonClientMock.mockImplementation(function MockDaemonClient() {
       return {
         stop: stopMock,
@@ -232,6 +241,7 @@ describe('daemon CLI restart', () => {
       expect(launchDaemonDetachedMock).toHaveBeenCalledWith(
         expect.objectContaining({ extraArgs: ['--log-file', expect.stringMatching(/daemon\.log$/u)] })
       );
+      expect(waitForDaemonReadyMock).toHaveBeenCalledOnce();
       expect(log).toHaveBeenCalledWith('Daemon started for 1 server(s).');
     } finally {
       log.mockRestore();

--- a/tests/daemon-startup-readiness.test.ts
+++ b/tests/daemon-startup-readiness.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DAEMON_STARTUP_TIMEOUT_MS, waitForDaemonReady } from '../src/daemon/startup-readiness.js';
+
+describe('daemon startup readiness', () => {
+  it('keeps polling beyond ten seconds and reports a slow start once', async () => {
+    let currentTime = 0;
+    const probe = vi.fn(async () => (currentTime >= 12_000 ? { pid: 42 } : null));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const result = await waitForDaemonReady(probe, {
+        now: () => currentTime,
+        delay: async (ms) => {
+          currentTime += ms;
+        },
+      });
+
+      expect(result).toEqual({ pid: 42 });
+      expect(currentTime).toBe(12_000);
+      expect(errorSpy).toHaveBeenCalledOnce();
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[mcporter] Daemon startup is taking longer than usual; Chrome relay discovery can take up to 30 seconds.'
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('times out at 45 seconds with foreground logging guidance', async () => {
+    let currentTime = 0;
+
+    const readiness = waitForDaemonReady(async () => null, {
+      now: () => currentTime,
+      delay: async (ms) => {
+        currentTime += ms;
+      },
+      reportSlowStart: vi.fn(),
+    });
+
+    await expect(readiness).rejects.toThrow(
+      "MCPorter daemon did not become ready within 45 seconds. Run 'mcporter daemon start --foreground --log' to diagnose startup."
+    );
+    expect(currentTime).toBe(DAEMON_STARTUP_TIMEOUT_MS);
+  });
+});


### PR DESCRIPTION
## Summary

- share one 45-second cold-start readiness policy between automatic and explicit daemon launches
- emit one slow-start hint after five seconds, with actionable foreground logging guidance on timeout
- report offline connection failures once instead of duplicating the same diagnostic during auto-correction

## Why

Chrome extension relay discovery can take up to 30 seconds. The daemon launcher previously stopped waiting after 10 seconds, so a healthy daemon could become ready immediately after the initiating CLI had already failed.

## Proof

- `pnpm check`
- `pnpm test` (192 passed, 4 skipped; 1604 tests passed, 26 skipped)
- focused daemon and CLI regression suite (18 passed)
- source-blind CLI validation: 11.394-second startup succeeded with one notice; true timeout failed at 45.212 seconds with foreground-log guidance; offline JSON output stayed parseable with one diagnostic
- autoreview clean
