### PR TITLE
fix(http): isolate OAuth request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.13.7] - Unreleased
 
+### OAuth
+
+- Keep MCP transport headers out of OAuth discovery and send an identifying User-Agent from the HTTP/1.1 SSE compatibility path, preventing misleading 403 responses from header-sensitive load balancers. (Issues #320 and #321)
+
 ### Maintenance
 
 - Retry transient Homebrew tap workflow API failures and propagation gaps with bounded backoff while preserving request-correlated release proof.

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -33,6 +33,12 @@ const CALLBACK_PATH = '/callback';
 // authorization older than this is treated as abandoned so a later request can prompt again.
 const INTERACTIVE_AUTHORIZATION_TTL_MS = 300_000;
 
+const oauthJsonFetch: FetchLike = (input, init = {}) => {
+  const headers = new Headers(init.headers);
+  headers.set('accept', 'application/json');
+  return fetch(input, { ...init, headers });
+};
+
 export interface OAuthAuthorizationRequest {
   authorizationUrl: string;
   redirectUrl: string;
@@ -435,7 +441,10 @@ class PersistentOAuthClientProvider implements OAuthClientProvider {
         if (!sameOAuthTokenGeneration(latest, rejected)) {
           return;
         }
-        await continueDefault({ fetchFn: withRefreshRequestTimeout(context.fetchFn) });
+        // OAuth metadata, registration, and token requests are ordinary JSON HTTP
+        // traffic. The transport fetch carries MCP requestInit headers (including
+        // text/event-stream), which can misclassify discovery GETs as SSE.
+        await continueDefault({ fetchFn: withRefreshRequestTimeout(oauthJsonFetch) });
       });
     } catch (error) {
       if (isFileLockTimeoutError(error)) {

--- a/src/runtime/node-http-fetch.ts
+++ b/src/runtime/node-http-fetch.ts
@@ -3,6 +3,7 @@ import https from 'node:https';
 import { Buffer } from 'node:buffer';
 import { Readable } from 'node:stream';
 import type { FetchLike } from '@modelcontextprotocol/client';
+import { MCPORTER_VERSION } from '../version.js';
 
 const MAX_REDIRECTS = 20;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
@@ -44,6 +45,9 @@ async function nodeHttp1FetchWithRedirects(
   }
 
   const headers = normalizeRequestHeaders(init.headers);
+  if (!hasHeader(headers, 'user-agent')) {
+    headers['user-agent'] = `mcporter/${MCPORTER_VERSION}`;
+  }
   const body = await materializeRequestBody(init.body);
   if (body !== undefined && !hasHeader(headers, 'content-length') && !hasHeader(headers, 'transfer-encoding')) {
     headers['content-length'] = String(Buffer.byteLength(body));

--- a/tests/node-http-fetch.test.ts
+++ b/tests/node-http-fetch.test.ts
@@ -2,6 +2,7 @@ import { createServer } from 'node:http';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createSseIsolatedFetch, nodeHttp1Fetch } from '../src/runtime/node-http-fetch.js';
+import { MCPORTER_VERSION } from '../src/version.js';
 
 let cleanup: (() => Promise<void>) | undefined;
 
@@ -11,6 +12,34 @@ afterEach(async () => {
 });
 
 describe('nodeHttp1Fetch', () => {
+  it('identifies mcporter when the caller does not provide a User-Agent', async () => {
+    let userAgent: string | undefined;
+    const { baseUrl, close } = await serve((request, response) => {
+      userAgent = request.headers['user-agent'];
+      response.writeHead(userAgent ? 200 : 403, { 'content-type': 'text/plain' });
+      response.end(userAgent ? 'ok' : 'missing User-Agent');
+    });
+    cleanup = close;
+
+    const response = await nodeHttp1Fetch(baseUrl);
+
+    expect(response.status).toBe(200);
+    expect(userAgent).toBe(`mcporter/${MCPORTER_VERSION}`);
+  });
+
+  it('preserves an explicit User-Agent', async () => {
+    let userAgent: string | undefined;
+    const { baseUrl, close } = await serve((request, response) => {
+      userAgent = request.headers['user-agent'];
+      response.end('ok');
+    });
+    cleanup = close;
+
+    await nodeHttp1Fetch(baseUrl, { headers: { 'User-Agent': 'custom-client/1.0' } });
+
+    expect(userAgent).toBe('custom-client/1.0');
+  });
+
   it('isolates only event-stream GET requests from the default fetch', async () => {
     const { baseUrl, close } = await serve((_request, response) => {
       response.writeHead(200, { 'content-type': 'text/plain' });

--- a/tests/oauth-session.test.ts
+++ b/tests/oauth-session.test.ts
@@ -5,7 +5,7 @@ import type { AddressInfo } from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { auth as sdkAuth, resolveClientMetadata } from '@modelcontextprotocol/client';
+import { auth as sdkAuth, discoverOAuthServerInfo, resolveClientMetadata } from '@modelcontextprotocol/client';
 import type { ServerDefinition } from '../src/config.js';
 import { __oauthInternals, createOAuthSession, OAuthRedirectUriMismatchError } from '../src/oauth.js';
 import { loadVaultEntry } from '../src/oauth-vault.js';
@@ -132,6 +132,56 @@ describe('FileOAuthClientProvider session lifecycle', () => {
     expect(session.provider.clientMetadataUrl).toBe('https://client.example.com/oauth/metadata.json');
     expect(resolveClientMetadata(session.provider).application_type).toBe('native');
     await session.close();
+  });
+
+  it('keeps the MCP event-stream Accept value out of post-401 OAuth discovery', async () => {
+    const tokenCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-oauth-test-'));
+    tempDirs.push(tokenCacheDir);
+    const discovery = await startSeparatedOAuthDiscoveryServers();
+    const definition: ServerDefinition = {
+      name: 'test-oauth-fetch-isolation',
+      command: {
+        kind: 'http',
+        url: new URL(discovery.serverUrl),
+        headers: { accept: 'application/json, text/event-stream' },
+      },
+      auth: 'oauth',
+      tokenCacheDir,
+    };
+    const session = await createOAuthSession(definition, { info: vi.fn(), warn: vi.fn(), error: vi.fn() });
+    await session.provider.saveTokens({
+      access_token: 'rejected-access-token',
+      token_type: 'Bearer',
+      refresh_token: 'refresh-token',
+    });
+    const presentedTokens = await session.provider.tokens();
+    expect(presentedTokens).toBeDefined();
+    const transportFetch = vi.fn(async () => {
+      throw new Error('OAuth discovery used the MCP transport fetch');
+    });
+
+    try {
+      await session.provider.onOAuthUnauthorized?.(
+        {
+          response: new Response(null, { status: 401 }),
+          serverUrl: new URL(discovery.serverUrl),
+          fetchFn: transportFetch,
+          presentedTokens: presentedTokens!,
+        },
+        async (options) => {
+          await discoverOAuthServerInfo(discovery.serverUrl, { fetchFn: options?.fetchFn });
+        }
+      );
+
+      expect(transportFetch).not.toHaveBeenCalled();
+      expect(discovery.requests).toEqual([
+        { origin: 'resource', accept: 'application/json' },
+        { origin: 'authorization', accept: 'application/json' },
+      ]);
+    } finally {
+      await session.close();
+      await discovery.close();
+    }
   });
 
   it('does not leave a callback listener bound when CIMD configuration is invalid', async () => {
@@ -1011,6 +1061,58 @@ async function startOAuthMetadataServer(supportsUrlBasedClientId: boolean): Prom
     serverUrl,
     registrationCount: () => registrations,
     close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+async function startSeparatedOAuthDiscoveryServers(): Promise<{
+  serverUrl: string;
+  requests: Array<{ origin: 'resource' | 'authorization'; accept: string | undefined }>;
+  close: () => Promise<void>;
+}> {
+  const requests: Array<{ origin: 'resource' | 'authorization'; accept: string | undefined }> = [];
+  let authorizationOrigin = '';
+  const authorizationServer = http.createServer((request, response) => {
+    requests.push({ origin: 'authorization', accept: request.headers.accept });
+    sendJson(response, {
+      issuer: authorizationOrigin,
+      authorization_endpoint: `${authorizationOrigin}/authorize`,
+      token_endpoint: `${authorizationOrigin}/token`,
+      registration_endpoint: `${authorizationOrigin}/register`,
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      token_endpoint_auth_methods_supported: ['none'],
+      code_challenge_methods_supported: ['S256'],
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    authorizationServer.once('error', reject);
+    authorizationServer.listen(0, '127.0.0.1', resolve);
+  });
+  authorizationOrigin = `http://127.0.0.1:${(authorizationServer.address() as AddressInfo).port}`;
+
+  let resourceOrigin = '';
+  const resourceServer = http.createServer((request, response) => {
+    requests.push({ origin: 'resource', accept: request.headers.accept });
+    sendJson(response, {
+      resource: `${resourceOrigin}/mcp`,
+      authorization_servers: [authorizationOrigin],
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    resourceServer.once('error', reject);
+    resourceServer.listen(0, '127.0.0.1', resolve);
+  });
+  resourceOrigin = `http://127.0.0.1:${(resourceServer.address() as AddressInfo).port}`;
+
+  return {
+    serverUrl: `${resourceOrigin}/mcp`,
+    requests,
+    close: async () => {
+      await Promise.all([
+        new Promise<void>((resolve) => resourceServer.close(() => resolve())),
+        new Promise<void>((resolve) => authorizationServer.close(() => resolve())),
+      ]);
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

- add a default `mcporter/<version>` User-Agent to the Node HTTP/1.1 compatibility fetch while preserving caller overrides
- keep MCP transport request headers out of post-401 OAuth work and require JSON responses for discovery, registration, and token traffic
- cover the header contracts with loopback-server regressions and document the fix in the changelog

## Proof

- `pnpm check`
- `pnpm test` — 1,619 passed, 26 skipped
- `pnpm exec vitest run tests/node-http-fetch.test.ts tests/oauth-session.test.ts` — 50 passed
- built-artifact loopback validation: default `mcporter/0.13.6`, explicit User-Agent preserved, separate resource/authorization origins both received `Accept: application/json`, transport fetch calls: 0
- autoreview clean: no accepted/actionable findings

Closes #320.
Closes #321.
