### PR TITLE
fix(cli): use canonical URL serialization

### DIFF
--- a/src/cli/http-utils.ts
+++ b/src/cli/http-utils.ts
@@ -73,7 +73,7 @@ export function normalizeHttpUrl(value: string | URL): string | undefined {
     if (!url.pathname) {
       url.pathname = '/';
     }
-    return url.href.replace(/\/$/, '/');
+    return url.href;
   } catch {
     return undefined;
   }

--- a/tests/http-utils.test.ts
+++ b/tests/http-utils.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeHttpUrl } from '../src/cli/http-utils.js';
+
+describe('normalizeHttpUrl', () => {
+  it('uses URL serialization for origin and path forms', () => {
+    expect(normalizeHttpUrl('HTTPS://WWW.Example.COM')).toBe('https://example.com/');
+    expect(normalizeHttpUrl('https://www.example.com/mcp/')).toBe('https://example.com/mcp/');
+    expect(normalizeHttpUrl('https://www.example.com/mcp')).toBe('https://example.com/mcp');
+  });
+});


### PR DESCRIPTION
## Summary

- return canonical `URL.href` directly
- cover origin, trailing-slash path, and non-trailing-slash path forms

Closes CodeQL alert #15 from default-setup run `32454518381`.

## Root cause

URL normalization ended with a literal identity replacement of `/` with `/`. Native `URL` serialization already owns the canonical output, so the redundant replacement is removed.

Production delta: net zero.

## Validation

- focused: 8 tests passed, including 2 built-artifact HTTP selector tests
- `pnpm check`
- full suite: 1,619 tests passed with one unrelated daemon-liveness timing failure under three-way local contention; exact failed surface rerun passed 5/5
- `git diff --check`

