### PR TITLE
fix(security): bound runtime timers

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -16,7 +16,7 @@ import {
   DAEMON_PROTOCOL_VERSION,
   DaemonFrameDecoder,
   isDaemonProgressFrame,
-  resolveProgressInterval,
+  resolveProgressTiming,
 } from './protocol.js';
 import { delay } from './request-utils.js';
 import { waitForDaemonReady } from './startup-readiness.js';
@@ -287,13 +287,13 @@ export class DaemonClient {
   }
 
   private async sendRequest<T>(method: DaemonRequestMethod, params: unknown, timeoutOverrideMs?: number): Promise<T> {
-    const idleTimeoutMs = resolveDaemonTimeout(timeoutOverrideMs);
+    const progressTiming = resolveProgressTiming(resolveDaemonTimeout(timeoutOverrideMs));
     const request: DaemonRequest = {
       id: randomUUID(),
       method,
       params,
       protocolVersion: DAEMON_PROTOCOL_VERSION,
-      progressIntervalMs: resolveProgressInterval(idleTimeoutMs),
+      progressIntervalMs: progressTiming.progressIntervalMs,
     };
     const payload = JSON.stringify(request);
     const parsed = await new Promise<DaemonResponse<T>>((resolve, reject) => {
@@ -315,7 +315,7 @@ export class DaemonClient {
         settled = true;
         resolve(value);
       };
-      socket.setTimeout(idleTimeoutMs);
+      socket.setTimeout(progressTiming.idleTimeoutMs);
       socket.on('timeout', () => {
         // Progress makes this an idle budget. Silence remains a transport failure and keeps the
         // existing restart-and-retry recovery for a genuinely wedged daemon.
@@ -325,7 +325,7 @@ export class DaemonClient {
         for (const frame of frames) {
           if (isDaemonProgressFrame(frame)) {
             if (frame.id === request.id) {
-              socket.setTimeout(idleTimeoutMs);
+              socket.setTimeout(progressTiming.idleTimeoutMs);
             }
             continue;
           }

--- a/src/daemon/host.ts
+++ b/src/daemon/host.ts
@@ -35,6 +35,7 @@ import {
   DAEMON_OPERATION_TIMEOUT_CODE,
   DAEMON_PROGRESS_INTERVAL_MS,
   DAEMON_PROTOCOL_VERSION,
+  MIN_DAEMON_PROGRESS_INTERVAL_MS,
   encodeDaemonFrame,
   type DaemonRequest,
   type DaemonResponse,
@@ -593,7 +594,12 @@ function startProgressFrames(socket: net.Socket, request?: DaemonRequest): () =>
   ) {
     return () => {};
   }
-  const intervalMs = Math.min(request.progressIntervalMs, DAEMON_PROGRESS_INTERVAL_MS);
+  // Raw protocol clients control this field, so enforce both ends before it
+  // reaches setInterval. The floor prevents a tight progress-frame loop.
+  const intervalMs = Math.min(
+    Math.max(Math.trunc(request.progressIntervalMs), MIN_DAEMON_PROGRESS_INTERVAL_MS),
+    DAEMON_PROGRESS_INTERVAL_MS
+  );
   const emit = (): void => {
     if (!socket.destroyed && !socket.writableEnded) {
       socket.write(encodeDaemonFrame({ type: 'progress', id: request.id }));

--- a/src/daemon/protocol.ts
+++ b/src/daemon/protocol.ts
@@ -5,15 +5,25 @@ export const DAEMON_OPERATION_TIMEOUT_CODE = 'operation_timeout';
 export const DAEMON_OAUTH_FLOW_ERROR_CODE = 'oauth_flow_error';
 export const DAEMON_PROGRESS_INTERVAL_MS = 250;
 export const MIN_DAEMON_PROGRESS_INTERVAL_MS = 25;
+const DAEMON_PROGRESS_SCHEDULING_SLACK_MS = MIN_DAEMON_PROGRESS_INTERVAL_MS;
 
-export function resolveProgressInterval(idleTimeoutMs: number): number {
-  if (!Number.isFinite(idleTimeoutMs) || idleTimeoutMs <= 0) {
-    return DAEMON_PROGRESS_INTERVAL_MS;
-  }
-  return Math.min(
+export function resolveProgressTiming(requestedIdleTimeoutMs: number): {
+  progressIntervalMs: number;
+  idleTimeoutMs: number;
+} {
+  const idleTimeoutMs =
+    Number.isFinite(requestedIdleTimeoutMs) && requestedIdleTimeoutMs > 0
+      ? requestedIdleTimeoutMs
+      : DAEMON_PROGRESS_INTERVAL_MS * 3 + DAEMON_PROGRESS_SCHEDULING_SLACK_MS;
+  const progressIntervalMs = Math.min(
     DAEMON_PROGRESS_INTERVAL_MS,
     Math.max(MIN_DAEMON_PROGRESS_INTERVAL_MS, Math.floor(idleTimeoutMs / 3))
   );
+  return {
+    progressIntervalMs,
+    // Keep three frame opportunities plus scheduler slack inside the socket idle budget.
+    idleTimeoutMs: Math.max(idleTimeoutMs, progressIntervalMs * 3 + DAEMON_PROGRESS_SCHEDULING_SLACK_MS),
+  };
 }
 
 export type DaemonRequestMethod =

--- a/src/daemon/protocol.ts
+++ b/src/daemon/protocol.ts
@@ -1,4 +1,5 @@
 import type { ChromeDevtoolsRelayDecision } from '../chrome-devtools-relay.js';
+import { normalizeTimeout } from '../runtime/utils.js';
 
 export const DAEMON_PROTOCOL_VERSION = 2;
 export const DAEMON_OPERATION_TIMEOUT_CODE = 'operation_timeout';
@@ -12,9 +13,7 @@ export function resolveProgressTiming(requestedIdleTimeoutMs: number): {
   idleTimeoutMs: number;
 } {
   const idleTimeoutMs =
-    Number.isFinite(requestedIdleTimeoutMs) && requestedIdleTimeoutMs > 0
-      ? requestedIdleTimeoutMs
-      : DAEMON_PROGRESS_INTERVAL_MS * 3 + DAEMON_PROGRESS_SCHEDULING_SLACK_MS;
+    normalizeTimeout(requestedIdleTimeoutMs) ?? DAEMON_PROGRESS_INTERVAL_MS * 3 + DAEMON_PROGRESS_SCHEDULING_SLACK_MS;
   const progressIntervalMs = Math.min(
     DAEMON_PROGRESS_INTERVAL_MS,
     Math.max(MIN_DAEMON_PROGRESS_INTERVAL_MS, Math.floor(idleTimeoutMs / 3))

--- a/src/daemon/protocol.ts
+++ b/src/daemon/protocol.ts
@@ -4,12 +4,16 @@ export const DAEMON_PROTOCOL_VERSION = 2;
 export const DAEMON_OPERATION_TIMEOUT_CODE = 'operation_timeout';
 export const DAEMON_OAUTH_FLOW_ERROR_CODE = 'oauth_flow_error';
 export const DAEMON_PROGRESS_INTERVAL_MS = 250;
+export const MIN_DAEMON_PROGRESS_INTERVAL_MS = 25;
 
 export function resolveProgressInterval(idleTimeoutMs: number): number {
   if (!Number.isFinite(idleTimeoutMs) || idleTimeoutMs <= 0) {
     return DAEMON_PROGRESS_INTERVAL_MS;
   }
-  return Math.min(DAEMON_PROGRESS_INTERVAL_MS, Math.max(1, Math.floor(idleTimeoutMs / 3)));
+  return Math.min(
+    DAEMON_PROGRESS_INTERVAL_MS,
+    Math.max(MIN_DAEMON_PROGRESS_INTERVAL_MS, Math.floor(idleTimeoutMs / 3))
+  );
 }
 
 export type DaemonRequestMethod =

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -40,19 +40,53 @@ export function raceWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Prom
     const delayMs = Number.isFinite(timeoutMs)
       ? Math.min(Math.max(Math.trunc(timeoutMs), 1), MAX_TIMER_DELAY_MS)
       : MAX_TIMER_DELAY_MS;
-    const timer = setTimeout(() => {
+    const cancelTimeout = scheduleDeadline(() => {
       // Reject with a Timeout error; higher-level catch blocks decide whether to recycle the transport.
       reject(new Error('Timeout'));
     }, delayMs);
     promise.then(
       (value) => {
-        clearTimeout(timer);
+        cancelTimeout();
         resolve(value);
       },
       (error) => {
-        clearTimeout(timer);
+        cancelTimeout();
         reject(error);
       }
     );
   });
+}
+
+function scheduleDeadline(callback: () => void, delayMs: number): () => void {
+  const deadline = Date.now() + delayMs;
+  let timer: NodeJS.Timeout | undefined;
+  let cancelled = false;
+
+  const scheduleNext = (): void => {
+    if (cancelled) return;
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      callback();
+    } else if (remainingMs > 86_400_000) {
+      timer = setTimeout(scheduleNext, 86_400_000);
+    } else if (remainingMs > 3_600_000) {
+      timer = setTimeout(scheduleNext, 3_600_000);
+    } else if (remainingMs > 60_000) {
+      timer = setTimeout(scheduleNext, 60_000);
+    } else if (remainingMs > 1_000) {
+      timer = setTimeout(scheduleNext, 1_000);
+    } else if (remainingMs > 100) {
+      timer = setTimeout(scheduleNext, 100);
+    } else if (remainingMs > 10) {
+      timer = setTimeout(scheduleNext, 10);
+    } else {
+      timer = setTimeout(scheduleNext, 1);
+    }
+  };
+
+  scheduleNext();
+  return () => {
+    cancelled = true;
+    if (timer) clearTimeout(timer);
+  };
 }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -58,13 +58,13 @@ export function raceWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Prom
 }
 
 function scheduleDeadline(callback: () => void, delayMs: number): () => void {
-  const deadline = Date.now() + delayMs;
+  const deadline = performance.now() + delayMs;
   let timer: NodeJS.Timeout | undefined;
   let cancelled = false;
 
   const scheduleNext = (): void => {
     if (cancelled) return;
-    const remainingMs = deadline - Date.now();
+    const remainingMs = deadline - performance.now();
     if (remainingMs <= 0) {
       callback();
     } else if (remainingMs > 86_400_000) {

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,6 +1,7 @@
 import { resolveEnvPlaceholders } from '../env.js';
 
 const ENV_PLACEHOLDER_PATTERN = /\$\{[A-Za-z_][A-Za-z0-9_]*(?::-[^}]*)?\}/;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 export function resolveCommandArgument(value: string, env: NodeJS.ProcessEnv = process.env): string {
   if (!value) {
@@ -31,15 +32,18 @@ export function normalizeTimeout(raw?: number): number | undefined {
     return undefined;
   }
   const coerced = Math.trunc(raw);
-  return coerced > 0 ? coerced : undefined;
+  return coerced > 0 ? Math.min(coerced, MAX_TIMER_DELAY_MS) : undefined;
 }
 
 export function raceWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   return new Promise<T>((resolve, reject) => {
+    const delayMs = Number.isFinite(timeoutMs)
+      ? Math.min(Math.max(Math.trunc(timeoutMs), 1), MAX_TIMER_DELAY_MS)
+      : MAX_TIMER_DELAY_MS;
     const timer = setTimeout(() => {
       // Reject with a Timeout error; higher-level catch blocks decide whether to recycle the transport.
       reject(new Error('Timeout'));
-    }, timeoutMs);
+    }, delayMs);
     promise.then(
       (value) => {
         clearTimeout(timer);

--- a/tests/daemon-client-timeout.test.ts
+++ b/tests/daemon-client-timeout.test.ts
@@ -147,6 +147,18 @@ describe('DaemonClient timeouts', () => {
     expect(callRecord?.timeout).toBe(4_500);
   });
 
+  it('caps oversized MCPORTER_DAEMON_TIMEOUT_MS values at the Node timer maximum', async () => {
+    process.env.MCPORTER_DAEMON_TIMEOUT_MS = String(Number.MAX_SAFE_INTEGER);
+    const configPath = 'mcporter.config.json';
+    await writeFreshMetadata(configPath);
+    const client = new DaemonClient({ configPath, configExplicit: true });
+    await client.callTool({ server: 'foo', tool: 'bar' });
+    const statusRecord = timeoutRecords.find((entry) => entry.method === 'status');
+    const callRecord = timeoutRecords.find((entry) => entry.method === 'callTool');
+    expect(statusRecord?.timeout).toBe(2_147_483_647);
+    expect(callRecord?.timeout).toBe(2_147_483_647);
+  });
+
   it('honors per-call timeout overrides', async () => {
     const configPath = 'mcporter.config.json';
     await writeFreshMetadata(configPath);
@@ -156,6 +168,17 @@ describe('DaemonClient timeouts', () => {
     const callRecord = timeoutRecords.find((entry) => entry.method === 'callTool');
     expect(statusRecord?.timeout).toBe(12_345);
     expect(callRecord?.timeout).toBe(12_345);
+  });
+
+  it('caps oversized per-call timeouts at the Node timer maximum', async () => {
+    const configPath = 'mcporter.config.json';
+    await writeFreshMetadata(configPath);
+    const client = new DaemonClient({ configPath, configExplicit: true });
+    await client.callTool({ server: 'foo', tool: 'bar', timeoutMs: Number.MAX_SAFE_INTEGER });
+    const statusRecord = timeoutRecords.find((entry) => entry.method === 'status');
+    const callRecord = timeoutRecords.find((entry) => entry.method === 'callTool');
+    expect(statusRecord?.timeout).toBe(2_147_483_647);
+    expect(callRecord?.timeout).toBe(2_147_483_647);
   });
 
   it('honors per-listTools timeout overrides', async () => {

--- a/tests/daemon-client-timeout.test.ts
+++ b/tests/daemon-client-timeout.test.ts
@@ -10,7 +10,7 @@ import { NON_INTERACTIVE_ELICITATION_HINT } from '../src/runtime/elicitation.js'
 import { DAEMON_OAUTH_FLOW_ERROR_CODE } from '../src/daemon/protocol.js';
 import { makeShortTempDir } from './fixtures/test-helpers.js';
 
-const timeoutRecords: Array<{ method: string; timeout: number }> = [];
+const timeoutRecords: Array<{ method: string; timeout: number; progressInterval?: number }> = [];
 
 class MockSocket extends EventEmitter {
   currentTimeout = 0;
@@ -22,7 +22,11 @@ class MockSocket extends EventEmitter {
 
   write(data: string, cb?: (err?: Error | null) => void): boolean {
     const payload = JSON.parse(data.toString());
-    timeoutRecords.push({ method: payload.method, timeout: this.currentTimeout });
+    timeoutRecords.push({
+      method: payload.method,
+      timeout: this.currentTimeout,
+      progressInterval: payload.progressIntervalMs,
+    });
     const response = buildResponse(payload.method, payload.id);
     setTimeout(() => {
       this.emit('data', responseOverrides.get(payload.method) ?? JSON.stringify(response));
@@ -165,7 +169,7 @@ describe('DaemonClient timeouts', () => {
     expect(listRecord?.timeout).toBe(300_000);
   });
 
-  it('clamps daemon status preflight timeout for tiny per-call timeouts', async () => {
+  it('keeps tiny daemon request idle budgets above the progress cadence', async () => {
     const configPath = 'mcporter.config.json';
     await writeFreshMetadata(configPath);
     const client = new DaemonClient({ configPath, configExplicit: true });
@@ -173,7 +177,7 @@ describe('DaemonClient timeouts', () => {
     const statusRecord = timeoutRecords.find((entry) => entry.method === 'status');
     const callRecord = timeoutRecords.find((entry) => entry.method === 'callTool');
     expect(statusRecord?.timeout).toBe(1_000);
-    expect(callRecord?.timeout).toBe(1);
+    expect(callRecord).toMatchObject({ timeout: 100, progressInterval: 25 });
   });
 
   it('surfaces daemon notices to the calling CLI process', async () => {

--- a/tests/daemon-liveness.test.ts
+++ b/tests/daemon-liveness.test.ts
@@ -22,6 +22,10 @@ describe('daemon frame protocol', () => {
     expect(resolveProgressTiming(1)).toEqual({ progressIntervalMs: 25, idleTimeoutMs: 100 });
     expect(resolveProgressTiming(60)).toEqual({ progressIntervalMs: 25, idleTimeoutMs: 100 });
     expect(resolveProgressTiming(900)).toEqual({ progressIntervalMs: 250, idleTimeoutMs: 900 });
+    expect(resolveProgressTiming(Number.MAX_SAFE_INTEGER)).toEqual({
+      progressIntervalMs: 250,
+      idleTimeoutMs: 2_147_483_647,
+    });
   });
 
   it('decodes split and coalesced frames and reports malformed lines', () => {

--- a/tests/daemon-liveness.test.ts
+++ b/tests/daemon-liveness.test.ts
@@ -9,7 +9,7 @@ import {
   DAEMON_PROTOCOL_VERSION,
   DaemonFrameDecoder,
   encodeDaemonFrame,
-  resolveProgressInterval,
+  resolveProgressTiming,
   type DaemonRequest,
 } from '../src/daemon/protocol.js';
 import type { Runtime } from '../src/runtime.js';
@@ -19,9 +19,9 @@ const describeUnixSocket = process.platform === 'win32' ? describe.skip : descri
 
 describe('daemon frame protocol', () => {
   it('bounds progress frequency for short and long idle budgets', () => {
-    expect(resolveProgressInterval(1)).toBe(25);
-    expect(resolveProgressInterval(60)).toBe(25);
-    expect(resolveProgressInterval(900)).toBe(250);
+    expect(resolveProgressTiming(1)).toEqual({ progressIntervalMs: 25, idleTimeoutMs: 100 });
+    expect(resolveProgressTiming(60)).toEqual({ progressIntervalMs: 25, idleTimeoutMs: 100 });
+    expect(resolveProgressTiming(900)).toEqual({ progressIntervalMs: 250, idleTimeoutMs: 900 });
   });
 
   it('decodes split and coalesced frames and reports malformed lines', () => {
@@ -72,6 +72,27 @@ describeUnixSocket('daemon socket liveness', () => {
     expect(listTools).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps a tiny-timeout request alive at the minimum progress cadence', async () => {
+    const listTools = vi.fn(async () => {
+      await delay(180);
+      return [{ name: 'tiny-timeout' }];
+    });
+    const served = await serveSocket(async (socket, request) => {
+      await __testHandleSocketRequest(
+        socket,
+        request,
+        { listTools } as unknown as Runtime,
+        managedServers(),
+        metadata(served.socketPath)
+      );
+    });
+    cleanups.push(served.close);
+    const client = clientForSocket(served.socketPath);
+
+    await expect(sendRequest(client, 'listTools', { server: 'oauth' }, 1)).resolves.toEqual([{ name: 'tiny-timeout' }]);
+    expect(listTools).toHaveBeenCalledTimes(1);
+  });
+
   it('destroys a genuinely silent daemon socket at the idle deadline', async () => {
     let observedClose!: () => void;
     const closed = new Promise<void>((resolve) => {
@@ -85,13 +106,13 @@ describeUnixSocket('daemon socket liveness', () => {
 
     await expect(
       Promise.race([
-        sendRequest(client, 'listTools', { server: 'oauth' }, 50),
-        delay(200).then(() => {
+        sendRequest(client, 'listTools', { server: 'oauth' }, 1),
+        delay(300).then(() => {
           throw new Error('silent daemon socket was not torn down');
         }),
       ])
     ).rejects.toMatchObject({ code: 'ETIMEDOUT' });
-    await expect(Promise.race([closed, delay(200).then(() => 'still-open')])).resolves.toBeUndefined();
+    await expect(Promise.race([closed, delay(300).then(() => 'still-open')])).resolves.toBeUndefined();
   });
 
   it('accepts a bare v1 response and retains the flat fallback deadline', async () => {

--- a/tests/daemon-liveness.test.ts
+++ b/tests/daemon-liveness.test.ts
@@ -9,6 +9,7 @@ import {
   DAEMON_PROTOCOL_VERSION,
   DaemonFrameDecoder,
   encodeDaemonFrame,
+  resolveProgressInterval,
   type DaemonRequest,
 } from '../src/daemon/protocol.js';
 import type { Runtime } from '../src/runtime.js';
@@ -17,6 +18,12 @@ import { makeShortTempDir } from './fixtures/test-helpers.js';
 const describeUnixSocket = process.platform === 'win32' ? describe.skip : describe;
 
 describe('daemon frame protocol', () => {
+  it('bounds progress frequency for short and long idle budgets', () => {
+    expect(resolveProgressInterval(1)).toBe(25);
+    expect(resolveProgressInterval(60)).toBe(25);
+    expect(resolveProgressInterval(900)).toBe(250);
+  });
+
   it('decodes split and coalesced frames and reports malformed lines', () => {
     const decoder = new DaemonFrameDecoder();
     const progress = encodeDaemonFrame({ type: 'progress', id: 'one' });
@@ -128,6 +135,39 @@ describeUnixSocket('daemon socket liveness', () => {
       result: [{ name: 'legacy-client' }],
     });
     expect(payload.trim().split('\n')).toHaveLength(1);
+  });
+
+  it('clamps a raw client progress interval before starting the frame timer', async () => {
+    const served = await serveSocket(async (socket, request) => {
+      await __testHandleSocketRequest(
+        socket,
+        request,
+        {
+          listTools: async () => {
+            await delay(80);
+            return [{ name: 'bounded' }];
+          },
+        } as unknown as Runtime,
+        managedServers(),
+        metadata(served.socketPath)
+      );
+    });
+    cleanups.push(served.close);
+
+    const payload = await rawRequest(served.socketPath, {
+      id: 'bounded-progress',
+      method: 'listTools',
+      params: { server: 'oauth' },
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
+      progressIntervalMs: 1,
+    });
+    const frames = payload
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+
+    expect(frames.filter((frame) => frame.type === 'progress').length).toBeLessThanOrEqual(5);
+    expect(frames.at(-1)).toMatchObject({ id: 'bounded-progress', ok: true });
   });
 });
 

--- a/tests/runtime-utils.test.ts
+++ b/tests/runtime-utils.test.ts
@@ -12,6 +12,10 @@ describe('normalizeTimeout', () => {
   it('returns a truncated positive integer', () => {
     expect(normalizeTimeout(1500.9)).toBe(1500);
   });
+
+  it('caps values at Node timer maximum instead of wrapping to an immediate timeout', () => {
+    expect(normalizeTimeout(Number.MAX_SAFE_INTEGER)).toBe(2_147_483_647);
+  });
 });
 
 describe('raceWithTimeout', () => {

--- a/tests/runtime-utils.test.ts
+++ b/tests/runtime-utils.test.ts
@@ -26,10 +26,30 @@ describe('raceWithTimeout', () => {
 
   it('rejects with a timeout error when exceeding the deadline', async () => {
     vi.useFakeTimers();
-    const promise = raceWithTimeout(new Promise<void>(() => {}), 500);
-    const expectation = expect(promise).rejects.toThrowError('Timeout');
-    vi.advanceTimersByTime(500);
-    await expectation;
-    vi.useRealTimers();
+    try {
+      const promise = raceWithTimeout(new Promise<void>(() => {}), 500);
+      const expectation = expect(promise).rejects.toThrowError('Timeout');
+      await vi.advanceTimersByTimeAsync(500);
+      await expectation;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps the timeout budget stable across wall-clock adjustments', async () => {
+    vi.useFakeTimers();
+    try {
+      const dateNow = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+      const { promise: operation, resolve: resolveOperation } = Promise.withResolvers<string>();
+      const promise = raceWithTimeout(operation, 500);
+
+      dateNow.mockReturnValue(60_001_000);
+      await vi.advanceTimersByTimeAsync(499);
+      resolveOperation('ok');
+
+      await expect(promise).resolves.toBe('ok');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- cap runtime and daemon socket timeouts at Node's maximum supported timer delay and schedule deadlines in fixed monotonic slices
- enforce a minimum daemon progress-frame interval and negotiate a compatible client idle budget
- cover timeout caps, wall-clock adjustments, tiny-timeout liveness, and silent daemon failure

Closes CodeQL alerts #13-#14 from default-setup run `32454518381`.

## Root cause

Untrusted timeout values reached Node timers without a platform-safe upper bound, and raw daemon clients could request a 1 ms progress interval. The owning runtime and protocol boundaries now share the canonical timeout clamp, deadline timers use constant monotonic slices, and the protocol resolves one bounded progress/idle timing pair so the client cannot expire before progress frames or wrap an oversized socket timeout into an immediate failure.

Production delta: +74/-17 (net +57), justified by the timer resource-consumption and daemon liveness invariants. Tests: +128/-12.

## Validation

- focused timer, daemon liveness, and client timeout boundaries: 29 tests passed
- `pnpm check`
- updated-head full suite: 1,625 tests passed; one unrelated CLI help timeout passed on exact 14-test rerun
- `git diff --check`
