### PR TITLE
fix(docs): parse heading HTML safely

### DIFF
--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { css, faviconSvg, js, preThemeScript, themeToggleHtml } from './docs-site-assets.mjs';
+import { plainTextFromHeadingHtml } from './docs-html-utils.mjs';
 
 const root = process.cwd();
 const docsDir = path.join(root, 'docs');
@@ -442,10 +443,7 @@ function tocFromHtml(html) {
   const re = /<h([23]) id="([^"]+)">([\s\S]*?)<\/h[23]>/g;
   let m;
   while ((m = re.exec(html))) {
-    const text = m[3]
-      .replace(/<a class="anchor"[^>]*>.*?<\/a>/, '')
-      .replace(/<[^>]+>/g, '')
-      .trim();
+    const text = plainTextFromHeadingHtml(m[3]);
     items.push({ level: Number(m[1]), id: m[2], text });
   }
   if (items.length < 2) return '';

--- a/scripts/docs-html-utils.d.mts
+++ b/scripts/docs-html-utils.d.mts
@@ -1,0 +1,1 @@
+export function plainTextFromHeadingHtml(headingHtml: string): string;

--- a/scripts/docs-html-utils.mjs
+++ b/scripts/docs-html-utils.mjs
@@ -1,0 +1,33 @@
+export function plainTextFromHeadingHtml(headingHtml) {
+  const anchorEnd = headingHtml.startsWith('<a class="anchor"') ? headingHtml.indexOf('</a>') : -1;
+  const content = anchorEnd === -1 ? headingHtml : headingHtml.slice(anchorEnd + '</a>'.length);
+  return stripHtmlTags(content).trim();
+}
+
+function stripHtmlTags(value) {
+  let output = '';
+  let inTag = false;
+  let quote = '';
+
+  for (const character of value) {
+    if (!inTag) {
+      if (character === '<') {
+        inTag = true;
+      } else {
+        output += character;
+      }
+      continue;
+    }
+    if (quote) {
+      if (character === quote) {
+        quote = '';
+      }
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === '>') {
+      inTag = false;
+    }
+  }
+
+  return output;
+}

--- a/tests/docs-html-utils.test.ts
+++ b/tests/docs-html-utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { plainTextFromHeadingHtml } from '../scripts/docs-html-utils.mjs';
+
+describe('docs heading HTML extraction', () => {
+  it('removes the anchor and inline markup while preserving text', () => {
+    expect(
+      plainTextFromHeadingHtml(
+        '<a class="anchor" href="#install" aria-label="Anchor link">#</a>Install <code>mcporter</code>'
+      )
+    ).toBe('Install mcporter');
+  });
+
+  it('does not create a script tag from nested attacker-controlled markup', () => {
+    const text = plainTextFromHeadingHtml(
+      '<a class="anchor" href="#safe" aria-label="Anchor link">#</a><scr<script>ipt>alert(1)</script>Safe'
+    );
+
+    expect(text).not.toContain('<script');
+    expect(text).toContain('Safe');
+  });
+});


### PR DESCRIPTION
## Summary

- replace repeated HTML tag removal with a single-pass tag-state parser
- preserve heading text while removing generated anchor markup
- add an adversarial nested-tag regression

Closes CodeQL alert #12 from default-setup run `32454518381`.

## Root cause

Repeated multi-character replacement could concatenate attacker-controlled fragments into a new tag-shaped string. The docs builder now extracts heading text in one pass before the existing output escaping boundary.

Production delta: +36/-4 (net +32), justified by the HTML-injection security invariant.

## Validation

- `pnpm docs:list`
- focused: 2 tests passed
- `pnpm docs:site`
- `pnpm check`
- full suite: 1,620 tests passed with one unrelated daemon-liveness timing failure under three-way local contention; exact failed surface rerun passed 5/5
- `git diff --check`
