### PR TITLE
fix(security): make text normalization linear

### DIFF
--- a/src/cli/adhoc-server.ts
+++ b/src/cli/adhoc-server.ts
@@ -5,6 +5,7 @@ import { __configInternals } from '../config.js';
 import { expandHome } from '../env.js';
 import { withFileLock, writeTextFileAtomic } from '../fs-json.js';
 import { canonicalKeepAliveName, resolveLifecycle } from '../lifecycle.js';
+import { toAsciiSlug } from './ascii-slug.js';
 
 export interface EphemeralServerSpec {
   name?: string;
@@ -197,17 +198,8 @@ function stripPackageVersion(token: string): string {
   return token;
 }
 
-function slugify(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .replace(/-{2,}/g, '-');
-}
-
 function normalizeEphemeralName(value: string): string {
-  const name = slugify(value);
+  const name = toAsciiSlug(value);
   if (!name) {
     throw new Error('Ad-hoc server name must contain at least one letter or digit.');
   }

--- a/src/cli/ascii-slug.ts
+++ b/src/cli/ascii-slug.ts
@@ -1,0 +1,21 @@
+export function toAsciiSlug(value: string): string {
+  let slug = '';
+  let pendingSeparator = false;
+
+  for (const character of value.trim().toLowerCase()) {
+    const code = character.charCodeAt(0);
+    const isLetter = code >= 97 && code <= 122;
+    const isDigit = code >= 48 && code <= 57;
+    if (isLetter || isDigit) {
+      if (pendingSeparator && slug.length > 0) {
+        slug += '-';
+      }
+      slug += character;
+      pendingSeparator = false;
+    } else if (slug.length > 0) {
+      pendingSeparator = true;
+    }
+  }
+
+  return slug;
+}

--- a/src/cli/generate/artifacts.ts
+++ b/src/cli/generate/artifacts.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { RolldownPlugin } from 'rolldown';
 import { MCPORTER_VERSION } from '../../version.js';
+import { toAsciiSlug } from '../ascii-slug.js';
 import { markExecutable, safeCopyFile } from './fs-helpers.js';
 import { verifyBunAvailable } from './runtime.js';
 
@@ -391,11 +392,7 @@ async function linkOrCopyDependency(sourceDir: string, targetDir: string): Promi
 }
 
 function sanitizeFileName(input: string): string {
-  const slug = input
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-');
-  return slug.replace(/^-+|-+$/g, '');
+  return toAsciiSlug(input);
 }
 
 function resolveUniquePath(directory: string, baseName: string): string {

--- a/src/cli/generate/name-utils.ts
+++ b/src/cli/generate/name-utils.ts
@@ -1,4 +1,5 @@
 import { splitCommandLine } from '../adhoc-server.js';
+import { toAsciiSlug } from '../ascii-slug.js';
 import { normalizeHttpUrlCandidate } from '../http-utils.js';
 import type { CommandInput } from './types.js';
 
@@ -103,11 +104,7 @@ export function parseInlineCommand(value: string): CommandInput {
 }
 
 function slugify(value: string): string | undefined {
-  const normalized = value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+  const normalized = toAsciiSlug(value);
   return normalized || undefined;
 }
 

--- a/src/error-classifier.ts
+++ b/src/error-classifier.ts
@@ -161,43 +161,50 @@ function extractStatusAfterUrl(message: string): string | undefined {
       return undefined;
     }
     let separatorIndex = urlStart;
-    while (separatorIndex < message.length && !/\s/.test(message.charAt(separatorIndex))) {
+    while (separatorIndex < normalized.length && !/\s/.test(normalized.charAt(separatorIndex))) {
       separatorIndex += 1;
     }
-    if (separatorIndex < message.length) {
-      const candidate = extractStatusFromUrlTail(message.slice(separatorIndex));
+    if (separatorIndex < normalized.length) {
+      const candidate = extractStatusFromUrlTail(normalized, separatorIndex);
       if (candidate !== undefined) {
         return candidate;
       }
     }
-    searchStart = urlStart + 1;
+    searchStart = separatorIndex;
   }
   return undefined;
 }
 
-function extractStatusFromUrlTail(value: string): string | undefined {
-  let tail = value.trimStart().toLowerCase();
+function extractStatusFromUrlTail(value: string, start: number): string | undefined {
+  let cursor = skipWhitespace(value, start);
   for (const prefix of ['returned status', 'returned code', 'returned', 'status', 'code']) {
-    if (tail.startsWith(prefix)) {
-      tail = tail.slice(prefix.length).trimStart();
+    if (value.startsWith(prefix, cursor)) {
+      cursor = skipWhitespace(value, cursor + prefix.length);
       break;
     }
   }
-  const candidate = tail.slice(0, 3);
-  const boundary = tail.charAt(3);
+  const candidate = value.slice(cursor, cursor + 3);
+  const boundary = value.charAt(cursor + 3);
   return /^\d{3}$/.test(candidate) && !/[a-z0-9_]/i.test(boundary) ? candidate : undefined;
+}
+
+function skipWhitespace(value: string, start: number): number {
+  let index = start;
+  while (index < value.length && /\s/.test(value.charAt(index))) {
+    index += 1;
+  }
+  return index;
 }
 
 function findNextHttpUrl(value: string, searchStart: number): number {
   let index = searchStart;
   while (index < value.length) {
-    const httpIndex = value.indexOf('http://', index);
-    const httpsIndex = value.indexOf('https://', index);
-    const candidate = httpIndex === -1 ? httpsIndex : httpsIndex === -1 ? httpIndex : Math.min(httpIndex, httpsIndex);
+    const candidate = value.indexOf('http', index);
     if (candidate === -1) {
       return -1;
     }
-    if (candidate === 0 || !/[a-z0-9_]/i.test(value.charAt(candidate - 1))) {
+    const isUrl = value.startsWith('http://', candidate) || value.startsWith('https://', candidate);
+    if (isUrl && (candidate === 0 || !/[a-z0-9_]/i.test(value.charAt(candidate - 1)))) {
       return candidate;
     }
     index = candidate + 1;

--- a/src/error-classifier.ts
+++ b/src/error-classifier.ts
@@ -42,7 +42,6 @@ const OFFLINE_PATTERNS = [
   'failed to start',
   'spawn enoent',
 ];
-const HTTP_STATUS_FALLBACK = /\bhttps?:\/\/[^\s]+(?:\s+returned\s+)?(?:status|code)?\s*(\d{3})\b/i;
 const STATUS_DIRECT_PATTERN = /\b(?:status(?:\s+code)?|http(?:\s+(?:status|code|error))?)[:\s]*(\d{3})\b/i;
 const STDIO_EXIT_PATTERN = /exit(?:ed)?(?:\s+with)?(?:\s+(?:code|status))\s+(-?\d+)/i;
 const STDIO_SIGNAL_PATTERN = /signal\s+([A-Z0-9]+)/i;
@@ -124,7 +123,7 @@ function extractStatusCode(message: string): number | undefined {
   const candidates = [
     message.match(/status code\s*\((\d{3})\)/i)?.[1],
     message.match(STATUS_DIRECT_PATTERN)?.[1],
-    message.match(HTTP_STATUS_FALLBACK)?.[1],
+    extractStatusAfterUrl(message),
   ].filter(Boolean) as string[];
   for (const candidate of candidates) {
     const parsed = Number.parseInt(candidate, 10);
@@ -151,6 +150,29 @@ function extractStatusCode(message: string): number | undefined {
     }
   }
   return undefined;
+}
+
+function extractStatusAfterUrl(message: string): string | undefined {
+  const urlStart = message.search(/\bhttps?:\/\//i);
+  if (urlStart === -1) {
+    return undefined;
+  }
+  const afterUrl = message.slice(urlStart);
+  const separatorIndex = afterUrl.search(/\s/);
+  if (separatorIndex === -1) {
+    return undefined;
+  }
+
+  let tail = afterUrl.slice(separatorIndex).trimStart().toLowerCase();
+  for (const prefix of ['returned status', 'returned code', 'returned', 'status', 'code']) {
+    if (tail.startsWith(prefix)) {
+      tail = tail.slice(prefix.length).trimStart();
+      break;
+    }
+  }
+  const candidate = tail.slice(0, 3);
+  const boundary = tail.charAt(3);
+  return /^\d{3}$/.test(candidate) && !/[a-z0-9_]/i.test(boundary) ? candidate : undefined;
 }
 
 function matchesAny(patterns: readonly RegExp[], normalizedMessage: string): boolean {

--- a/src/error-classifier.ts
+++ b/src/error-classifier.ts
@@ -153,17 +153,30 @@ function extractStatusCode(message: string): number | undefined {
 }
 
 function extractStatusAfterUrl(message: string): string | undefined {
-  const urlStart = message.search(/\bhttps?:\/\//i);
-  if (urlStart === -1) {
-    return undefined;
+  const normalized = message.toLowerCase();
+  let searchStart = 0;
+  while (searchStart < message.length) {
+    const urlStart = findNextHttpUrl(normalized, searchStart);
+    if (urlStart === -1) {
+      return undefined;
+    }
+    let separatorIndex = urlStart;
+    while (separatorIndex < message.length && !/\s/.test(message.charAt(separatorIndex))) {
+      separatorIndex += 1;
+    }
+    if (separatorIndex < message.length) {
+      const candidate = extractStatusFromUrlTail(message.slice(separatorIndex));
+      if (candidate !== undefined) {
+        return candidate;
+      }
+    }
+    searchStart = urlStart + 1;
   }
-  const afterUrl = message.slice(urlStart);
-  const separatorIndex = afterUrl.search(/\s/);
-  if (separatorIndex === -1) {
-    return undefined;
-  }
+  return undefined;
+}
 
-  let tail = afterUrl.slice(separatorIndex).trimStart().toLowerCase();
+function extractStatusFromUrlTail(value: string): string | undefined {
+  let tail = value.trimStart().toLowerCase();
   for (const prefix of ['returned status', 'returned code', 'returned', 'status', 'code']) {
     if (tail.startsWith(prefix)) {
       tail = tail.slice(prefix.length).trimStart();
@@ -173,6 +186,23 @@ function extractStatusAfterUrl(message: string): string | undefined {
   const candidate = tail.slice(0, 3);
   const boundary = tail.charAt(3);
   return /^\d{3}$/.test(candidate) && !/[a-z0-9_]/i.test(boundary) ? candidate : undefined;
+}
+
+function findNextHttpUrl(value: string, searchStart: number): number {
+  let index = searchStart;
+  while (index < value.length) {
+    const httpIndex = value.indexOf('http://', index);
+    const httpsIndex = value.indexOf('https://', index);
+    const candidate = httpIndex === -1 ? httpsIndex : httpsIndex === -1 ? httpIndex : Math.min(httpIndex, httpsIndex);
+    if (candidate === -1) {
+      return -1;
+    }
+    if (candidate === 0 || !/[a-z0-9_]/i.test(value.charAt(candidate - 1))) {
+      return candidate;
+    }
+    index = candidate + 1;
+  }
+  return -1;
 }
 
 function matchesAny(patterns: readonly RegExp[], normalizedMessage: string): boolean {

--- a/src/generate-cli.ts
+++ b/src/generate-cli.ts
@@ -199,10 +199,27 @@ function resolveImplicitTemplateDir(serverName: string, definition: ReturnType<t
 }
 
 function sanitizePathSegment(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9._-]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+  let segment = '';
+  let inRejectedRun = false;
+
+  for (const character of value.toLowerCase()) {
+    const code = character.charCodeAt(0);
+    const isLetter = code >= 97 && code <= 122;
+    const isDigit = code >= 48 && code <= 57;
+    if (isLetter || isDigit || character === '.' || character === '_' || character === '-') {
+      segment += character;
+      inRejectedRun = false;
+    } else if (!inRejectedRun) {
+      segment += '-';
+      inRejectedRun = true;
+    }
+  }
+
+  let start = 0;
+  let end = segment.length;
+  while (segment.charAt(start) === '-') start += 1;
+  while (end > start && segment.charAt(end - 1) === '-') end -= 1;
+  return segment.slice(start, end);
 }
 
 function applyToolFilters(tools: ServerToolInfo[], includeTools?: string[], excludeTools?: string[]): ServerToolInfo[] {

--- a/src/runtime/elicitation.ts
+++ b/src/runtime/elicitation.ts
@@ -229,12 +229,8 @@ function formatDefault(value: PrimitiveValue): string {
   return sanitizeTerminalText(Array.isArray(value) ? value.join(', ') : String(value));
 }
 
-const ANSI_ESCAPE_PATTERN =
-  // eslint-disable-next-line no-control-regex -- Terminal escape bytes are the exact untrusted input being removed.
-  /(?:\u001b\][^\u0007]*(?:\u0007|\u001b\\)|\u001b[P^_][\s\S]*?\u001b\\|(?:\u001b\[|\u009b)[0-?]*[ -/]*[@-~]|\u001b[@-_])/gu;
-
 export function sanitizeTerminalText(value: string): string {
-  const withoutEscapes = value.replace(ANSI_ESCAPE_PATTERN, '');
+  const withoutEscapes = stripAnsiSequences(value);
   let withoutControls = '';
   for (const character of withoutEscapes) {
     const codePoint = character.codePointAt(0) ?? 0;
@@ -244,7 +240,71 @@ export function sanitizeTerminalText(value: string): string {
       withoutControls += character;
     }
   }
-  return withoutControls.replace(/ {2,}/gu, ' ').trim();
+  return collapseSpaces(withoutControls).trim();
+}
+
+function stripAnsiSequences(value: string): string {
+  let output = '';
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code === 0x9b) {
+      index = consumeControlSequence(value, index + 1);
+      continue;
+    }
+    if (code !== 0x1b) {
+      output += value[index];
+      continue;
+    }
+
+    const introducer = value.charAt(index + 1);
+    if (introducer === '[') {
+      index = consumeControlSequence(value, index + 2);
+    } else if (introducer === ']' || introducer === 'P' || introducer === '^' || introducer === '_') {
+      index = consumeStringSequence(value, index + 2, introducer === ']');
+    } else if (introducer) {
+      index += 1;
+    }
+  }
+  return output;
+}
+
+function consumeControlSequence(value: string, start: number): number {
+  for (let index = start; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0x40 && code <= 0x7e) {
+      return index;
+    }
+  }
+  return value.length;
+}
+
+function consumeStringSequence(value: string, start: number, allowBell: boolean): number {
+  for (let index = start; index < value.length; index += 1) {
+    if (allowBell && value.charCodeAt(index) === 0x07) {
+      return index;
+    }
+    if (value.charCodeAt(index) === 0x1b && value.charAt(index + 1) === '\\') {
+      return index + 1;
+    }
+  }
+  return value.length;
+}
+
+function collapseSpaces(value: string): string {
+  let output = '';
+  let previousWasSpace = false;
+  for (const character of value) {
+    if (character === ' ') {
+      if (!previousWasSpace) {
+        output += character;
+      }
+      previousWasSpace = true;
+    } else {
+      output += character;
+      previousWasSpace = false;
+    }
+  }
+  return output;
 }
 
 function writeLine(output: NodeJS.WritableStream, message: string): void {

--- a/tests/adhoc-server.test.ts
+++ b/tests/adhoc-server.test.ts
@@ -139,6 +139,12 @@ describe('resolveEphemeralServer', () => {
     expect(() => splitCommandLine(`node 'unterminated`)).toThrow('Unterminated quote');
   });
 
+  it('normalizes long separator runs without changing slug semantics', () => {
+    expect(resolveEphemeralServer({ name: `alpha${'-'.repeat(100_000)}beta`, stdioCommand: 'node' }).name).toBe(
+      'alpha-beta'
+    );
+  });
+
   it('persists into new and existing config containers without dropping unrelated keys', async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-adhoc-persist-'));
     const configPath = path.join(dir, 'nested', 'mcporter.json');

--- a/tests/cli-generate-artifacts.test.ts
+++ b/tests/cli-generate-artifacts.test.ts
@@ -352,6 +352,7 @@ describe('artifact implementation behavior', () => {
     try {
       expect(artifactsTestHooks.sanitizeFileName('  My Fancy CLI!!  ')).toBe('my-fancy-cli');
       expect(artifactsTestHooks.sanitizeFileName('!!!')).toBe('');
+      expect(artifactsTestHooks.sanitizeFileName(`alpha${'-'.repeat(100_000)}beta`)).toBe('alpha-beta');
       await fsPromises.writeFile(path.join(tempDir, 'tool'), '', 'utf8');
       await fsPromises.writeFile(path.join(tempDir, 'tool-1'), '', 'utf8');
       expect(artifactsTestHooks.resolveUniquePath(tempDir, 'tool')).toBe(path.join(tempDir, 'tool-2'));

--- a/tests/error-classifier.test.ts
+++ b/tests/error-classifier.test.ts
@@ -26,6 +26,11 @@ describe('analyzeConnectionError', () => {
     expect(issue.statusCode).toBe(429);
   });
 
+  it('extracts a status after a long URL without backtracking', () => {
+    const issue = analyzeConnectionError(new Error(`https://example.com/${'a'.repeat(100_000)} returned status 503`));
+    expect(issue).toMatchObject({ kind: 'http', statusCode: 503 });
+  });
+
   it.each([401, 403] as const)('keeps %s classified as auth', (status) => {
     const issue = analyzeConnectionError(new Error(`SSE error: Non-200 status code (${status})`));
     expect(issue.kind).toBe('auth');

--- a/tests/error-classifier.test.ts
+++ b/tests/error-classifier.test.ts
@@ -38,6 +38,12 @@ describe('analyzeConnectionError', () => {
     expect(issue).toMatchObject({ kind: 'http', statusCode: 503 });
   });
 
+  it('scans many status-less URL candidates without rescanning their suffixes', () => {
+    const candidates = Array.from({ length: 5_000 }, (_, index) => `https://example.com/${index} skipped`).join(' ');
+    const issue = analyzeConnectionError(new Error(`${candidates} https://final.example/mcp returned status 503`));
+    expect(issue).toMatchObject({ kind: 'http', statusCode: 503 });
+  });
+
   it.each([401, 403] as const)('keeps %s classified as auth', (status) => {
     const issue = analyzeConnectionError(new Error(`SSE error: Non-200 status code (${status})`));
     expect(issue.kind).toBe('auth');

--- a/tests/error-classifier.test.ts
+++ b/tests/error-classifier.test.ts
@@ -31,6 +31,13 @@ describe('analyzeConnectionError', () => {
     expect(issue).toMatchObject({ kind: 'http', statusCode: 503 });
   });
 
+  it('continues to a later URL when the first has no adjacent status', () => {
+    const issue = analyzeConnectionError(
+      new Error('Proxy failed at https://first.example/ then https://second.example/mcp 503')
+    );
+    expect(issue).toMatchObject({ kind: 'http', statusCode: 503 });
+  });
+
   it.each([401, 403] as const)('keeps %s classified as auth', (status) => {
     const issue = analyzeConnectionError(new Error(`SSE error: Non-200 status code (${status})`));
     expect(issue.kind).toBe('auth');

--- a/tests/generate-name-utils.test.ts
+++ b/tests/generate-name-utils.test.ts
@@ -52,4 +52,8 @@ describe('generated CLI command naming', () => {
     expect(inferNameFromCommand({ command: 'runner', args: ['chosen', '--verbose'] })).toBe('chosen');
     expect(inferNameFromCommand({ command: 'runner', args: ['chosen', 'TOKEN=value'] })).toBe('chosen');
   });
+
+  it('normalizes long separator runs without backtracking', () => {
+    expect(inferNameFromCommand({ command: `alpha${'-'.repeat(100_000)}beta` })).toBe('alpha-beta');
+  });
 });

--- a/tests/runtime-elicitation.test.ts
+++ b/tests/runtime-elicitation.test.ts
@@ -11,6 +11,7 @@ import {
   type ElicitationHandler,
   NON_INTERACTIVE_ELICITATION_HINT,
   registerElicitationHandler,
+  sanitizeTerminalText,
 } from '../src/runtime/elicitation.js';
 
 const connectedClients: Array<{ close(): Promise<void> }> = [];
@@ -39,6 +40,11 @@ function stripReadlinePromptCodes(output: string): string {
 }
 
 describe('elicitation responder', () => {
+  it('strips long and unterminated terminal sequences without backtracking', () => {
+    expect(sanitizeTerminalText(`before\u001b]52;c;${'A'.repeat(100_000)}\u0007after`)).toBe('beforeafter');
+    expect(sanitizeTerminalText(`before\u001bP${'A'.repeat(100_000)}`)).toBe('before');
+  });
+
   it('attributes interactive form prompts and strips terminal control sequences from every display field', async () => {
     const request = {
       method: 'elicitation/create',


### PR DESCRIPTION
## Summary

- replace backtracking slug/path normalization with linear scanners
- scan every URL-adjacent HTTP status candidate with one forward cursor
- strip terminal escape sequences with a bounded state machine

Closes CodeQL alerts #1-#6 from default-setup run `32454518381`.

## Root cause

Several untrusted-text normalizers used overlapping quantified regular expressions. Long separator, URL, or escape-sequence inputs could force polynomial backtracking, and an initial multi-URL repair copied the remaining suffix per candidate. The canonical fix moves normalization to single-pass owner helpers and keeps existing output semantics.

Production delta: +175/-32 (net +143). The positive delta is the explicit linear parsing needed to enforce the resource-consumption security invariant across the six affected surfaces while preserving multi-URL diagnostic behavior.

## Validation

- focused: 5 files, 86 tests passed
- ClawSweeper regression repair: classifier 36/36 passed, including 5,000 status-less URL candidates
- `pnpm check`
- updated-head full suite: 1,624 tests passed; one unrelated daemon-liveness timing assertion failed under load
- exact failed surface rerun: 5/5 passed
- `git diff --check`
