### PR TITLE
chore(release): prepare 0.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # mcporter Changelog
 
-## [0.13.6] - Unreleased
+## [0.13.6] - 2026-08-13
 
 ### CLI
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcporter",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "TypeScript runtime and CLI for connecting to configured Model Context Protocol servers.",
   "keywords": [
     "cli",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   fast-uri: 3.1.5
   hono: 4.13.0
   ip-address: 10.4.0
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   qs: 6.15.3
   vite: 8.2.1
 
@@ -1362,8 +1362,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2675,7 +2675,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   negotiator@1.0.0: {}
 
@@ -2787,7 +2787,7 @@ snapshots:
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ overrides:
   fast-uri: 3.1.5
   hono: 4.13.0
   ip-address: 10.4.0
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   qs: 6.15.3
   vite: 8.2.1
 patchedDependencies:

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -433,7 +433,11 @@ def named_step(job, name)
   job.fetch('steps').find { |step| step['name'] == name }
 end
 
-publish = YAML.safe_load_file(ENV.fetch('PUBLISH_WORKFLOW'), aliases: true)
+def safe_load_yaml(path)
+  YAML.safe_load(File.read(path), aliases: true)
+end
+
+publish = safe_load_yaml(ENV.fetch('PUBLISH_WORKFLOW'))
 publish_jobs = publish.fetch('jobs')
 release_job = publish_jobs.fetch('release')
 proof_step = named_step(release_job, 'Verify protected native proof and published assets')
@@ -448,7 +452,7 @@ contract_assert(dispatch_step, 'protected Homebrew dispatch step is missing')
 contract_assert(dispatch_job.dig('permissions', 'actions') == 'write', 'same-repository dispatch lacks actions: write')
 contract_assert(dispatch_step.dig('env', 'GH_TOKEN') == '${{ github.token }}', 'same-repository dispatch does not use github.token')
 
-homebrew = YAML.safe_load_file(ENV.fetch('HOMEBREW_WORKFLOW'), aliases: true)
+homebrew = safe_load_yaml(ENV.fetch('HOMEBREW_WORKFLOW'))
 contract_assert(homebrew.dig('permissions', 'actions') == 'read', 'Homebrew proof workflow lacks actions: read')
 homebrew_job = homebrew.fetch('jobs').fetch('update-homebrew-tap')
 homebrew_proof = named_step(homebrew_job, 'Verify protected release for tap update')


### PR DESCRIPTION
## Summary

- prepare version 0.13.6 and date the changelog entry for 2026-08-13
- update the nanoid override to 3.3.18 to remediate the advisory
- keep release-contract YAML checks compatible with Ruby Psych while preserving safe loading and alias support

## Verification

- `pnpm check`
- 192 test files / 1604 tests
- Node build
- Bun build
- release-contract tests
- `pnpm audit` with no vulnerabilities
