### PR TITLE
fix(security): bucket daemon progress intervals

### DIFF
--- a/src/daemon/host.ts
+++ b/src/daemon/host.ts
@@ -33,10 +33,9 @@ import {
 import {
   DAEMON_OAUTH_FLOW_ERROR_CODE,
   DAEMON_OPERATION_TIMEOUT_CODE,
-  DAEMON_PROGRESS_INTERVAL_MS,
   DAEMON_PROTOCOL_VERSION,
-  MIN_DAEMON_PROGRESS_INTERVAL_MS,
   encodeDaemonFrame,
+  resolveProgressInterval,
   type DaemonRequest,
   type DaemonResponse,
   type CallToolParams,
@@ -594,12 +593,9 @@ function startProgressFrames(socket: net.Socket, request?: DaemonRequest): () =>
   ) {
     return () => {};
   }
-  // Raw protocol clients control this field, so enforce both ends before it
-  // reaches setInterval. The floor prevents a tight progress-frame loop.
-  const intervalMs = Math.min(
-    Math.max(Math.trunc(request.progressIntervalMs), MIN_DAEMON_PROGRESS_INTERVAL_MS),
-    DAEMON_PROGRESS_INTERVAL_MS
-  );
+  // Only fixed protocol-owned cadences reach the timer. Raw clients cannot
+  // create a tight loop or retain arbitrary-duration interval resources.
+  const intervalMs = resolveProgressInterval(request.progressIntervalMs);
   const emit = (): void => {
     if (!socket.destroyed && !socket.writableEnded) {
       socket.write(encodeDaemonFrame({ type: 'progress', id: request.id }));

--- a/src/daemon/protocol.ts
+++ b/src/daemon/protocol.ts
@@ -8,16 +8,20 @@ export const DAEMON_PROGRESS_INTERVAL_MS = 250;
 export const MIN_DAEMON_PROGRESS_INTERVAL_MS = 25;
 const DAEMON_PROGRESS_SCHEDULING_SLACK_MS = MIN_DAEMON_PROGRESS_INTERVAL_MS;
 
+export function resolveProgressInterval(requestedIntervalMs: number): number {
+  if (requestedIntervalMs >= DAEMON_PROGRESS_INTERVAL_MS) return DAEMON_PROGRESS_INTERVAL_MS;
+  if (requestedIntervalMs >= 100) return 100;
+  if (requestedIntervalMs >= 50) return 50;
+  return MIN_DAEMON_PROGRESS_INTERVAL_MS;
+}
+
 export function resolveProgressTiming(requestedIdleTimeoutMs: number): {
   progressIntervalMs: number;
   idleTimeoutMs: number;
 } {
   const idleTimeoutMs =
     normalizeTimeout(requestedIdleTimeoutMs) ?? DAEMON_PROGRESS_INTERVAL_MS * 3 + DAEMON_PROGRESS_SCHEDULING_SLACK_MS;
-  const progressIntervalMs = Math.min(
-    DAEMON_PROGRESS_INTERVAL_MS,
-    Math.max(MIN_DAEMON_PROGRESS_INTERVAL_MS, Math.floor(idleTimeoutMs / 3))
-  );
+  const progressIntervalMs = resolveProgressInterval(Math.floor(idleTimeoutMs / 3));
   return {
     progressIntervalMs,
     // Keep three frame opportunities plus scheduler slack inside the socket idle budget.

--- a/tests/daemon-liveness.test.ts
+++ b/tests/daemon-liveness.test.ts
@@ -9,6 +9,7 @@ import {
   DAEMON_PROTOCOL_VERSION,
   DaemonFrameDecoder,
   encodeDaemonFrame,
+  resolveProgressInterval,
   resolveProgressTiming,
   type DaemonRequest,
 } from '../src/daemon/protocol.js';
@@ -18,6 +19,12 @@ import { makeShortTempDir } from './fixtures/test-helpers.js';
 const describeUnixSocket = process.platform === 'win32' ? describe.skip : describe;
 
 describe('daemon frame protocol', () => {
+  it('maps raw progress requests to fixed protocol-owned cadences', () => {
+    expect([1, 49, 50, 99, 100, 249, 250, Number.MAX_SAFE_INTEGER].map(resolveProgressInterval)).toEqual([
+      25, 25, 50, 50, 100, 100, 250, 250,
+    ]);
+  });
+
   it('bounds progress frequency for short and long idle budgets', () => {
     expect(resolveProgressTiming(1)).toEqual({ progressIntervalMs: 25, idleTimeoutMs: 100 });
     expect(resolveProgressTiming(60)).toEqual({ progressIntervalMs: 25, idleTimeoutMs: 100 });


### PR DESCRIPTION
## Summary

- map raw daemon progress requests to fixed protocol-owned cadence buckets
- reuse the same cadence resolver for normal client negotiation and raw host requests
- prevent user-controlled numeric values from reaching `setInterval`

Closes residual CodeQL alert #13 (`js/resource-exhaustion`) from default-setup run `32454518381`. Follow-up to #326 after the squash-SHA scan showed the numeric clamp still carried taint into the timer.

## Root cause

The daemon host bounded the raw progress interval numerically, but the user-provided value still flowed into `setInterval`. The protocol owner now returns only fixed `25`, `50`, `100`, or `250` ms constants. Cadences are rounded down, so progress is never slower than requested, while the existing 25 ms floor still caps resource use.

Production delta: +12/-12 (net zero). Tests: +7.

## Validation

- `pnpm exec vitest run tests/daemon-liveness.test.ts tests/daemon-client-timeout.test.ts`: 24 tests passed
- `pnpm check`
- `pnpm test`: 1,636 tests passed, 26 skipped
- `git diff --check`
