### PR TITLE
docs(changelog): open 0.13.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # mcporter Changelog
 
+## [0.13.7] - Unreleased
+
 ## [0.13.6] - 2026-08-13
 
 ### CLI


### PR DESCRIPTION
Open the 0.13.7 Unreleased changelog section after the 0.13.6 release.